### PR TITLE
Add comprehensive logging and fix MockLogger mutex deadlock

### DIFF
--- a/internal/testutil/mock_logger.go
+++ b/internal/testutil/mock_logger.go
@@ -76,6 +76,7 @@ func (m *MockLogger) Warn(msg string, keysAndValues ...interface{}) {
 		return
 	}
 	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.logs = append(m.logs, LogEntry{
 		Level:   "warn",
 		Message: msg,
@@ -89,6 +90,7 @@ func (m *MockLogger) Error(msg string, keysAndValues ...interface{}) {
 		return
 	}
 	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.logs = append(m.logs, LogEntry{
 		Level:   "error",
 		Message: msg,

--- a/pkg/logging/slog_adapter.go
+++ b/pkg/logging/slog_adapter.go
@@ -1,6 +1,9 @@
 package logging
 
-import "log/slog"
+import (
+	"log/slog"
+	"os"
+)
 
 // SlogAdapter adapts Go's standard library log/slog to the Logger interface.
 // This is the recommended logger for production use as it has no external


### PR DESCRIPTION
## Summary
- Fixed critical mutex deadlock in MockLogger Warn() and Error() methods
- Added comprehensive logging throughout key manager lifecycle
- Added 700+ lines of logging tests covering all operations
- Fixed loop iteration bug in cleanup operations

## Key Changes

### Mock Logger Fixes
- Added missing `defer m.mu.Unlock()` to Warn() and Error() methods This prevented tests from hanging when trying to read logs

### Key Manager Logging
- Added error logging in Start() when key generation fails
- Added error logging when saving initial key to disk fails
- Enhanced PEM decode failures with file and error details
- Added logging for key load operations with counts
- Added duration tracking to rotation operations
- Added shutdown lifecycle logging (initiate/stop)
- Fixed for loop in cleanupExpiredKeys() (was logging indices instead of key IDs)

### Test Suite
- Added 700+ lines of comprehensive logging tests:
  - Logger integration and structured fields
  - Startup event logging
  - Key loading and persistence
  - Corrupted file handling
  - Rotation success and failure scenarios
  - Automatic rotation triggers
  - Cleanup and expiration operations
  - Error scenarios and log levels
  - Shutdown events
  - Metadata persistence
  - Concurrent operation logging

## Bugs Fixed
- Mutex deadlock in MockLogger preventing test execution
- Loop variable shadowing in cleanupExpiredKeys (using indices instead of values)
- Missing error logging in Start() method
- Empty duration field in rotation logs