### PR TITLE
Add Debug level to Logger interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ config := keymanager.ManagerConfig{
 ```go
 // Implement the simple Logger interface
 type Logger interface {
+    Debug(msg string, args ...interface{})
     Info(msg string, args ...interface{})
     Warn(msg string, args ...interface{})
     Error(msg string, args ...interface{})
@@ -327,6 +328,9 @@ type MyZapAdapter struct {
     logger *zap.Logger
 }
 
+func (m *MyZapAdapter) Debug(msg string, args ...interface{}) {
+    m.logger.Sugar().Debugw(msg, args...)
+}
 func (m *MyZapAdapter) Info(msg string, args ...interface{}) {
     m.logger.Sugar().Infow(msg, args...)
 }
@@ -356,7 +360,7 @@ type Metrics interface {
 github.com/aetomala/jwtauth/
 ├── pkg/                          # Public API packages
 │   ├── logging/                  # Logging abstraction
-│   │   ├── logger.go             # Logger interface (3 methods)
+│   │   ├── logger.go             # Logger interface (4 methods: Debug, Info, Warn, Error)
 │   │   ├── slog_adapter.go       # Standard library adapter
 │   │   └── noop.go               # NoOp implementation
 │   ├── metrics/                  # Metrics abstraction

--- a/internal/testutil/mock_logger.go
+++ b/internal/testutil/mock_logger.go
@@ -44,7 +44,7 @@ type MockLogger struct {
 // LogEntry represents a single log entry captured by MockLogger.
 type LogEntry struct {
 	Fields  map[string]interface{} // Structured fields (key-value pairs)
-	Level   string                 // "info","warn","error"
+	Level   string                 // "debug","info","warn","error"
 	Message string                 // Log message
 }
 
@@ -54,6 +54,20 @@ func NewMockLogger() *MockLogger {
 		logs:   make([]LogEntry, 0),
 		enable: true,
 	}
+}
+
+// Debug records a debug-level log entry
+func (m *MockLogger) Debug(msg string, keysAndValues ...interface{}) {
+	if !m.enable {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.logs = append(m.logs, LogEntry{
+		Level:   "debug",
+		Message: msg,
+		Fields:  m.parseFields(keysAndValues),
+	})
 }
 
 // Info records an info-level log entry

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -8,12 +8,16 @@ package logging
 // keys are strings and values can be any type.
 //
 // Design Philosophy:
-//   - Simple: Only 3 log levels (Info, Warn, Error)
+//   - Simple: Only 4 log levels (Debug, Info, Warn, Error)
 //   - Structured: Key-value pairs for machine-readable logs
 //   - Flexible: Works with any logging library via adapters
 //   - Optional: Components work without a logger (nil-safe)
 //
 // Example Usage:
+//
+//	logger.Debug("JWKS cache populated",
+//	    "keyCount", 3,
+//	    "ttl", 5*time.Minute)
 //
 //	logger.Info("key rotation successful",
 //	    "keyID", "abc-123",
@@ -37,6 +41,16 @@ package logging
 //   - Zerolog: github.com/rs/zerolog
 //   - Logrus: github.com/sirupsen/logrus
 type Logger interface {
+	// Debug logs verbose diagnostic messages for development and troubleshooting.
+	// Use for: internal state, cache hits/misses, detailed operation tracing.
+	// Suppressed when the logger is configured at Info level or above.
+	//
+	// keysAndValues must be alternating keys (string) and values (any type).
+	//
+	// Example:
+	//   Debug("JWKS cache populated", "keyCount", 3, "ttl", 5*time.Minute)
+	Debug(msg string, keysAndValues ...interface{})
+
 	// Info logs informational messages for normal operations.
 	// Use for: successful operations, state changes, important milestones
 	//

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -203,6 +203,46 @@ var _ = Describe("SlogAdapter", func() {
 		})
 	})
 
+	// === DEBUG LEVEL ===
+	Describe("Debug", func() {
+		BeforeEach(func() {
+			handler := slog.NewTextHandler(buf, &slog.HandlerOptions{
+				Level: slog.LevelDebug,
+			})
+			logger = logging.NewSlogAdapter(slog.New(handler))
+		})
+
+		It("should log debug message without fields", func() {
+			logger.Debug("cache miss")
+
+			output := buf.String()
+			Expect(output).To(ContainSubstring("level=DEBUG"))
+			Expect(output).To(ContainSubstring("msg=\"cache miss\""))
+		})
+
+		It("should log debug message with key-value pairs", func() {
+			logger.Debug("JWKS cache populated", "keyCount", 3, "ttl", 5*time.Minute)
+
+			output := buf.String()
+			Expect(output).To(ContainSubstring("level=DEBUG"))
+			Expect(output).To(ContainSubstring("keyCount=3"))
+		})
+
+		It("should handle empty message", func() {
+			logger.Debug("", "key", "value")
+
+			output := buf.String()
+			Expect(output).To(ContainSubstring("level=DEBUG"))
+			Expect(output).To(ContainSubstring("key=value"))
+		})
+
+		It("should not panic with nil values", func() {
+			Expect(func() {
+				logger.Debug("test", "data", nil)
+			}).NotTo(Panic())
+		})
+	})
+
 	// === WARN LEVEL ===
 	Describe("Warn", func() {
 		BeforeEach(func() {
@@ -377,6 +417,12 @@ var _ = Describe("SlogAdapter", func() {
 				Expect(strings.Count(output, "level=WARN")).To(Equal(1))
 				Expect(strings.Count(output, "level=ERROR")).To(Equal(1))
 			})
+
+			It("should suppress debug messages at Info level threshold", func() {
+				logger.Debug("this should be suppressed")
+
+				Expect(buf.String()).To(BeEmpty())
+			})
 		})
 
 		Context("when level is Warn", func() {
@@ -416,6 +462,28 @@ var _ = Describe("SlogAdapter", func() {
 				Expect(output).NotTo(ContainSubstring("level=INFO"))
 				Expect(output).NotTo(ContainSubstring("level=WARN"))
 				Expect(output).To(ContainSubstring("level=ERROR"))
+			})
+		})
+
+		Context("when level is Debug", func() {
+			BeforeEach(func() {
+				handler := slog.NewTextHandler(buf, &slog.HandlerOptions{
+					Level: slog.LevelDebug,
+				})
+				logger = logging.NewSlogAdapter(slog.New(handler))
+			})
+
+			It("should log all four levels", func() {
+				logger.Debug("debug message")
+				logger.Info("info message")
+				logger.Warn("warn message")
+				logger.Error("error message")
+
+				output := buf.String()
+				Expect(strings.Count(output, "level=DEBUG")).To(Equal(1))
+				Expect(strings.Count(output, "level=INFO")).To(Equal(1))
+				Expect(strings.Count(output, "level=WARN")).To(Equal(1))
+				Expect(strings.Count(output, "level=ERROR")).To(Equal(1))
 			})
 		})
 	})
@@ -520,11 +588,38 @@ var _ = Describe("NoOpLogger", func() {
 		})
 	})
 
+	Describe("Debug", func() {
+		It("should not panic with no arguments", func() {
+			Expect(func() {
+				logger.Debug("debug message")
+			}).NotTo(Panic())
+		})
+
+		It("should not panic with key-value pairs", func() {
+			Expect(func() {
+				logger.Debug("verbose detail", "component", "keymanager", "operation", "load")
+			}).NotTo(Panic())
+		})
+
+		It("should not panic with nil values", func() {
+			Expect(func() {
+				logger.Debug("test", "data", nil)
+			}).NotTo(Panic())
+		})
+
+		It("should not panic with empty message", func() {
+			Expect(func() {
+				logger.Debug("")
+			}).NotTo(Panic())
+		})
+	})
+
 	Describe("Silent Operation", func() {
 		It("should produce no output", func() {
 			// NoOpLogger doesn't write anywhere, so we just verify it doesn't panic
 			// In a real scenario, you'd verify no side effects occurred
 			Expect(func() {
+				logger.Debug("debug")
 				logger.Info("info")
 				logger.Warn("warn")
 				logger.Error("error")
@@ -534,6 +629,7 @@ var _ = Describe("NoOpLogger", func() {
 		It("should handle all log levels silently", func() {
 			Expect(func() {
 				for i := 0; i < 100; i++ {
+					logger.Debug("debug", "iteration", i)
 					logger.Info("info", "iteration", i)
 					logger.Warn("warn", "iteration", i)
 					logger.Error("error", "iteration", i)
@@ -550,6 +646,7 @@ var _ = Describe("NoOpLogger", func() {
 				go func(id int) {
 					defer GinkgoRecover()
 					for j := 0; j < 100; j++ {
+						logger.Debug("debug", "goroutine", id, "iteration", j)
 						logger.Info("message", "goroutine", id, "iteration", j)
 						logger.Warn("warning", "goroutine", id)
 						logger.Error("error", "goroutine", id)

--- a/pkg/logging/noop.go
+++ b/pkg/logging/noop.go
@@ -17,6 +17,9 @@ package logging
 //	}
 type NoOpLogger struct{}
 
+// Debug discards the log message.
+func (n *NoOpLogger) Debug(msg string, keysAndValues ...interface{}) {}
+
 // Info discards the log message.
 func (n *NoOpLogger) Info(msg string, keysAndValues ...interface{}) {}
 

--- a/pkg/logging/slog_adapter.go
+++ b/pkg/logging/slog_adapter.go
@@ -48,6 +48,11 @@ func NewSlogAdapter(logger *slog.Logger) *SlogAdapter {
 	return &SlogAdapter{logger: logger}
 }
 
+// Debug logs a verbose diagnostic message with structured key-value pairs.
+func (s *SlogAdapter) Debug(msg string, keysAndValues ...interface{}) {
+	s.logger.Debug(msg, keysAndValues...)
+}
+
 // Info logs an informational message with structured key-value pairs.
 func (s *SlogAdapter) Info(msg string, keysAndValues ...interface{}) {
 	s.logger.Info(msg, keysAndValues...)


### PR DESCRIPTION
Extends the Logger interface with a Debug method as the lowest-severity level, suitable for verbose diagnostic output during development.

- Logger interface: add Debug method (first, before Info)
- NoOpLogger: add silent Debug no-op
- SlogAdapter: add Debug delegating to slog.Logger.Debug
- MockLogger: add Debug storing LogEntry{Level: "debug"}; all existing query helpers (HasLog, CountLogs, GetLogsByLevel) work unchanged
- Tests: Debug specs for SlogAdapter and NoOpLogger; level filtering tests for suppression at Info threshold and full emission at Debug threshold; Silent Operation and Concurrent Usage updated
- README: update Logger interface snippet, Zap adapter example, and project structure comment