### PR TITLE
Add context propagation and error_type metrics to KeyManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ func main() {
     defer manager.Shutdown(ctx)
     
     // Get current signing key
-    _, keyID, err := manager.GetCurrentSigningKey()
+    _, keyID, err := manager.GetCurrentSigningKey(ctx)
     if err != nil {
         log.Fatal(err)
     }

--- a/internal/testutil/README.md
+++ b/internal/testutil/README.md
@@ -1,351 +1,122 @@
 # Test Utilities
 
-Comprehensive mock implementations for testing components that depend on external interfaces. These mocks enable isolated, deterministic testing without external dependencies.
+Mock implementations for testing components that depend on external interfaces. All auto-generated mocks use gomock's record/replay pattern; `MockLogger` is a hand-written capture implementation.
 
 ## Available Mocks
 
-| Mock | Purpose | Type | Key Features |
-|------|---------|------|--------------|
-| **MockKeyManager** | RSA key operations | Auto-generated (gomock) | EXPECT() pattern, call verification, error injection |
-| **MockRateLimiter** | Request throttling | Auto-generated (gomock) | EXPECT() pattern, call verification, error injection |
-| **MockLogger** | Structured logging | Custom implementation | Capture logs, assert on messages, verify fields |
-| **MockRefreshStore** | Token persistence | Auto-generated (gomock) | EXPECT() pattern, call verification, error injection |
+| Mock | Source interface | File | Generation |
+|------|-----------------|------|------------|
+| **MockKeyManager** | `keymanager.KeyManager` | mock_keymanager.go | Auto-generated (mockgen) |
+| **MockKeyStore** | `keymanager.KeyStore` | mock_keystore.go | Auto-generated (mockgen) |
+| **MockRefreshStore** | `storage.RefreshStore` | mock_refreshstore.go | Auto-generated (mockgen) |
+| **MockMetrics** | `metrics.Metrics` | mock_metrics.go | Auto-generated (mockgen) |
+| **MockLogger** | `logging.Logger` | mock_logger.go | Custom implementation |
 
-### Mock Types
+Shared error helpers live in `errors.go`.
 
-- **Auto-generated (gomock)**: `MockKeyManager`, `MockRateLimiter`, and `MockRefreshStore` are generated from their respective interfaces using mockgen. They use the record/replay pattern with `EXPECT()`.
-- **Custom implementations**: `MockLogger` and error types (`MockError`, `MockErrorWithContext` in errors.go) are hand-written test utilities with special behaviors for specific testing scenarios.
+## Quick Start
 
-## Quick Start Examples
-
-### MockKeyManager (Auto-generated with gomock)
+### Auto-generated mocks (MockKeyManager, MockKeyStore, MockRefreshStore, MockMetrics)
 
 ```go
-import (
-	"crypto/rsa"
+ctrl := gomock.NewController(GinkgoT())
+defer ctrl.Finish()
 
-	"github.com/aetomala/jwtauth/internal/testutil"
-	"go.uber.org/mock/gomock"
-)
-
-ctrl := gomock.NewController(t)
 mockKM := testutil.NewMockKeyManager(ctrl)
 
-// Set up expectations for method calls
-mockKM.EXPECT().
-	GetCurrentSigningKey().
-	Return(privateKey, "test-key-id", nil).
-	Times(1)
+// Expect a call and specify the return value
+mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(privateKey, "key-1", nil)
 
-// Set up error behavior
-mockKM.EXPECT().
-	GetPublicKey("invalid-key").
-	Return(nil, errors.New("key not found")).
-	Times(1)
+// Expect a call that should not happen — omit EXPECT entirely;
+// any unexpected call causes the test to fail automatically.
 
-// Execute code under test that uses mockKM
-// Assertions are automatic - gomock verifies expectations after test
+// Expect a call any number of times
+mockKM.EXPECT().Start(gomock.Any()).Return(nil).AnyTimes()
 ```
-
-**Note**: `MockKeyManager` is auto-generated from the `KeyManager` interface using mockgen. It uses gomock's record/replay pattern. See [gomock documentation](https://github.com/golang/mock) for detailed usage patterns.
 
 ### MockLogger
 
 ```go
-mockLogger := testutil.NewMockLogger()
+mockLog := testutil.NewMockLogger()
 
-// Use in component under test
-component := myapp.NewComponent(myapp.Config{
-    Logger: mockLogger,
+// Pass to the component under test
+svc := myapp.NewService(myapp.Config{Logger: mockLog})
+
+// Assert on captured output
+Expect(mockLog.HasLog("info", "service started")).To(BeTrue())
+Expect(mockLog.HasLogWithField("warn", "token expired", "tokenID")).To(BeTrue())
+Expect(mockLog.CountLogs("error")).To(Equal(0))
+
+// Clear between phases
+mockLog.Clear()
+```
+
+### MockMetrics
+
+```go
+ctrl := gomock.NewController(GinkgoT())
+mockM := testutil.NewMockMetrics(ctrl)
+
+mockM.EXPECT().IncrementCounter("jwtauth_tokens_issued_total", map[string]string{
+    "status":     "success",
+    "error_type": "",
+})
+mockM.EXPECT().RecordDuration("jwtauth_operation_duration_seconds", gomock.Any(), map[string]string{
+    "operation": "issue_access_token",
 })
 
-// Verify logs
-Expect(mockLogger.HasLog("info", "component started")).To(BeTrue())
-Expect(mockLogger.HasLogWithField("info", "request processed", "requestID")).To(BeTrue())
-
-// Check log count
-Expect(mockLogger.CountLogs("error")).To(Equal(0))
+// Use gomock.Any() for duration values — exact timing is non-deterministic.
+// Use exact label maps — label correctness is what the test verifies.
 ```
 
-### MockRateLimiter (Auto-generated with gomock)
+### MockKeyStore
 
 ```go
-import (
-	"github.com/aetomala/jwtauth/internal/testutil"
-	"go.uber.org/mock/gomock"
-)
+ctrl := gomock.NewController(GinkgoT())
+mockKS := testutil.NewMockKeyStore(ctrl)
 
-ctrl := gomock.NewController(t)
-mockRL := testutil.NewMockRateLimiter(ctrl)
-
-// Set up expectations
-mockRL.EXPECT().
-	Allow("user-123", 1).
-	Return(true, nil).
-	Times(1)
-
-mockRL.EXPECT().
-	Allow("user-456", 1).
-	Return(false, errors.New("rate limit exceeded")).
-	Times(1)
-
-// Code under test uses mockRL
-// Assertions are verified automatically by gomock
+mockKS.EXPECT().LoadAll(gomock.Any()).Return([]*keymanager.StoredKey{}, nil)
+mockKS.EXPECT().Save(gomock.Any(), "key-1", gomock.Any(), gomock.Any()).Return(nil)
 ```
 
-### MockRefreshStore (Auto-generated with gomock)
+### MockRefreshStore
 
 ```go
-import (
-	"github.com/aetomala/jwtauth/internal/testutil"
-	"go.uber.org/mock/gomock"
-)
-
-ctrl := gomock.NewController(t)
+ctrl := gomock.NewController(GinkgoT())
 mockStore := testutil.NewMockRefreshStore(ctrl)
 
-// Set up expectations
 mockStore.EXPECT().
-	Store("token-123", "user-456", gomock.Any(), nil).
-	Return(nil).
-	Times(1)
+    Store(gomock.Any(), "token-abc", "user-1", gomock.Any(), gomock.Any()).
+    Return(nil)
 
 mockStore.EXPECT().
-	Retrieve("token-123").
-	Return(&ratelimit.RefreshToken{UserID: "user-456"}, nil).
-	Times(1)
-
-// Code under test uses mockStore
-// Assertions are verified automatically by gomock
+    Retrieve(gomock.Any(), "token-abc").
+    Return(&storage.RefreshToken{UserID: "user-1", ExpiresAt: time.Now().Add(time.Hour)}, nil)
 ```
 
-## Key Features
-
-### Thread Safety
-
-All mocks are **thread-safe** and can be used in concurrent tests:
+## Error Helpers (`errors.go`)
 
 ```go
-var wg sync.WaitGroup
-for i := 0; i < 10; i++ {
-    wg.Add(1)
-    go func() {
-        defer wg.Done()
-        mockRL.Allow("concurrent-user", 1)
-    }()
-}
-wg.Wait()
-Expect(mockRL.GetCallCount("Allow")).To(Equal(10))
+// Simple sentinel error
+err := testutil.NewMockError("database offline")
+
+// Wrapped error with context
+wrapped := testutil.NewMockErrorWithContext("operation failed", err)
 ```
 
-### Error Injection
+## Regenerating Auto-generated Mocks
 
-Configure mocks to return errors for testing error handling:
-
-```go
-// Logger
-mockLogger.Disable()  // Stop recording logs
-
-// RateLimiter
-mockRL.SetAllowError(testutil.NewMockError("rate limit service down"))
-
-// RefreshStore
-mockStore.SetStoreError(testutil.NewMockError("database offline"))
-```
-
-### State Reset
-
-Reset mocks between test phases:
-
-```go
-mockKM.Reset()              // Reset all call counters
-mockLogger.Clear()          // Clear all recorded logs
-mockRL.ResetCounters()      // Reset call counts
-mockRL.ResetState()         // Reset per-identifier state
-mockStore.Reset()           // Reset entire store state
-```
-
-## Error Types
-
-Custom error types for testing:
-
-```go
-// Create mock error
-err := testutil.NewMockError("custom error message")
-
-// Check error type
-if testutil.IsMockError(err) {
-    // Handle mock error
-}
-
-// Wrap with context
-wrapped := testutil.WrapMockError(err, "operation context")
-```
-
-## Testing Patterns
-
-### MockKeyManager - Verify Expected Calls (gomock)
-
-```go
-ctrl := gomock.NewController(t)
-mockKM := testutil.NewMockKeyManager(ctrl)
-
-// Set up expectations
-mockKM.EXPECT().
-	GetPublicKey("key-1").
-	Return(&rsaPublicKey1, nil)
-
-mockKM.EXPECT().
-	GetPublicKey("key-2").
-	Return(&rsaPublicKey2, nil)
-
-// Code under test calls these methods
-myComponent.GetKeys(mockKM)
-
-// Assertions are verified automatically by gomock
-```
-
-### Assert Log Fields
-
-```go
-log := mockLogger.GetLogWithField("info", "operation complete", "duration")
-Expect(log).NotTo(BeNil())
-duration := log.Fields["duration"].(time.Duration)
-Expect(duration).To(BeNumerically(">", 0))
-```
-
-### Verify Multiple Calls (gomock)
-
-```go
-ctrl := gomock.NewController(t)
-mockRL := testutil.NewMockRateLimiter(ctrl)
-
-// Set up expectations for multiple calls
-mockRL.EXPECT().
-	Allow("alice", 5).
-	Return(true, nil).
-	Times(1)
-
-mockRL.EXPECT().
-	Allow("bob", 3).
-	Return(true, nil).
-	Times(1)
-
-// Code under test makes these calls
-myComponent.CheckRateLimit(mockRL)
-
-// Assertions verified automatically by gomock
-```
-
-## API Reference
-
-### Auto-generated Mocks (gomock)
-
-Auto-generated from interface definitions using mockgen. See [gomock documentation](https://github.com/golang/mock) for detailed usage patterns.
-
-- **[mock_keymanager.go](./mock_keymanager.go)** - Auto-generated from `KeyManager` interface
-- **[mock_ratelimiter.go](./mock_ratelimiter.go)** - Auto-generated from `RateLimiter` interface
-- **[mock_refreshstore.go](./mock_refreshstore.go)** - Auto-generated from `RefreshStore` interface
-
-### Custom Mock Implementations
-
-For complete API documentation, see the docstrings in:
-- **[mock_logger.go](./mock_logger.go)** - Custom implementation for capturing and asserting on structured logs
-
-### Shared Utilities
-
-- **[errors.go](./errors.go)** - `MockError` and `MockErrorWithContext` for test error handling
-- **[README.md](./README.md)** - This file
-
-## Mock Type Comparison
-
-### Auto-generated Mocks (MockKeyManager, MockRateLimiter, MockRefreshStore)
-
-Auto-generated using [mockgen](https://github.com/golang/mock), these mocks use gomock's record/replay pattern:
-
-**Use when:**
-- Testing components that depend on an interface
-- You want strict call verification
-- You need to set up complex call sequences
-- Testing interface methods that may change
-
-**API:**
-```go
-ctrl := gomock.NewController(t)
-mock := testutil.NewMockKeyManager(ctrl)
-
-mock.EXPECT().MethodName(args...).Return(values...).Times(n)
-```
-
-**Regeneration:**
 ```bash
 go generate ./...
 ```
 
-### Custom Mocks (MockLogger)
+Each mock file contains the exact `mockgen` command used to generate it in its header comment.
 
-Hand-written implementation with special behavior for logging capture:
+## Files
 
-**Use when:**
-- You need to capture and verify logs from components
-- You need custom helper methods for asserting log state
-- You need more control over mock behavior than gomock provides
-
-**API:**
-```go
-mock := testutil.NewMockLogger()
-mock.HasLog("info", "message")
-mock.HasLogWithField("info", "message", "fieldName")
-mock.Clear()
-```
-
----
-
-## Testing Best Practices
-
-1. **Reset between tests** - Use `Reset()` or `Clear()` in `AfterEach`
-2. **Configure errors early** - Set error behavior before test execution
-3. **Verify behavior, not implementation** - Assert on mock method calls, not internal state
-4. **Use concurrent tests** - All mocks support parallel test execution
-5. **Document mock configuration** - Comment on why specific mock behavior is configured
-
-## Example Test Suite
-
-```go
-var _ = Describe("MyComponent", func() {
-    var (
-        ctrl    *gomock.Controller
-        mockKM  *testutil.MockKeyManager
-        mockLog *testutil.MockLogger
-    )
-
-    BeforeEach(func() {
-        ctrl = gomock.NewController(GinkgoT())
-        mockKM = testutil.NewMockKeyManager(ctrl)
-        mockLog = testutil.NewMockLogger()
-    })
-
-    AfterEach(func() {
-        ctrl.Finish()  // Verify all expectations were met
-    })
-
-    Describe("key signing", func() {
-        It("should retrieve signing key on startup", func() {
-            privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
-
-            // Set up expectations
-            mockKM.EXPECT().
-                GetCurrentSigningKey().
-                Return(privateKey, "test-key-id", nil).
-                Times(1)
-
-            component := myapp.New(myapp.Config{
-                KeyManager: mockKM,
-                Logger:     mockLog,
-            })
-
-            Expect(mockLog.HasLog("info", "loaded current key")).To(BeTrue())
-        })
-    })
-})
-```
+- **[mock_keymanager.go](./mock_keymanager.go)** — `KeyManager` interface (key signing, rotation, lifecycle)
+- **[mock_keystore.go](./mock_keystore.go)** — `KeyStore` interface (key persistence: LoadAll, Save, UpdateMetadata, LoadKey, Delete)
+- **[mock_refreshstore.go](./mock_refreshstore.go)** — `RefreshStore` interface (token persistence: Store, Retrieve, Revoke, Cleanup)
+- **[mock_metrics.go](./mock_metrics.go)** — `Metrics` interface (counters, gauges, histograms, durations)
+- **[mock_logger.go](./mock_logger.go)** — custom `Logger` capture implementation
+- **[errors.go](./errors.go)** — `MockError` and `MockErrorWithContext` test error types

--- a/internal/testutil/mock_keymanager.go
+++ b/internal/testutil/mock_keymanager.go
@@ -43,9 +43,9 @@ func (m *MockKeyManager) EXPECT() *MockKeyManagerMockRecorder {
 }
 
 // GetCurrentSigningKey mocks base method.
-func (m *MockKeyManager) GetCurrentSigningKey() (*rsa.PrivateKey, string, error) {
+func (m *MockKeyManager) GetCurrentSigningKey(ctx context.Context) (*rsa.PrivateKey, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCurrentSigningKey")
+	ret := m.ctrl.Call(m, "GetCurrentSigningKey", ctx)
 	ret0, _ := ret[0].(*rsa.PrivateKey)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -53,9 +53,9 @@ func (m *MockKeyManager) GetCurrentSigningKey() (*rsa.PrivateKey, string, error)
 }
 
 // GetCurrentSigningKey indicates an expected call of GetCurrentSigningKey.
-func (mr *MockKeyManagerMockRecorder) GetCurrentSigningKey() *gomock.Call {
+func (mr *MockKeyManagerMockRecorder) GetCurrentSigningKey(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentSigningKey", reflect.TypeOf((*MockKeyManager)(nil).GetCurrentSigningKey))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentSigningKey", reflect.TypeOf((*MockKeyManager)(nil).GetCurrentSigningKey), ctx)
 }
 
 // GetJWKS mocks base method.
@@ -74,18 +74,18 @@ func (mr *MockKeyManagerMockRecorder) GetJWKS() *gomock.Call {
 }
 
 // GetPublicKey mocks base method.
-func (m *MockKeyManager) GetPublicKey(keyID string) (*rsa.PublicKey, error) {
+func (m *MockKeyManager) GetPublicKey(ctx context.Context, keyID string) (*rsa.PublicKey, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPublicKey", keyID)
+	ret := m.ctrl.Call(m, "GetPublicKey", ctx, keyID)
 	ret0, _ := ret[0].(*rsa.PublicKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPublicKey indicates an expected call of GetPublicKey.
-func (mr *MockKeyManagerMockRecorder) GetPublicKey(keyID any) *gomock.Call {
+func (mr *MockKeyManagerMockRecorder) GetPublicKey(ctx, keyID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicKey", reflect.TypeOf((*MockKeyManager)(nil).GetPublicKey), keyID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicKey", reflect.TypeOf((*MockKeyManager)(nil).GetPublicKey), ctx, keyID)
 }
 
 // IsRunning mocks base method.

--- a/pkg/keymanager/disk.go
+++ b/pkg/keymanager/disk.go
@@ -69,12 +69,14 @@ func NewDiskKeyStore(dir string, keySize int, logger logging.Logger, m metrics.M
 func (d *DiskKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 	start := time.Now()
 	status := "error"
+	errorType := "error"
 	var keyCount int
 	defer func() {
 		if d.metrics != nil {
 			d.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
 				"operation":       "load_all",
 				"status":          status,
+				"error_type":      errorType,
 				"storage_backend": d.backend,
 			})
 			d.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
@@ -92,6 +94,7 @@ func (d *DiskKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
+		errorType = "cancelled"
 		return nil, err
 	}
 
@@ -151,6 +154,7 @@ func (d *DiskKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 
 	// ===== STEP 4: Log and Return =====
 	status = "success"
+	errorType = ""
 	keyCount = len(keys)
 	if d.logger != nil {
 		d.logger.Info("loaded keys from disk", "count", keyCount)
@@ -164,11 +168,13 @@ func (d *DiskKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 func (d *DiskKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.PrivateKey, meta KeyMetadata) error {
 	start := time.Now()
 	status := "error"
+	errorType := "error"
 	defer func() {
 		if d.metrics != nil {
 			d.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
 				"operation":       "save",
 				"status":          status,
+				"error_type":      errorType,
 				"storage_backend": d.backend,
 			})
 			d.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
@@ -181,6 +187,7 @@ func (d *DiskKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.P
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
+		errorType = "cancelled"
 		return err
 	}
 
@@ -227,6 +234,7 @@ func (d *DiskKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.P
 
 	// ===== STEP 5: Log and Return =====
 	status = "success"
+	errorType = ""
 	if d.logger != nil {
 		d.logger.Info("saved key to disk", "keyID", keyID)
 	}
@@ -240,11 +248,13 @@ func (d *DiskKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.P
 func (d *DiskKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta KeyMetadata) error {
 	start := time.Now()
 	status := "error"
+	errorType := "error"
 	defer func() {
 		if d.metrics != nil {
 			d.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
 				"operation":       "update_metadata",
 				"status":          status,
+				"error_type":      errorType,
 				"storage_backend": d.backend,
 			})
 			d.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
@@ -257,6 +267,7 @@ func (d *DiskKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta Ke
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
+		errorType = "cancelled"
 		return err
 	}
 
@@ -264,6 +275,7 @@ func (d *DiskKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta Ke
 	pemPath := filepath.Join(d.dir, keyID+".pem")
 	if _, err := os.Stat(pemPath); errors.Is(err, os.ErrNotExist) {
 		status = "not_found"
+		errorType = "not_found"
 		return ErrKeyStoreKeyNotFound
 	}
 
@@ -279,6 +291,7 @@ func (d *DiskKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta Ke
 
 	// ===== STEP 4: Log and Return =====
 	status = "success"
+	errorType = ""
 	if d.logger != nil {
 		d.logger.Info("updated key metadata", "keyID", keyID)
 	}
@@ -291,11 +304,13 @@ func (d *DiskKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta Ke
 func (d *DiskKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.PrivateKey, *KeyMetadata, error) {
 	start := time.Now()
 	status := "error"
+	errorType := "error"
 	defer func() {
 		if d.metrics != nil {
 			d.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
 				"operation":       "load_key",
 				"status":          status,
+				"error_type":      errorType,
 				"storage_backend": d.backend,
 			})
 			d.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
@@ -308,12 +323,14 @@ func (d *DiskKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.PrivateK
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
+		errorType = "cancelled"
 		return nil, nil, err
 	}
 
 	// ===== STEP 2: Validate Key ID =====
 	if strings.TrimSpace(keyID) == "" {
 		status = "not_found"
+		errorType = "not_found"
 		return nil, nil, ErrKeyStoreInvalidKeyID
 	}
 
@@ -323,6 +340,7 @@ func (d *DiskKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.PrivateK
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) || strings.Contains(err.Error(), "no such file") {
 			status = "not_found"
+			errorType = "not_found"
 			return nil, nil, ErrKeyStoreKeyNotFound
 		}
 		if d.logger != nil {
@@ -346,6 +364,7 @@ func (d *DiskKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.PrivateK
 
 	// ===== STEP 5: Log and Return =====
 	status = "success"
+	errorType = ""
 	if d.logger != nil {
 		d.logger.Debug("loaded key from disk", "keyID", keyID)
 	}
@@ -358,11 +377,13 @@ func (d *DiskKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.PrivateK
 func (d *DiskKeyStore) Delete(ctx context.Context, keyID string) error {
 	start := time.Now()
 	status := "error"
+	errorType := "error"
 	defer func() {
 		if d.metrics != nil {
 			d.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
 				"operation":       "delete",
 				"status":          status,
+				"error_type":      errorType,
 				"storage_backend": d.backend,
 			})
 			d.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
@@ -375,6 +396,7 @@ func (d *DiskKeyStore) Delete(ctx context.Context, keyID string) error {
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
+		errorType = "cancelled"
 		return err
 	}
 
@@ -402,6 +424,7 @@ func (d *DiskKeyStore) Delete(ctx context.Context, keyID string) error {
 
 	// ===== STEP 4: Log and Return =====
 	status = "success"
+	errorType = ""
 	if d.logger != nil {
 		d.logger.Info("deleted key from disk", "keyID", keyID)
 	}

--- a/pkg/keymanager/disk_test.go
+++ b/pkg/keymanager/disk_test.go
@@ -506,9 +506,14 @@ var _ = Describe("DiskKeyStore", func() {
 		}
 
 		expectOpsMetrics := func(operation, status string) {
+			errorType := status
+			if status == "success" {
+				errorType = ""
+			}
 			mockM.EXPECT().IncrementCounter("jwtauth_keystore_operations_total", map[string]string{
 				"operation":       operation,
 				"status":          status,
+				"error_type":      errorType,
 				"storage_backend": "disk",
 			})
 			mockM.EXPECT().RecordDuration("jwtauth_keystore_operation_duration_seconds", gomock.Any(), map[string]string{

--- a/pkg/keymanager/interface.go
+++ b/pkg/keymanager/interface.go
@@ -8,42 +8,21 @@ import (
 // Generate mock from this interface using mockgen
 //go:generate mockgen -source=interface.go -destination=../../internal/testutil/mock_keymanager.go -package=testutil -mock_names=KeyManager=MockKeyManager
 
-// KeyManager defines the interface for JWT key management operations.
-//
-// This interface ensures:
-//   - Compile-time verification that implementations are complete
-//   - Clear contract for all key management operations
-//   - Easy mocking for testing dependent components
-//   - Automatic mock generation via mockgen
-//
-// Implementations:
-//   - Manager: Production implementation with file persistence and automatic rotation
-//   - MockKeyManager (testutil): Auto-generated testing implementation
+// KeyManager is a thread-safe interface for JWT key management operations,
+// suitable for use in long-running services with automatic key rotation. All
+// methods are safe for concurrent use.
 type KeyManager interface {
-	// GetCurrentSigningKey returns the current private key for signing tokens.
-	// Returns the private key and its unique identifier.
-	//
-	// This is called when issuing new tokens.
-	//
-	// Returns:
-	//   - privateKey: RSA private key for signing
-	//   - keyID: Unique identifier for this key (used in JWT header)
-	//   - error: If key retrieval fails
-	GetCurrentSigningKey() (*rsa.PrivateKey, string, error)
+	// GetCurrentSigningKey returns the current private key and its ID for JWT signing.
+	// Returns ErrManagerNotRunning if the manager has not been started.
+	// Returns the context error if the context is cancelled.
+	GetCurrentSigningKey(ctx context.Context) (*rsa.PrivateKey, string, error)
 
-	// GetPublicKey returns the public key for the given key ID.
-	// This is used to verify tokens that were signed with a specific key.
-	//
-	// During key rotation, multiple keys may be valid (overlap period).
-	// This method must support retrieving both current and recently-expired keys.
-	//
-	// Args:
-	//   - keyID: The key identifier from the JWT header
-	//
-	// Returns:
-	//   - publicKey: RSA public key for verification
-	//   - error: If key not found or retrieval fails
-	GetPublicKey(keyID string) (*rsa.PublicKey, error)
+	// GetPublicKey returns the public key for the given key ID. During key rotation,
+	// multiple keys may be valid concurrently — this method supports retrieving both
+	// current and recently-rotated keys. Returns ErrInvalidKeyID if keyID is empty
+	// or whitespace-only, ErrKeyNotFound if the key does not exist or has expired.
+	// Returns the context error if the context is cancelled.
+	GetPublicKey(ctx context.Context, keyID string) (*rsa.PublicKey, error)
 
 	// GetJWKS returns the JSON Web Key Set.
 	// Contains all currently valid public keys for token verification.

--- a/pkg/keymanager/keymanager.go
+++ b/pkg/keymanager/keymanager.go
@@ -315,16 +315,25 @@ func (m *Manager) Start(ctx context.Context) error {
 // Returns ErrManagerNotRunning if the Manager is not running, or ErrKeyNotFound
 // if the current key is not in the cache (should not happen in practice).
 // The returned key is safe to use for concurrent signing operations.
-func (m *Manager) GetCurrentSigningKey() (*rsa.PrivateKey, string, error) {
+// Returns the context error if the context is cancelled.
+func (m *Manager) GetCurrentSigningKey(ctx context.Context) (*rsa.PrivateKey, string, error) {
 	// ===== STEP 1: Check Manager is Running =====
 	if !m.IsRunning() {
 		if m.metrics != nil {
-			m.metrics.IncrementCounter(metricKeySigningOpsTotal, map[string]string{"status": "error"})
+			m.metrics.IncrementCounter(metricKeySigningOpsTotal, map[string]string{"status": "error", "error_type": "error"})
 		}
 		return nil, "", ErrManagerNotRunning
 	}
 
-	// ===== STEP 2: Acquire Read Lock and Retrieve Key =====
+	// ===== STEP 2: Context Check =====
+	if err := ctx.Err(); err != nil {
+		if m.metrics != nil {
+			m.metrics.IncrementCounter(metricKeySigningOpsTotal, map[string]string{"status": "cancelled", "error_type": "cancelled"})
+		}
+		return nil, "", err
+	}
+
+	// ===== STEP 3: Acquire Read Lock and Retrieve Key =====
 	if m.config.Logger != nil {
 		m.config.Logger.Debug("getting current signing key")
 	}
@@ -335,14 +344,14 @@ func (m *Manager) GetCurrentSigningKey() (*rsa.PrivateKey, string, error) {
 
 	if !found {
 		if m.metrics != nil {
-			m.metrics.IncrementCounter(metricKeySigningOpsTotal, map[string]string{"status": "error"})
+			m.metrics.IncrementCounter(metricKeySigningOpsTotal, map[string]string{"status": "error", "error_type": "error"})
 		}
 		return nil, "", ErrKeyNotFound
 	}
 
-	// ===== STEP 3: Return Key and ID =====
+	// ===== STEP 4: Return Key and ID =====
 	if m.metrics != nil {
-		m.metrics.IncrementCounter(metricKeySigningOpsTotal, map[string]string{"status": "success"})
+		m.metrics.IncrementCounter(metricKeySigningOpsTotal, map[string]string{"status": "success", "error_type": ""})
 	}
 	return keyPair.PrivateKey, m.currentKeyID, nil
 }
@@ -398,11 +407,13 @@ func (m *Manager) IsRotationSchedulerActive() bool {
 // cache first, then loads from the KeyStore if not found. Returns ErrInvalidKeyID
 // if keyID is empty or whitespace-only, or ErrKeyNotFound if the key does not
 // exist or has expired. Uses a double-check locking pattern to cache loaded keys.
-func (m *Manager) GetPublicKey(keyID string) (*rsa.PublicKey, error) {
+// Returns the context error if the context is cancelled.
+func (m *Manager) GetPublicKey(ctx context.Context, keyID string) (*rsa.PublicKey, error) {
 	status := "error"
+	errorType := "error"
 	defer func() {
 		if m.metrics != nil {
-			m.metrics.IncrementCounter(metricKeyValidationOpsTotal, map[string]string{"status": status})
+			m.metrics.IncrementCounter(metricKeyValidationOpsTotal, map[string]string{"status": status, "error_type": errorType})
 		}
 	}()
 
@@ -412,7 +423,14 @@ func (m *Manager) GetPublicKey(keyID string) (*rsa.PublicKey, error) {
 		return nil, ErrInvalidKeyID
 	}
 
-	// ===== STEP 2: Check Cache First =====
+	// ===== STEP 2: Context Check =====
+	if err := ctx.Err(); err != nil {
+		status = "cancelled"
+		errorType = "cancelled"
+		return nil, err
+	}
+
+	// ===== STEP 3: Check Cache First =====
 	m.mu.RLock()
 	if keyPair, exists := m.keys[keyID]; exists {
 		m.mu.RUnlock()
@@ -420,35 +438,39 @@ func (m *Manager) GetPublicKey(keyID string) (*rsa.PublicKey, error) {
 			m.config.Logger.Debug("public key cache hit", "keyID", keyID)
 		}
 		status = "success"
+		errorType = ""
 		return keyPair.PublicKey, nil
 	}
 	m.mu.RUnlock()
 
-	// ===== STEP 3: Load from KeyStore =====
+	// ===== STEP 4: Load from KeyStore =====
 	if m.config.Logger != nil {
 		m.config.Logger.Debug("public key not in cache, loading from store", "keyID", keyID)
 	}
-	privateKey, meta, err := m.config.KeyStore.LoadKey(context.Background(), keyID)
+	privateKey, meta, err := m.config.KeyStore.LoadKey(ctx, keyID)
 	if err != nil {
 		if errors.Is(err, ErrKeyStoreKeyNotFound) {
 			status = "not_found"
+			errorType = "not_found"
 			return nil, ErrKeyNotFound
 		}
 		return nil, err
 	}
 
-	// ===== STEP 4: Check Expiration =====
+	// ===== STEP 5: Check Expiration =====
 	if !meta.ExpiresAt.IsZero() && time.Now().After(meta.ExpiresAt) {
 		status = "not_found"
+		errorType = "not_found"
 		return nil, ErrKeyNotFound
 	}
 
-	// ===== STEP 5: Cache with Double-Check Pattern =====
+	// ===== STEP 6: Cache with Double-Check Pattern =====
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if keyPair, exists := m.keys[keyID]; exists {
 		status = "success"
+		errorType = ""
 		return keyPair.PublicKey, nil
 	}
 
@@ -460,6 +482,7 @@ func (m *Manager) GetPublicKey(keyID string) (*rsa.PublicKey, error) {
 	}
 
 	status = "success"
+	errorType = ""
 	return &privateKey.PublicKey, nil
 }
 
@@ -521,9 +544,10 @@ func (m *Manager) GetKeyInfo(keyID string) (*KeyPair, error) {
 func (m *Manager) RotateKeys(ctx context.Context) error {
 	start := time.Now()
 	status := "error"
+	errorType := "error"
 	defer func() {
 		if m.metrics != nil {
-			m.metrics.IncrementCounter(metricKeyRotationsTotal, map[string]string{"status": status})
+			m.metrics.IncrementCounter(metricKeyRotationsTotal, map[string]string{"status": status, "error_type": errorType})
 			m.metrics.RecordDuration(metricKeyOpDuration, time.Since(start), map[string]string{"operation": "rotate"})
 		}
 	}()
@@ -532,6 +556,7 @@ func (m *Manager) RotateKeys(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
 		status = "cancelled"
+		errorType = "cancelled"
 		if m.config.Logger != nil {
 			m.config.Logger.Warn("key rotation cancelled")
 		}
@@ -608,6 +633,7 @@ func (m *Manager) RotateKeys(ctx context.Context) error {
 	}
 
 	status = "success"
+	errorType = ""
 	if m.metrics != nil {
 		m.metrics.SetGauge(metricKeyActiveVersionsCount, float64(len(m.keys)), nil)
 	}

--- a/pkg/keymanager/keymanager_test.go
+++ b/pkg/keymanager/keymanager_test.go
@@ -289,20 +289,20 @@ var _ = Describe("Manager", func() {
 			})
 
 			It("should return a valid private key and non-empty key ID", func() {
-				key, keyID, err := manager.GetCurrentSigningKey()
+				key, keyID, err := manager.GetCurrentSigningKey(ctx)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(key).NotTo(BeNil())
 				Expect(keyID).NotTo(BeEmpty())
 			})
 
 			It("should return consistent key ID across multiple calls", func() {
-				_, id1, _ := manager.GetCurrentSigningKey()
-				_, id2, _ := manager.GetCurrentSigningKey()
+				_, id1, _ := manager.GetCurrentSigningKey(ctx)
+				_, id2, _ := manager.GetCurrentSigningKey(ctx)
 				Expect(id1).To(Equal(id2))
 			})
 
 			It("should return a key of the configured size", func() {
-				key, _, err := manager.GetCurrentSigningKey()
+				key, _, err := manager.GetCurrentSigningKey(ctx)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(key.N.BitLen()).To(Equal(2048))
 			})
@@ -310,8 +310,24 @@ var _ = Describe("Manager", func() {
 
 		Context("when the manager is not running", func() {
 			It("should return ErrManagerNotRunning", func() {
-				_, _, err := manager.GetCurrentSigningKey()
+				_, _, err := manager.GetCurrentSigningKey(ctx)
 				Expect(err).To(MatchError(keymanager.ErrManagerNotRunning))
+			})
+		})
+
+		Context("context cancellation", func() {
+			BeforeEach(func() {
+				mockKS.EXPECT().LoadAll(gomock.Any()).Return([]*keymanager.StoredKey{}, nil)
+				mockKS.EXPECT().Save(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				Expect(manager.Start(ctx)).To(Succeed())
+			})
+
+			It("should return context error when context is already cancelled", func() {
+				cancelledCtx, cancelFn := context.WithCancel(context.Background())
+				cancelFn()
+
+				_, _, err := manager.GetCurrentSigningKey(cancelledCtx)
+				Expect(err).To(MatchError(context.Canceled))
 			})
 		})
 	})
@@ -358,7 +374,7 @@ var _ = Describe("Manager", func() {
 
 		Context("cache hit", func() {
 			It("should return the public key for a cached key ID", func() {
-				pub, err := manager.GetPublicKey(testKeyID)
+				pub, err := manager.GetPublicKey(ctx, testKeyID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pub).NotTo(BeNil())
 				Expect(pub).To(Equal(&testKey.PublicKey))
@@ -373,7 +389,7 @@ var _ = Describe("Manager", func() {
 
 				mockKS.EXPECT().LoadKey(gomock.Any(), uncachedID).Return(uncachedKey, meta, nil)
 
-				pub, err := manager.GetPublicKey(uncachedID)
+				pub, err := manager.GetPublicKey(ctx, uncachedID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pub).To(Equal(&uncachedKey.PublicKey))
 			})
@@ -381,7 +397,7 @@ var _ = Describe("Manager", func() {
 			It("should return ErrKeyNotFound when store returns ErrKeyStoreKeyNotFound", func() {
 				mockKS.EXPECT().LoadKey(gomock.Any(), "missing-id").Return(nil, nil, keymanager.ErrKeyStoreKeyNotFound)
 
-				_, err := manager.GetPublicKey("missing-id")
+				_, err := manager.GetPublicKey(ctx, "missing-id")
 				Expect(err).To(MatchError(keymanager.ErrKeyNotFound))
 			})
 
@@ -396,24 +412,24 @@ var _ = Describe("Manager", func() {
 
 				mockKS.EXPECT().LoadKey(gomock.Any(), expiredID).Return(expiredKey, expiredMeta, nil)
 
-				_, err := manager.GetPublicKey(expiredID)
+				_, err := manager.GetPublicKey(ctx, expiredID)
 				Expect(err).To(MatchError(keymanager.ErrKeyNotFound))
 			})
 		})
 
 		Context("input validation", func() {
 			It("should return ErrInvalidKeyID for an empty key ID", func() {
-				_, err := manager.GetPublicKey("")
+				_, err := manager.GetPublicKey(ctx, "")
 				Expect(err).To(MatchError(keymanager.ErrInvalidKeyID))
 			})
 
 			It("should return ErrInvalidKeyID for a whitespace-only key ID", func() {
-				_, err := manager.GetPublicKey("   ")
+				_, err := manager.GetPublicKey(ctx, "   ")
 				Expect(err).To(MatchError(keymanager.ErrInvalidKeyID))
 			})
 
 			It("should trim whitespace from keyID and succeed", func() {
-				pub, err := manager.GetPublicKey("  " + testKeyID + "  ")
+				pub, err := manager.GetPublicKey(ctx, "  "+testKeyID+"  ")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pub).NotTo(BeNil())
 			})
@@ -426,7 +442,7 @@ var _ = Describe("Manager", func() {
 
 				for i := 0; i < numReaders; i++ {
 					go func() {
-						_, err := manager.GetPublicKey(testKeyID)
+						_, err := manager.GetPublicKey(ctx, testKeyID)
 						results <- err
 					}()
 				}
@@ -434,6 +450,16 @@ var _ = Describe("Manager", func() {
 				for i := 0; i < numReaders; i++ {
 					Expect(<-results).NotTo(HaveOccurred())
 				}
+			})
+		})
+
+		Context("context cancellation", func() {
+			It("should return context error when context is already cancelled", func() {
+				cancelledCtx, cancelFn := context.WithCancel(context.Background())
+				cancelFn()
+
+				_, err := manager.GetPublicKey(cancelledCtx, testKeyID)
+				Expect(err).To(MatchError(context.Canceled))
 			})
 		})
 	})
@@ -562,14 +588,14 @@ var _ = Describe("Manager", func() {
 			})
 
 			It("should change the current signing key ID after rotation", func() {
-				_, originalID, _ := manager.GetCurrentSigningKey()
+				_, originalID, _ := manager.GetCurrentSigningKey(ctx)
 
 				mockKS.EXPECT().Save(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 				mockKS.EXPECT().UpdateMetadata(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 				Expect(manager.RotateKeys(ctx)).To(Succeed())
 
-				_, newID, _ := manager.GetCurrentSigningKey()
+				_, newID, _ := manager.GetCurrentSigningKey(ctx)
 				Expect(newID).NotTo(Equal(originalID))
 			})
 
@@ -743,7 +769,11 @@ var _ = Describe("Manager", func() {
 		// expectRotationMetrics sets up MockMetrics expectations for a RotateKeys call.
 		// For "success", also expects the active-versions gauge to be updated.
 		expectRotationMetrics := func(status string) {
-			mockM.EXPECT().IncrementCounter("jwtauth_key_rotations_total", map[string]string{"status": status})
+			errorType := status
+			if status == "success" {
+				errorType = ""
+			}
+			mockM.EXPECT().IncrementCounter("jwtauth_key_rotations_total", map[string]string{"status": status, "error_type": errorType})
 			mockM.EXPECT().RecordDuration("jwtauth_key_operation_duration_seconds", gomock.Any(), map[string]string{"operation": "rotate"})
 			if status == "success" {
 				mockM.EXPECT().SetGauge("jwtauth_key_active_versions_count", gomock.Any(), gomock.Nil())
@@ -805,9 +835,9 @@ var _ = Describe("Manager", func() {
 					_ = m.Shutdown(shutdownCtx)
 				}()
 
-				mockM.EXPECT().IncrementCounter("jwtauth_key_signing_operations_total", map[string]string{"status": "success"})
+				mockM.EXPECT().IncrementCounter("jwtauth_key_signing_operations_total", map[string]string{"status": "success", "error_type": ""})
 
-				_, _, err := m.GetCurrentSigningKey()
+				_, _, err := m.GetCurrentSigningKey(ctx)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -821,10 +851,27 @@ var _ = Describe("Manager", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				mockM.EXPECT().IncrementCounter("jwtauth_key_signing_operations_total", map[string]string{"status": "error"})
+				mockM.EXPECT().IncrementCounter("jwtauth_key_signing_operations_total", map[string]string{"status": "error", "error_type": "error"})
 
-				_, _, err = m.GetCurrentSigningKey()
+				_, _, err = m.GetCurrentSigningKey(ctx)
 				Expect(err).To(MatchError(keymanager.ErrManagerNotRunning))
+			})
+
+			It("should record cancelled counter when context is already cancelled", func() {
+				m := newMetricManager()
+				defer func() {
+					shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+					defer cancel()
+					_ = m.Shutdown(shutdownCtx)
+				}()
+
+				cancelledCtx, cancelFn := context.WithCancel(context.Background())
+				cancelFn()
+
+				mockM.EXPECT().IncrementCounter("jwtauth_key_signing_operations_total", map[string]string{"status": "cancelled", "error_type": "cancelled"})
+
+				_, _, err := m.GetCurrentSigningKey(cancelledCtx)
+				Expect(err).To(MatchError(context.Canceled))
 			})
 		})
 
@@ -837,9 +884,9 @@ var _ = Describe("Manager", func() {
 					_ = m.Shutdown(shutdownCtx)
 				}()
 
-				mockM.EXPECT().IncrementCounter("jwtauth_key_validation_operations_total", map[string]string{"status": "success"})
+				mockM.EXPECT().IncrementCounter("jwtauth_key_validation_operations_total", map[string]string{"status": "success", "error_type": ""})
 
-				_, err := m.GetPublicKey("existing-metric-key")
+				_, err := m.GetPublicKey(ctx, "existing-metric-key")
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -851,11 +898,28 @@ var _ = Describe("Manager", func() {
 					_ = m.Shutdown(shutdownCtx)
 				}()
 
-				mockM.EXPECT().IncrementCounter("jwtauth_key_validation_operations_total", map[string]string{"status": "not_found"})
+				mockM.EXPECT().IncrementCounter("jwtauth_key_validation_operations_total", map[string]string{"status": "not_found", "error_type": "not_found"})
 				mockKS.EXPECT().LoadKey(gomock.Any(), "ghost-key").Return(nil, nil, keymanager.ErrKeyStoreKeyNotFound)
 
-				_, err := m.GetPublicKey("ghost-key")
+				_, err := m.GetPublicKey(ctx, "ghost-key")
 				Expect(err).To(MatchError(keymanager.ErrKeyNotFound))
+			})
+
+			It("should record cancelled counter when context is already cancelled", func() {
+				m := newMetricManager()
+				defer func() {
+					shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+					defer cancel()
+					_ = m.Shutdown(shutdownCtx)
+				}()
+
+				cancelledCtx, cancelFn := context.WithCancel(context.Background())
+				cancelFn()
+
+				mockM.EXPECT().IncrementCounter("jwtauth_key_validation_operations_total", map[string]string{"status": "cancelled", "error_type": "cancelled"})
+
+				_, err := m.GetPublicKey(cancelledCtx, "some-key")
+				Expect(err).To(MatchError(context.Canceled))
 			})
 		})
 
@@ -886,8 +950,8 @@ var _ = Describe("Manager", func() {
 					_ = m.Shutdown(shutdownCtx)
 				}()
 
-				Expect(func() { _, _, _ = m.GetCurrentSigningKey() }).NotTo(Panic())
-				Expect(func() { _, _ = m.GetPublicKey(existingID) }).NotTo(Panic())
+				Expect(func() { _, _, _ = m.GetCurrentSigningKey(ctx) }).NotTo(Panic())
+				Expect(func() { _, _ = m.GetPublicKey(ctx, existingID) }).NotTo(Panic())
 
 				mockKS.EXPECT().Save(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 				mockKS.EXPECT().UpdateMetadata(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)

--- a/pkg/keymanager/redis.go
+++ b/pkg/keymanager/redis.go
@@ -64,12 +64,14 @@ func NewRedisKeyStore(client *redis.Client, logger logging.Logger, m metrics.Met
 func (r *RedisKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 	start := time.Now()
 	status := "error"
+	errorType := "error"
 	var keyCount int
 	defer func() {
 		if r.metrics != nil {
 			r.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
 				"operation":       "load_all",
 				"status":          status,
+				"error_type":      errorType,
 				"storage_backend": r.backend,
 			})
 			r.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
@@ -87,6 +89,7 @@ func (r *RedisKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
+		errorType = "cancelled"
 		return nil, err
 	}
 
@@ -170,6 +173,7 @@ func (r *RedisKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 
 	// ===== STEP 6: Log and Return =====
 	status = "success"
+	errorType = ""
 	keyCount = len(keys)
 	if r.logger != nil {
 		r.logger.Info("loaded keys from redis", "count", keyCount)
@@ -183,11 +187,13 @@ func (r *RedisKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 func (r *RedisKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.PrivateKey, meta KeyMetadata) error {
 	start := time.Now()
 	status := "error"
+	errorType := "error"
 	defer func() {
 		if r.metrics != nil {
 			r.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
 				"operation":       "save",
 				"status":          status,
+				"error_type":      errorType,
 				"storage_backend": r.backend,
 			})
 			r.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
@@ -200,6 +206,7 @@ func (r *RedisKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
+		errorType = "cancelled"
 		return err
 	}
 
@@ -233,6 +240,7 @@ func (r *RedisKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.
 
 	// ===== STEP 5: Log and Return =====
 	status = "success"
+	errorType = ""
 	if r.logger != nil {
 		r.logger.Info("saved key to redis", "keyID", keyID)
 	}
@@ -246,11 +254,13 @@ func (r *RedisKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.
 func (r *RedisKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta KeyMetadata) error {
 	start := time.Now()
 	status := "error"
+	errorType := "error"
 	defer func() {
 		if r.metrics != nil {
 			r.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
 				"operation":       "update_metadata",
 				"status":          status,
+				"error_type":      errorType,
 				"storage_backend": r.backend,
 			})
 			r.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
@@ -263,6 +273,7 @@ func (r *RedisKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta K
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
+		errorType = "cancelled"
 		return err
 	}
 
@@ -278,6 +289,7 @@ func (r *RedisKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta K
 	}
 	if exists == 0 {
 		status = "not_found"
+		errorType = "not_found"
 		return ErrKeyStoreKeyNotFound
 	}
 
@@ -303,6 +315,7 @@ func (r *RedisKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta K
 
 	// ===== STEP 4: Log and Return =====
 	status = "success"
+	errorType = ""
 	if r.logger != nil {
 		r.logger.Info("updated key metadata", "keyID", keyID)
 	}
@@ -316,11 +329,13 @@ func (r *RedisKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta K
 func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.PrivateKey, *KeyMetadata, error) {
 	start := time.Now()
 	status := "error"
+	errorType := "error"
 	defer func() {
 		if r.metrics != nil {
 			r.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
 				"operation":       "load_key",
 				"status":          status,
+				"error_type":      errorType,
 				"storage_backend": r.backend,
 			})
 			r.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
@@ -333,12 +348,14 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
+		errorType = "cancelled"
 		return nil, nil, err
 	}
 
 	// ===== STEP 2: Validate Key ID =====
 	if strings.TrimSpace(keyID) == "" {
 		status = "not_found"
+		errorType = "not_found"
 		return nil, nil, ErrKeyStoreInvalidKeyID
 	}
 
@@ -347,6 +364,7 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 	if err != nil {
 		if errors.Is(err, redis.Nil) {
 			status = "not_found"
+			errorType = "not_found"
 			return nil, nil, ErrKeyStoreKeyNotFound
 		}
 		if r.logger != nil {
@@ -372,6 +390,7 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 	if err != nil {
 		if errors.Is(err, redis.Nil) {
 			status = "not_found"
+			errorType = "not_found"
 			return nil, nil, ErrKeyStoreKeyNotFound
 		}
 		if r.logger != nil {
@@ -394,6 +413,7 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 
 	// ===== STEP 5: Log and Return =====
 	status = "success"
+	errorType = ""
 	if r.logger != nil {
 		r.logger.Debug("loaded key from redis", "keyID", keyID)
 	}
@@ -406,11 +426,13 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 func (r *RedisKeyStore) Delete(ctx context.Context, keyID string) error {
 	start := time.Now()
 	status := "error"
+	errorType := "error"
 	defer func() {
 		if r.metrics != nil {
 			r.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
 				"operation":       "delete",
 				"status":          status,
+				"error_type":      errorType,
 				"storage_backend": r.backend,
 			})
 			r.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
@@ -423,6 +445,7 @@ func (r *RedisKeyStore) Delete(ctx context.Context, keyID string) error {
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
+		errorType = "cancelled"
 		return err
 	}
 
@@ -438,6 +461,7 @@ func (r *RedisKeyStore) Delete(ctx context.Context, keyID string) error {
 
 	// ===== STEP 3: Log and Return =====
 	status = "success"
+	errorType = ""
 	if r.logger != nil {
 		r.logger.Info("deleted key from redis", "keyID", keyID)
 	}

--- a/pkg/keymanager/redis_test.go
+++ b/pkg/keymanager/redis_test.go
@@ -436,9 +436,14 @@ var _ = Describe("RedisKeyStore", func() {
 		}
 
 		expectOpsMetrics := func(operation, status string) {
+			errorType := status
+			if status == "success" {
+				errorType = ""
+			}
 			mockM.EXPECT().IncrementCounter("jwtauth_keystore_operations_total", map[string]string{
 				"operation":       operation,
 				"status":          status,
+				"error_type":      errorType,
 				"storage_backend": "redis",
 			})
 			mockM.EXPECT().RecordDuration("jwtauth_keystore_operation_duration_seconds", gomock.Any(), map[string]string{

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -133,7 +133,7 @@ func (pm *PrometheusMetrics) registerAllMetrics(namespace string) {
 
 	pm.registerCounter(namespace, "keystore_operations_total",
 		"Total number of key store operations",
-		[]string{"operation", "status", "storage_backend"})
+		[]string{"operation", "status", "error_type", "storage_backend"})
 
 	pm.registerHistogram(namespace, "keystore_operation_duration_seconds",
 		"Duration of key store operations in seconds",
@@ -148,15 +148,15 @@ func (pm *PrometheusMetrics) registerAllMetrics(namespace string) {
 
 	pm.registerCounter(namespace, "key_rotations_total",
 		"Total number of key rotations",
-		[]string{"status"})
+		[]string{"status", "error_type"})
 
 	pm.registerCounter(namespace, "key_signing_operations_total",
 		"Total number of key signing operations",
-		[]string{"status"})
+		[]string{"status", "error_type"})
 
 	pm.registerCounter(namespace, "key_validation_operations_total",
 		"Total number of key validation operations",
-		[]string{"status"})
+		[]string{"status", "error_type"})
 
 	pm.registerHistogram(namespace, "key_operation_duration_seconds",
 		"Duration of key operations in seconds",

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -739,7 +739,8 @@ var _ = Describe("Prometheus", func() {
 			It("should track rotation → sign → validate flow", func() {
 				// Key rotation
 				pm.IncrementCounter("jwtauth_key_rotations_total", map[string]string{
-					"status": "success",
+					"status":     "success",
+					"error_type": "",
 				})
 				pm.RecordDuration("jwtauth_key_operation_duration_seconds", 100*time.Millisecond, map[string]string{
 					"operation": "rotate",
@@ -751,7 +752,8 @@ var _ = Describe("Prometheus", func() {
 
 				// Signing operations
 				pm.IncrementCounter("jwtauth_key_signing_operations_total", map[string]string{
-					"status": "success",
+					"status":     "success",
+					"error_type": "",
 				})
 				pm.RecordDuration("jwtauth_key_operation_duration_seconds", 500*time.Microsecond, map[string]string{
 					"operation": "sign",
@@ -759,15 +761,16 @@ var _ = Describe("Prometheus", func() {
 
 				// Validation operations
 				pm.IncrementCounter("jwtauth_key_validation_operations_total", map[string]string{
-					"status": "success",
+					"status":     "success",
+					"error_type": "",
 				})
 				pm.RecordDuration("jwtauth_key_operation_duration_seconds", 300*time.Microsecond, map[string]string{
 					"operation": "validate",
 				})
 
-				Expect(counterValue(registry, "jwtauth_key_rotations_total", map[string]string{"status": "success"})).To(Equal(1.0))
-				Expect(counterValue(registry, "jwtauth_key_signing_operations_total", map[string]string{"status": "success"})).To(Equal(1.0))
-				Expect(counterValue(registry, "jwtauth_key_validation_operations_total", map[string]string{"status": "success"})).To(Equal(1.0))
+				Expect(counterValue(registry, "jwtauth_key_rotations_total", map[string]string{"status": "success", "error_type": ""})).To(Equal(1.0))
+				Expect(counterValue(registry, "jwtauth_key_signing_operations_total", map[string]string{"status": "success", "error_type": ""})).To(Equal(1.0))
+				Expect(counterValue(registry, "jwtauth_key_validation_operations_total", map[string]string{"status": "success", "error_type": ""})).To(Equal(1.0))
 				Expect(gaugeValue(registry, "jwtauth_key_current_version", map[string]string{})).To(Equal(5.0))
 				Expect(gaugeValue(registry, "jwtauth_key_active_versions_count", map[string]string{})).To(Equal(2.0))
 				Expect(histogramSampleCount(registry, "jwtauth_key_operation_duration_seconds", map[string]string{"operation": "rotate"})).To(Equal(uint64(1)))

--- a/pkg/tokens/service.go
+++ b/pkg/tokens/service.go
@@ -366,7 +366,7 @@ func (s *Service) IssueAccessToken(ctx context.Context, userID string) (string, 
 	// ===== STEP 4: Get Signing Key =====
 	// Retrieve current private key and its ID from KeyManager
 	// The key ID will be included in the JWT header for verification
-	privateKey, keyID, err := s.keyManager.GetCurrentSigningKey()
+	privateKey, keyID, err := s.keyManager.GetCurrentSigningKey(ctx)
 	if err != nil {
 		if s.logger != nil {
 			s.logger.Error("failed to get signing key",
@@ -528,7 +528,7 @@ func (s *Service) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 	}
 
 	// ===== STEP 4: Get Signing Key =====
-	privateKey, keyID, err := s.keyManager.GetCurrentSigningKey()
+	privateKey, keyID, err := s.keyManager.GetCurrentSigningKey(ctx)
 	if err != nil {
 		if s.logger != nil {
 			s.logger.Error("failed to get signing key",
@@ -960,7 +960,7 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 	}
 
 	// ===== STEP 4: Get Signing Key =====
-	privateKey, keyID, err := s.keyManager.GetCurrentSigningKey()
+	privateKey, keyID, err := s.keyManager.GetCurrentSigningKey(ctx)
 	if err != nil {
 		if s.logger != nil {
 			s.logger.Error("failed to get signing key",
@@ -1142,7 +1142,7 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 			}
 
 			// ===== STEP 4c: Get Public Key =====
-			publicKey, err := s.keyManager.GetPublicKey(kid)
+			publicKey, err := s.keyManager.GetPublicKey(ctx, kid)
 			if err != nil {
 				if s.logger != nil {
 					s.logger.Error("failed to get public key",

--- a/pkg/tokens/service_lifecycle_test.go
+++ b/pkg/tokens/service_lifecycle_test.go
@@ -397,7 +397,7 @@ var _ = Describe("TokenService", func() {
 	Describe("Complete Lifecycle", func() {
 		It("should handle start -> use -> shutdown cycle", func() {
 			mockKM.EXPECT().Start(gomock.Any()).Return(nil)
-			mockKM.EXPECT().GetCurrentSigningKey().Return(testKey, testKeyID, nil).AnyTimes()
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil).AnyTimes()
 			mockKM.EXPECT().Shutdown(gomock.Any()).Return(nil)
 
 			service = createService()

--- a/pkg/tokens/service_metrics_test.go
+++ b/pkg/tokens/service_metrics_test.go
@@ -100,7 +100,7 @@ var _ = Describe("TokenService Metrics", func() {
 	Describe("IssueAccessToken", func() {
 		It("records success counter and duration on successful issuance", func() {
 			startService()
-			mockKM.EXPECT().GetCurrentSigningKey().Return(testKey, testKeyID, nil)
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
 			mockM.EXPECT().IncrementCounter(metricTokensIssuedTotal, map[string]string{
 				"status":     "success",
 				"error_type": "",
@@ -179,7 +179,7 @@ var _ = Describe("TokenService Metrics", func() {
 		It("records success counter and duration on valid token", func() {
 			startService()
 			// Issue a real token first so we have a valid string to validate
-			mockKM.EXPECT().GetCurrentSigningKey().Return(testKey, testKeyID, nil)
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
 			mockM.EXPECT().IncrementCounter(metricTokensIssuedTotal, gomock.Any())
 			mockM.EXPECT().RecordDuration(metricOperationDuration, gomock.Any(), map[string]string{
 				"operation": "issue_access_token",
@@ -188,7 +188,7 @@ var _ = Describe("TokenService Metrics", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Now validate
-			mockKM.EXPECT().GetPublicKey(testKeyID).Return(&testKey.PublicKey, nil)
+			mockKM.EXPECT().GetPublicKey(gomock.Any(), testKeyID).Return(&testKey.PublicKey, nil)
 			mockM.EXPECT().IncrementCounter(metricTokensValidatedTotal, map[string]string{
 				"status":     "success",
 				"error_type": "",
@@ -227,7 +227,7 @@ var _ = Describe("TokenService Metrics", func() {
 				Revoked:   false,
 			}
 			mockStore.EXPECT().Retrieve(gomock.Any(), "rt-1").Return(storedToken, nil)
-			mockKM.EXPECT().GetCurrentSigningKey().Return(testKey, testKeyID, nil)
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
 			// IssueAccessToken metrics (called internally by RefreshAccessToken)
 			mockM.EXPECT().IncrementCounter(metricTokensIssuedTotal, gomock.Any())
 			mockM.EXPECT().RecordDuration(metricOperationDuration, gomock.Any(), map[string]string{
@@ -398,7 +398,7 @@ var _ = Describe("TokenService Metrics", func() {
 			Expect(nilService.Start(ctx)).To(Succeed())
 
 			// IssueAccessToken should not panic
-			mockKM.EXPECT().GetCurrentSigningKey().Return(testKey, testKeyID, nil)
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
 			_, err := nilService.IssueAccessToken(ctx, "user-1")
 			Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/tokens/service_test.go
+++ b/pkg/tokens/service_test.go
@@ -204,7 +204,7 @@ var _ = Describe("TokenService", func() {
 		})
 		It("should issue access token successfully", func() {
 			// Expect key retrieval
-			mockKM.EXPECT().GetCurrentSigningKey().Return(testKey, testKeyID, nil)
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
 			token, err := service.IssueAccessToken(ctx, testUserID)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(token).NotTo((BeEmpty()))
@@ -212,13 +212,13 @@ var _ = Describe("TokenService", func() {
 
 		It("should use KeyManager to sign token", func() {
 			// This is what we're verifying
-			mockKM.EXPECT().GetCurrentSigningKey().Return(testKey, testKeyID, nil).Times(1)
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil).Times(1)
 
 			service.IssueAccessToken(ctx, testUserID)
 		})
 
 		It("should log token issuance", func() {
-			mockKM.EXPECT().GetCurrentSigningKey().Return(testKey, testKeyID, nil)
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
 
 			service.IssueAccessToken(ctx, testUserID)
 
@@ -228,7 +228,7 @@ var _ = Describe("TokenService", func() {
 		})
 
 		It("should include custom claims issuance if provided", func() {
-			mockKM.EXPECT().GetCurrentSigningKey().Return(testKey, testKeyID, nil)
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
 
 			customClaims := map[string]interface{}{
 				"role":   "admin",
@@ -247,14 +247,14 @@ var _ = Describe("TokenService", func() {
 		})
 
 		It("should respect call order", func() {
-			mockKM.EXPECT().GetCurrentSigningKey().Return(testKey, testKeyID, nil)
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
 
 			service.IssueAccessToken(ctx, testUserID)
 		})
 
 		Context("when key retrieval fails", func() {
 			It("should return error", func() {
-				mockKM.EXPECT().GetCurrentSigningKey().Return(nil, "", errors.New("key unavailable")).Times(1)
+				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(nil, "", errors.New("key unavailable")).Times(1)
 
 				_, err := service.IssueAccessToken(ctx, testUserID)
 
@@ -264,7 +264,7 @@ var _ = Describe("TokenService", func() {
 
 			It("should log error", func() {
 				mockKM.EXPECT().
-					GetCurrentSigningKey().
+					GetCurrentSigningKey(gomock.Any()).
 					Return(nil, "", errors.New("key error"))
 
 				service.IssueAccessToken(ctx, testUserID)
@@ -278,7 +278,7 @@ var _ = Describe("TokenService", func() {
 		Context("with invalid user ID", func() {
 			It("should return error for empty user ID", func() {
 				// Should not call any dependencies for invalid input
-				mockKM.EXPECT().GetCurrentSigningKey().Times(0)
+				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Times(0)
 
 				_, err := service.IssueAccessToken(ctx, "")
 
@@ -287,7 +287,7 @@ var _ = Describe("TokenService", func() {
 			})
 
 			It("should return error for whitespace-only user ID", func() {
-				mockKM.EXPECT().GetCurrentSigningKey().Times(0)
+				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Times(0)
 
 				_, err := service.IssueAccessToken(ctx, "   ")
 
@@ -302,7 +302,7 @@ var _ = Describe("TokenService", func() {
 				cancelFn() // cancel immediately
 
 				// Might not even get to dependencies
-				mockKM.EXPECT().GetCurrentSigningKey().Times(0)
+				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Times(0)
 
 				_, err := service.IssueAccessToken(cancelledCtx, testUserID)
 				Expect(err).To(Equal(context.Canceled))
@@ -334,7 +334,7 @@ var _ = Describe("TokenService", func() {
 			})
 
 			It("should not override reserved claim sub", func() {
-				mockKM.EXPECT().GetCurrentSigningKey().Return(testKey, testKeyID, nil)
+				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
 				customClaims := map[string]interface{}{"sub": "hacker", "role": "admin"}
 				tokenStr, err := service.IssueAccessTokenWithClaims(ctx, testUserID, customClaims)
 				Expect(err).NotTo(HaveOccurred())
@@ -521,7 +521,7 @@ var _ = Describe("TokenService", func() {
 			It("should issue both token successfully", func() {
 				// Expect all dependencies called in order
 				gomock.InOrder(
-					mockKM.EXPECT().GetCurrentSigningKey().Return(testKey, testKeyID, nil),
+					mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil),
 					mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), testUserID, gomock.Any(), gomock.Any()).Return(nil),
 				)
 
@@ -534,7 +534,7 @@ var _ = Describe("TokenService", func() {
 
 			It("should use KeyManager for access token", func() {
 				mockKM.EXPECT().
-					GetCurrentSigningKey().
+					GetCurrentSigningKey(gomock.Any()).
 					Return(testKey, testKeyID, nil).
 					Times(1)
 
@@ -544,7 +544,7 @@ var _ = Describe("TokenService", func() {
 			})
 
 			It("should store refresh token", func() {
-				mockKM.EXPECT().GetCurrentSigningKey().Return(testKey, testKeyID, nil)
+				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
 
 				mockStore.EXPECT().
 					Store(gomock.Any(), gomock.Any(), testUserID, gomock.Any(), gomock.Any()).
@@ -555,7 +555,7 @@ var _ = Describe("TokenService", func() {
 			})
 
 			It("should log both issuances", func() {
-				mockKM.EXPECT().GetCurrentSigningKey().Return(testKey, testKeyID, nil)
+				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
 				mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 				service.IssueTokenPair(ctx, testUserID)
@@ -569,7 +569,7 @@ var _ = Describe("TokenService", func() {
 		Context("when access token issuance fails", func() {
 			It("should not issue refresh token", func() {
 				mockKM.EXPECT().
-					GetCurrentSigningKey().
+					GetCurrentSigningKey(gomock.Any()).
 					Return(nil, "", errors.New("key error"))
 
 				// Store should NOT be called
@@ -583,7 +583,7 @@ var _ = Describe("TokenService", func() {
 
 		Context("when refresh token storage fails", func() {
 			It("should return error", func() {
-				mockKM.EXPECT().GetCurrentSigningKey().Return(testKey, testKeyID, nil)
+				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
 				mockStore.EXPECT().
 					Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(errors.New("storage error"))
@@ -633,14 +633,14 @@ var _ = Describe("TokenService", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Then issue a valid token
-			mockKM.EXPECT().GetCurrentSigningKey().Return(testKey, testKeyID, nil)
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
 			validToken, _ = service.IssueAccessToken(ctx, testUserID)
 		})
 
 		Context("with valid token", func() {
 			It("should validate successfully", func() {
 				// Expect public key retrieval
-				mockKM.EXPECT().GetPublicKey(testKeyID).
+				mockKM.EXPECT().GetPublicKey(gomock.Any(), testKeyID).
 					Return(&testKey.PublicKey, nil).
 					Times(1)
 
@@ -653,7 +653,7 @@ var _ = Describe("TokenService", func() {
 
 			It("should use KeyManager to get public key", func() {
 				mockKM.EXPECT().
-					GetPublicKey(gomock.Any()).
+					GetPublicKey(gomock.Any(), gomock.Any()).
 					Return(&testKey.PublicKey, nil).
 					Times(1)
 
@@ -662,14 +662,14 @@ var _ = Describe("TokenService", func() {
 
 			It("should verify correct key ID from header", func() {
 				mockKM.EXPECT().
-					GetPublicKey(testKeyID). // Exact key ID
+					GetPublicKey(gomock.Any(), testKeyID). // Exact key ID
 					Return(&testKey.PublicKey, nil)
 
 				service.ValidateAccessToken(ctx, validToken)
 			})
 
 			It("should log successful validation", func() {
-				mockKM.EXPECT().GetPublicKey(gomock.Any()).Return(&testKey.PublicKey, nil)
+				mockKM.EXPECT().GetPublicKey(gomock.Any(), gomock.Any()).Return(&testKey.PublicKey, nil)
 
 				service.ValidateAccessToken(ctx, validToken)
 
@@ -682,7 +682,7 @@ var _ = Describe("TokenService", func() {
 		Context("with invalid token format", func() {
 			It("should return error for malformed token", func() {
 				// Should not call KeyManager for invalid format
-				mockKM.EXPECT().GetPublicKey(gomock.Any()).Times(0)
+				mockKM.EXPECT().GetPublicKey(gomock.Any(), gomock.Any()).Times(0)
 
 				_, err := service.ValidateAccessToken(ctx, "not-a-jwt-token")
 
@@ -691,7 +691,7 @@ var _ = Describe("TokenService", func() {
 			})
 
 			It("should return error for empty token", func() {
-				mockKM.EXPECT().GetPublicKey(gomock.Any()).Times(0)
+				mockKM.EXPECT().GetPublicKey(gomock.Any(), gomock.Any()).Times(0)
 
 				_, err := service.ValidateAccessToken(ctx, "")
 
@@ -712,7 +712,7 @@ var _ = Describe("TokenService", func() {
 			It("should return error", func() {
 				expiredToken := createExpiredToken(testKey, testKeyID, testUserID)
 
-				mockKM.EXPECT().GetPublicKey(gomock.Any()).Return(&testKey.PublicKey, nil).AnyTimes()
+				mockKM.EXPECT().GetPublicKey(gomock.Any(), gomock.Any()).Return(&testKey.PublicKey, nil).AnyTimes()
 
 				_, err := service.ValidateAccessToken(ctx, expiredToken)
 
@@ -722,7 +722,7 @@ var _ = Describe("TokenService", func() {
 
 			It("should log expiration", func() {
 				expiredToken := createExpiredToken(testKey, testKeyID, testUserID)
-				mockKM.EXPECT().GetPublicKey(gomock.Any()).Return(&testKey.PublicKey, nil).AnyTimes()
+				mockKM.EXPECT().GetPublicKey(gomock.Any(), gomock.Any()).Return(&testKey.PublicKey, nil).AnyTimes()
 
 				service.ValidateAccessToken(ctx, expiredToken)
 
@@ -736,7 +736,7 @@ var _ = Describe("TokenService", func() {
 		Context("when public key retrieval fails", func() {
 			It("should return error", func() {
 				mockKM.EXPECT().
-					GetPublicKey(gomock.Any()).
+					GetPublicKey(gomock.Any(), gomock.Any()).
 					Return(nil, errors.New("key unavailable"))
 
 				_, err := service.ValidateAccessToken(ctx, validToken)
@@ -746,7 +746,7 @@ var _ = Describe("TokenService", func() {
 
 			It("should log error", func() {
 				mockKM.EXPECT().
-					GetPublicKey(gomock.Any()).
+					GetPublicKey(gomock.Any(), gomock.Any()).
 					Return(nil, errors.New("key error"))
 
 				service.ValidateAccessToken(ctx, validToken)
@@ -760,7 +760,7 @@ var _ = Describe("TokenService", func() {
 		Context("with key not found", func() {
 			It("should return error", func() {
 				mockKM.EXPECT().
-					GetPublicKey(gomock.Any()).
+					GetPublicKey(gomock.Any(), gomock.Any()).
 					Return(nil, keymanager.ErrKeyNotFound)
 
 				_, err := service.ValidateAccessToken(ctx, validToken)
@@ -812,7 +812,7 @@ var _ = Describe("TokenService", func() {
 		Context("with issuer mismatch", func() {
 			It("should return ErrInvalidIssuer", func() {
 				mismatchToken := createTokenWithIssuer(testKey, testKeyID, "wrong-issuer")
-				mockKM.EXPECT().GetPublicKey(testKeyID).Return(&testKey.PublicKey, nil)
+				mockKM.EXPECT().GetPublicKey(gomock.Any(), testKeyID).Return(&testKey.PublicKey, nil)
 				_, err := service.ValidateAccessToken(ctx, mismatchToken)
 				Expect(err).To(Equal(tokens.ErrInvalidIssuer))
 			})
@@ -821,7 +821,7 @@ var _ = Describe("TokenService", func() {
 		Context("with audience mismatch", func() {
 			It("should return ErrInvalidAudience", func() {
 				mismatchToken := createTokenWithAudience(testKey, testKeyID, []string{"wrong-audience"})
-				mockKM.EXPECT().GetPublicKey(testKeyID).Return(&testKey.PublicKey, nil)
+				mockKM.EXPECT().GetPublicKey(gomock.Any(), testKeyID).Return(&testKey.PublicKey, nil)
 				_, err := service.ValidateAccessToken(ctx, mismatchToken)
 				Expect(err).To(Equal(tokens.ErrInvalidAudience))
 			})
@@ -858,7 +858,7 @@ var _ = Describe("TokenService", func() {
 					}, nil)
 
 				// Expect new access token signed
-				mockKM.EXPECT().GetCurrentSigningKey().Return(testKey, testKeyID, nil)
+				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
 
 				accessToken, err := service.RefreshAccessToken(ctx, validRefreshToken)
 
@@ -872,14 +872,14 @@ var _ = Describe("TokenService", func() {
 					Return(&storage.RefreshToken{UserID: testUserID, ExpiresAt: time.Now().Add(1 * time.Hour)}, nil).
 					Times(1)
 
-				mockKM.EXPECT().GetCurrentSigningKey().Return(testKey, testKeyID, nil)
+				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
 
 				service.RefreshAccessToken(ctx, validRefreshToken)
 			})
 
 			It("should preserve user ID from refresh token", func() {
 				mockStore.EXPECT().Retrieve(gomock.Any(), gomock.Any()).Return(&storage.RefreshToken{UserID: testUserID, ExpiresAt: time.Now().Add(1 * time.Hour)}, nil)
-				mockKM.EXPECT().GetCurrentSigningKey().Return(testKey, testKeyID, nil)
+				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
 
 				accessToken, _ := service.RefreshAccessToken(ctx, validRefreshToken)
 
@@ -889,7 +889,7 @@ var _ = Describe("TokenService", func() {
 
 			It("should log refresh operation", func() {
 				mockStore.EXPECT().Retrieve(gomock.Any(), gomock.Any()).Return(&storage.RefreshToken{UserID: testUserID, ExpiresAt: time.Now().Add(1 * time.Hour)}, nil)
-				mockKM.EXPECT().GetCurrentSigningKey().Return(testKey, testKeyID, nil)
+				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
 
 				service.RefreshAccessToken(ctx, validRefreshToken)
 
@@ -943,7 +943,7 @@ var _ = Describe("TokenService", func() {
 				mockStore.EXPECT().Retrieve(gomock.Any(), gomock.Any()).Return(&storage.RefreshToken{
 					UserID: testUserID, ExpiresAt: time.Now().Add(time.Hour),
 				}, nil)
-				mockKM.EXPECT().GetCurrentSigningKey().Return(nil, "", errors.New("key unavailable"))
+				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(nil, "", errors.New("key unavailable"))
 				_, err := service.RefreshAccessToken(ctx, validRefreshToken)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("key unavailable"))
@@ -1365,7 +1365,7 @@ var _ = Describe("TokenService", func() {
 
 		It("should handle concurrent token issuance", func() {
 			// Allow many concurrent calls
-			mockKM.EXPECT().GetCurrentSigningKey().Return(testKey, testKeyID, nil).Times(10)
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil).Times(10)
 
 			done := make(chan bool, 10)
 
@@ -1386,12 +1386,12 @@ var _ = Describe("TokenService", func() {
 
 		It("should handle concurrent validation", func() {
 			// Issue token first (service is running from BeforeEach)
-			mockKM.EXPECT().GetCurrentSigningKey().Return(testKey, testKeyID, nil)
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
 			token, err := service.IssueAccessToken(ctx, testUserID)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Allow many concurrent validations
-			mockKM.EXPECT().GetPublicKey(gomock.Any()).Return(&testKey.PublicKey, nil).Times(10)
+			mockKM.EXPECT().GetPublicKey(gomock.Any(), gomock.Any()).Return(&testKey.PublicKey, nil).Times(10)
 
 			done := make(chan bool, 10)
 


### PR DESCRIPTION
## Summary

- Add `context.Context` to `GetCurrentSigningKey` and `GetPublicKey` in the `KeyManager` interface — required for OTEL trace propagation
- Pass `ctx` through to `KeyStore.LoadKey` on cache-miss, replacing the silent `context.Background()` at the store boundary
- Add `ctx.Err()` checks in both methods with a new `"cancelled"` metric status
- Add `error_type` label to all KeyManager and KeyStore counters (`key_signing_operations_total`, `key_validation_operations_total`, `key_rotations_total`, `keystore_operations_total`), consistent with the pattern established in TokenService
- Update Prometheus registration, mock, all call sites in `tokens/service.go`, and all test files
- 4 new context-cancellation test cases added to Phases 4, 5, and 9

## Test plan

- [x] `ginkgo --race pkg/keymanager` — 129/129
- [x] `ginkgo --race pkg/tokens` — 144/144
- [x] `ginkgo --race pkg/metrics` — 66/66
- [x] `go build ./...` — clean