### PR TITLE
Storage error_type label + pre-OTEL audit items 4–6

### DIFF
--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -114,7 +114,7 @@ func (pm *PrometheusMetrics) registerAllMetrics(namespace string) {
 
 	pm.registerCounter(namespace, "storage_operations_total",
 		"Total number of storage operations",
-		[]string{"operation", "status", "storage_backend"})
+		[]string{"operation", "status", "error_type", "storage_backend"})
 
 	pm.registerCounter(namespace, "storage_cleanup_tokens_removed_total",
 		"Total number of tokens removed during cleanup",

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -698,6 +698,7 @@ var _ = Describe("Prometheus", func() {
 				pm.IncrementCounter("jwtauth_storage_operations_total", map[string]string{
 					"operation":       "store",
 					"status":          "success",
+					"error_type":      "",
 					"storage_backend": "redis",
 				})
 				pm.RecordDuration("jwtauth_storage_operation_duration_seconds", 2*time.Millisecond, map[string]string{
@@ -709,6 +710,7 @@ var _ = Describe("Prometheus", func() {
 				pm.IncrementCounter("jwtauth_storage_operations_total", map[string]string{
 					"operation":       "retrieve",
 					"status":          "success",
+					"error_type":      "",
 					"storage_backend": "redis",
 				})
 				pm.RecordDuration("jwtauth_storage_operation_duration_seconds", 1*time.Millisecond, map[string]string{
@@ -726,8 +728,8 @@ var _ = Describe("Prometheus", func() {
 					"storage_backend": "redis",
 				})
 
-				Expect(counterValue(registry, "jwtauth_storage_operations_total", map[string]string{"operation": "store", "status": "success", "storage_backend": "redis"})).To(Equal(1.0))
-				Expect(counterValue(registry, "jwtauth_storage_operations_total", map[string]string{"operation": "retrieve", "status": "success", "storage_backend": "redis"})).To(Equal(1.0))
+				Expect(counterValue(registry, "jwtauth_storage_operations_total", map[string]string{"operation": "store", "status": "success", "error_type": "", "storage_backend": "redis"})).To(Equal(1.0))
+				Expect(counterValue(registry, "jwtauth_storage_operations_total", map[string]string{"operation": "retrieve", "status": "success", "error_type": "", "storage_backend": "redis"})).To(Equal(1.0))
 				Expect(counterValue(registry, "jwtauth_storage_cleanup_tokens_removed_total", map[string]string{"storage_backend": "redis"})).To(Equal(25.0))
 				Expect(histogramSampleCount(registry, "jwtauth_storage_operation_duration_seconds", map[string]string{"operation": "store", "storage_backend": "redis"})).To(Equal(uint64(1)))
 				Expect(histogramSampleCount(registry, "jwtauth_storage_operation_duration_seconds", map[string]string{"operation": "retrieve", "storage_backend": "redis"})).To(Equal(uint64(1)))

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -58,12 +58,14 @@ func NewMemoryRefreshStore(logger logging.Logger, m metrics.Metrics) *MemoryRefr
 func (m *MemoryRefreshStore) Store(ctx context.Context, tokenID, userID string, expiresAt time.Time, metadata map[string]interface{}) error {
 	start := time.Now()
 	status := "error"
+	errorType := "error"
 	tokenCount := 0
 	defer func() {
 		if m.metrics != nil {
 			m.metrics.IncrementCounter(metricStorageOpsTotal, map[string]string{
 				"operation":       "store",
 				"status":          status,
+				"error_type":      errorType,
 				"storage_backend": m.backend,
 			})
 			m.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), map[string]string{
@@ -81,6 +83,7 @@ func (m *MemoryRefreshStore) Store(ctx context.Context, tokenID, userID string, 
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
+		errorType = "cancelled"
 		if m.logger != nil {
 			m.logger.Warn("store aborted: context cancelled",
 				"reason", err)
@@ -91,6 +94,7 @@ func (m *MemoryRefreshStore) Store(ctx context.Context, tokenID, userID string, 
 	// ===== STEP 2: Validate Inputs =====
 	if len(strings.TrimSpace(tokenID)) == 0 {
 		status = "validation_error"
+		errorType = "validation_error"
 		if m.logger != nil {
 			m.logger.Warn("store rejected: tokenID is empty or whitespace",
 				"userID", userID)
@@ -100,6 +104,7 @@ func (m *MemoryRefreshStore) Store(ctx context.Context, tokenID, userID string, 
 
 	if len(strings.TrimSpace(userID)) == 0 {
 		status = "validation_error"
+		errorType = "validation_error"
 		if m.logger != nil {
 			m.logger.Warn("store rejected: userID is empty or whitespace",
 				"tokenID", tokenID)
@@ -109,6 +114,7 @@ func (m *MemoryRefreshStore) Store(ctx context.Context, tokenID, userID string, 
 
 	if expiresAt.Before(time.Now()) {
 		status = "validation_error"
+		errorType = "validation_error"
 		if m.logger != nil {
 			m.logger.Warn("store rejected: token is already expired",
 				"tokenID", tokenID,
@@ -152,6 +158,7 @@ func (m *MemoryRefreshStore) Store(ctx context.Context, tokenID, userID string, 
 
 	// ===== STEP 6: Log Success =====
 	status = "success"
+	errorType = ""
 	if m.logger != nil {
 		m.logger.Info("refresh token stored",
 			"tokenID", tokenID,
@@ -171,11 +178,13 @@ func (m *MemoryRefreshStore) Store(ctx context.Context, tokenID, userID string, 
 func (m *MemoryRefreshStore) Retrieve(ctx context.Context, tokenID string) (*RefreshToken, error) {
 	start := time.Now()
 	status := "error"
+	errorType := "error"
 	defer func() {
 		if m.metrics != nil {
 			m.metrics.IncrementCounter(metricStorageOpsTotal, map[string]string{
 				"operation":       "retrieve",
 				"status":          status,
+				"error_type":      errorType,
 				"storage_backend": m.backend,
 			})
 			m.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), map[string]string{
@@ -188,6 +197,7 @@ func (m *MemoryRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Ref
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
+		errorType = "cancelled"
 		if m.logger != nil {
 			m.logger.Warn("retrieve aborted: context cancelled",
 				"tokenID", tokenID,
@@ -199,6 +209,7 @@ func (m *MemoryRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Ref
 	// ===== STEP 2: Validate Inputs =====
 	if len(strings.TrimSpace(tokenID)) == 0 {
 		status = "validation_error"
+		errorType = "validation_error"
 		if m.logger != nil {
 			m.logger.Warn("retrieve rejected: tokenID is empty or whitespace")
 		}
@@ -218,6 +229,7 @@ func (m *MemoryRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Ref
 	token, found := m.tokens[tokenID]
 	if !found {
 		status = "not_found"
+		errorType = "not_found"
 		if m.logger != nil {
 			m.logger.Warn("retrieve: token not found",
 				"tokenID", tokenID)
@@ -228,6 +240,7 @@ func (m *MemoryRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Ref
 	// ===== STEP 5: Check Revocation =====
 	if token.Revoked {
 		status = "revoked"
+		errorType = "revoked"
 		if m.logger != nil {
 			m.logger.Warn("retrieve: token has been revoked",
 				"tokenID", tokenID,
@@ -239,6 +252,7 @@ func (m *MemoryRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Ref
 	// ===== STEP 6: Check Expiration =====
 	if token.ExpiresAt.Before(time.Now()) {
 		status = "expired"
+		errorType = "expired"
 		if m.logger != nil {
 			m.logger.Warn("retrieve: token has expired",
 				"tokenID", tokenID,
@@ -265,6 +279,7 @@ func (m *MemoryRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Ref
 
 	// ===== STEP 8: Log Success =====
 	status = "success"
+	errorType = ""
 	if m.logger != nil {
 		m.logger.Info("retrieve: token retrieved successfully",
 			"tokenID", tokenID)
@@ -279,11 +294,13 @@ func (m *MemoryRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Ref
 func (m *MemoryRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 	start := time.Now()
 	status := "error"
+	errorType := "error"
 	defer func() {
 		if m.metrics != nil {
 			m.metrics.IncrementCounter(metricStorageOpsTotal, map[string]string{
 				"operation":       "revoke",
 				"status":          status,
+				"error_type":      errorType,
 				"storage_backend": m.backend,
 			})
 			m.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), map[string]string{
@@ -296,6 +313,7 @@ func (m *MemoryRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
+		errorType = "cancelled"
 		if m.logger != nil {
 			m.logger.Warn("revoke aborted: context cancelled",
 				"tokenID", tokenID)
@@ -306,6 +324,7 @@ func (m *MemoryRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 	// ===== STEP 2: Validate Inputs =====
 	if len(strings.TrimSpace(tokenID)) == 0 {
 		status = "validation_error"
+		errorType = "validation_error"
 		if m.logger != nil {
 			m.logger.Warn("revoke rejected: tokenID is empty or whitespace")
 		}
@@ -320,6 +339,7 @@ func (m *MemoryRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 	token, found := m.tokens[tokenID]
 	if !found {
 		status = "success" // idempotent: not-found is not an error
+		errorType = ""
 		if m.logger != nil {
 			m.logger.Warn("revoke: token not found",
 				"tokenID", tokenID)
@@ -332,6 +352,7 @@ func (m *MemoryRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 
 	// ===== STEP 6: Log Success =====
 	status = "success"
+	errorType = ""
 	if m.logger != nil {
 		m.logger.Info("revoke: successfully revoked",
 			"tokenID", tokenID)
@@ -347,11 +368,13 @@ func (m *MemoryRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 func (m *MemoryRefreshStore) RevokeAllForUser(ctx context.Context, userID string) error {
 	start := time.Now()
 	status := "error"
+	errorType := "error"
 	defer func() {
 		if m.metrics != nil {
 			m.metrics.IncrementCounter(metricStorageOpsTotal, map[string]string{
 				"operation":       "revoke_all",
 				"status":          status,
+				"error_type":      errorType,
 				"storage_backend": m.backend,
 			})
 			m.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), map[string]string{
@@ -364,6 +387,7 @@ func (m *MemoryRefreshStore) RevokeAllForUser(ctx context.Context, userID string
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
+		errorType = "cancelled"
 		if m.logger != nil {
 			m.logger.Warn("revokeAllForUser aborted: context cancelled",
 				"userID", userID,
@@ -375,6 +399,7 @@ func (m *MemoryRefreshStore) RevokeAllForUser(ctx context.Context, userID string
 	// ===== STEP 2: Validate Inputs =====
 	if len(strings.TrimSpace(userID)) == 0 {
 		status = "validation_error"
+		errorType = "validation_error"
 		if m.logger != nil {
 			m.logger.Warn("revokeAllForUser rejected: userID is empty or whitespace")
 		}
@@ -400,6 +425,7 @@ func (m *MemoryRefreshStore) RevokeAllForUser(ctx context.Context, userID string
 
 	// ===== STEP 5: Log Success =====
 	status = "success"
+	errorType = ""
 	if m.logger != nil {
 		m.logger.Info("revokeAllForUser: all tokens revoked",
 			"userID", userID,
@@ -416,6 +442,7 @@ func (m *MemoryRefreshStore) RevokeAllForUser(ctx context.Context, userID string
 func (m *MemoryRefreshStore) Cleanup(ctx context.Context) (int, error) {
 	start := time.Now()
 	status := "error"
+	errorType := "error"
 	removed := 0
 	remaining := 0
 	defer func() {
@@ -423,6 +450,7 @@ func (m *MemoryRefreshStore) Cleanup(ctx context.Context) (int, error) {
 			m.metrics.IncrementCounter(metricStorageOpsTotal, map[string]string{
 				"operation":       "cleanup",
 				"status":          status,
+				"error_type":      errorType,
 				"storage_backend": m.backend,
 			})
 			m.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), map[string]string{
@@ -443,6 +471,7 @@ func (m *MemoryRefreshStore) Cleanup(ctx context.Context) (int, error) {
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
+		errorType = "cancelled"
 		if m.logger != nil {
 			m.logger.Warn("cleanup aborted: context cancelled")
 		}
@@ -473,6 +502,7 @@ func (m *MemoryRefreshStore) Cleanup(ctx context.Context) (int, error) {
 
 	// ===== STEP 4: Log Success =====
 	status = "success"
+	errorType = ""
 	if m.logger != nil {
 		m.logger.Info("cleanup: successful",
 			"count", count)

--- a/pkg/storage/redis.go
+++ b/pkg/storage/redis.go
@@ -59,11 +59,13 @@ func NewRedisRefreshStore(client *redis.Client, logger logging.Logger, m metrics
 func (r *RedisRefreshStore) Store(ctx context.Context, tokenID, userID string, expiresAt time.Time, metadata map[string]interface{}) error {
 	start := time.Now()
 	status := "error"
+	errorType := "error"
 	defer func() {
 		if r.metrics != nil {
 			r.metrics.IncrementCounter(metricStorageOpsTotal, map[string]string{
 				"operation":       "store",
 				"status":          status,
+				"error_type":      errorType,
 				"storage_backend": r.backend,
 			})
 			r.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), map[string]string{
@@ -76,6 +78,7 @@ func (r *RedisRefreshStore) Store(ctx context.Context, tokenID, userID string, e
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
+		errorType = "cancelled"
 		if r.logger != nil {
 			r.logger.Warn("store aborted: context cancelled",
 				"reason", err)
@@ -86,6 +89,7 @@ func (r *RedisRefreshStore) Store(ctx context.Context, tokenID, userID string, e
 	// ===== STEP 2: Validate Inputs =====
 	if len(strings.TrimSpace(tokenID)) == 0 {
 		status = "validation_error"
+		errorType = "validation_error"
 		if r.logger != nil {
 			r.logger.Warn("store rejected: tokenID is empty or whitespace",
 				"userID", userID)
@@ -95,6 +99,7 @@ func (r *RedisRefreshStore) Store(ctx context.Context, tokenID, userID string, e
 
 	if len(strings.TrimSpace(userID)) == 0 {
 		status = "validation_error"
+		errorType = "validation_error"
 		if r.logger != nil {
 			r.logger.Warn("store rejected: userID is empty or whitespace",
 				"tokenID", tokenID)
@@ -104,6 +109,7 @@ func (r *RedisRefreshStore) Store(ctx context.Context, tokenID, userID string, e
 
 	if expiresAt.Before(time.Now()) || expiresAt.Equal(time.Now()) {
 		status = "validation_error"
+		errorType = "validation_error"
 		if r.logger != nil {
 			r.logger.Warn("store rejected: token is already expired",
 				"tokenID", tokenID,
@@ -173,6 +179,7 @@ func (r *RedisRefreshStore) Store(ctx context.Context, tokenID, userID string, e
 
 	// ===== STEP 6: Log Success =====
 	status = "success"
+	errorType = ""
 	if r.logger != nil {
 		r.logger.Info("refresh token stored",
 			"tokenID", tokenID,
@@ -193,11 +200,13 @@ func (r *RedisRefreshStore) Store(ctx context.Context, tokenID, userID string, e
 func (r *RedisRefreshStore) Retrieve(ctx context.Context, tokenID string) (*RefreshToken, error) {
 	start := time.Now()
 	status := "error"
+	errorType := "error"
 	defer func() {
 		if r.metrics != nil {
 			r.metrics.IncrementCounter(metricStorageOpsTotal, map[string]string{
 				"operation":       "retrieve",
 				"status":          status,
+				"error_type":      errorType,
 				"storage_backend": r.backend,
 			})
 			r.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), map[string]string{
@@ -210,6 +219,7 @@ func (r *RedisRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Refr
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
+		errorType = "cancelled"
 		if r.logger != nil {
 			r.logger.Warn("retrieve aborted: context cancelled",
 				"tokenID", tokenID,
@@ -221,6 +231,7 @@ func (r *RedisRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Refr
 	// ===== STEP 2: Validate Inputs =====
 	if len(strings.TrimSpace(tokenID)) == 0 {
 		status = "validation_error"
+		errorType = "validation_error"
 		if r.logger != nil {
 			r.logger.Warn("retrieve rejected: tokenID is empty or whitespace")
 		}
@@ -248,6 +259,7 @@ func (r *RedisRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Refr
 	// ===== STEP 4: Check if Token Exists =====
 	if len(hash) == 0 {
 		status = "not_found"
+		errorType = "not_found"
 		if r.logger != nil {
 			r.logger.Warn("retrieve: token not found",
 				"tokenID", tokenID)
@@ -259,6 +271,7 @@ func (r *RedisRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Refr
 	revoked := hash["revoked"] == "true"
 	if revoked {
 		status = "revoked"
+		errorType = "revoked"
 		if r.logger != nil {
 			r.logger.Warn("retrieve: token has been revoked",
 				"tokenID", tokenID,
@@ -281,6 +294,7 @@ func (r *RedisRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Refr
 	expiresAt := time.UnixMilli(expiresAtMillis)
 	if expiresAt.Before(time.Now()) {
 		status = "expired"
+		errorType = "expired"
 		if r.logger != nil {
 			r.logger.Warn("retrieve: token has expired",
 				"tokenID", tokenID,
@@ -327,6 +341,7 @@ func (r *RedisRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Refr
 
 	// ===== STEP 8: Log Success =====
 	status = "success"
+	errorType = ""
 	if r.logger != nil {
 		r.logger.Info("retrieve: token retrieved successfully",
 			"tokenID", tokenID)
@@ -341,11 +356,13 @@ func (r *RedisRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Refr
 func (r *RedisRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 	start := time.Now()
 	status := "error"
+	errorType := "error"
 	defer func() {
 		if r.metrics != nil {
 			r.metrics.IncrementCounter(metricStorageOpsTotal, map[string]string{
 				"operation":       "revoke",
 				"status":          status,
+				"error_type":      errorType,
 				"storage_backend": r.backend,
 			})
 			r.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), map[string]string{
@@ -358,6 +375,7 @@ func (r *RedisRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
+		errorType = "cancelled"
 		if r.logger != nil {
 			r.logger.Warn("revoke aborted: context cancelled",
 				"tokenID", tokenID)
@@ -368,6 +386,7 @@ func (r *RedisRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 	// ===== STEP 2: Validate Inputs =====
 	if len(strings.TrimSpace(tokenID)) == 0 {
 		status = "validation_error"
+		errorType = "validation_error"
 		if r.logger != nil {
 			r.logger.Warn("revoke rejected: tokenID is empty or whitespace")
 		}
@@ -391,6 +410,7 @@ func (r *RedisRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 	if exists == 0 {
 		// Expected to be idempotent; thus, return nil
 		status = "success" // idempotent: not-found is not an error
+		errorType = ""
 		if r.logger != nil {
 			r.logger.Warn("revoke: token not found",
 				"tokenID", tokenID)
@@ -411,6 +431,7 @@ func (r *RedisRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 
 	// ===== STEP 5: Log Success =====
 	status = "success"
+	errorType = ""
 	if r.logger != nil {
 		r.logger.Info("revoke: successfully revoked",
 			"tokenID", tokenID)
@@ -426,11 +447,13 @@ func (r *RedisRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 func (r *RedisRefreshStore) RevokeAllForUser(ctx context.Context, userID string) error {
 	start := time.Now()
 	status := "error"
+	errorType := "error"
 	defer func() {
 		if r.metrics != nil {
 			r.metrics.IncrementCounter(metricStorageOpsTotal, map[string]string{
 				"operation":       "revoke_all",
 				"status":          status,
+				"error_type":      errorType,
 				"storage_backend": r.backend,
 			})
 			r.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), map[string]string{
@@ -443,6 +466,7 @@ func (r *RedisRefreshStore) RevokeAllForUser(ctx context.Context, userID string)
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
+		errorType = "cancelled"
 		if r.logger != nil {
 			r.logger.Warn("revokeAllForUser aborted: context cancelled",
 				"userID", userID,
@@ -454,6 +478,7 @@ func (r *RedisRefreshStore) RevokeAllForUser(ctx context.Context, userID string)
 	// ===== STEP 2: Validate Inputs =====
 	if len(strings.TrimSpace(userID)) == 0 {
 		status = "validation_error"
+		errorType = "validation_error"
 		if r.logger != nil {
 			r.logger.Warn("revokeAllForUser rejected: userID is empty or whitespace")
 		}
@@ -500,6 +525,7 @@ func (r *RedisRefreshStore) RevokeAllForUser(ctx context.Context, userID string)
 
 	// ===== STEP 5: Log Success =====
 	status = "success"
+	errorType = ""
 	if r.logger != nil {
 		r.logger.Info("revokeAllForUser: all tokens revoked",
 			"userID", userID,
@@ -516,6 +542,7 @@ func (r *RedisRefreshStore) RevokeAllForUser(ctx context.Context, userID string)
 func (r *RedisRefreshStore) Cleanup(ctx context.Context) (int, error) {
 	start := time.Now()
 	status := "error"
+	errorType := "error"
 	removed := 0
 	remaining := 0
 	defer func() {
@@ -523,6 +550,7 @@ func (r *RedisRefreshStore) Cleanup(ctx context.Context) (int, error) {
 			r.metrics.IncrementCounter(metricStorageOpsTotal, map[string]string{
 				"operation":       "cleanup",
 				"status":          status,
+				"error_type":      errorType,
 				"storage_backend": r.backend,
 			})
 			r.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), map[string]string{
@@ -543,6 +571,7 @@ func (r *RedisRefreshStore) Cleanup(ctx context.Context) (int, error) {
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
+		errorType = "cancelled"
 		if r.logger != nil {
 			r.logger.Warn("cleanup aborted: context cancelled")
 		}
@@ -626,6 +655,7 @@ func (r *RedisRefreshStore) Cleanup(ctx context.Context) (int, error) {
 
 	// ===== STEP 4: Log Success =====
 	status = "success"
+	errorType = ""
 	if r.logger != nil {
 		r.logger.Info("cleanup: successful",
 			"count", count)

--- a/pkg/storage/suite_test.go
+++ b/pkg/storage/suite_test.go
@@ -621,7 +621,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 			It("should record counter and duration on Store success", func() {
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "store", "status": "success", "storage_backend": backend})
+					map[string]string{"operation": "store", "status": "success", "error_type": "", "storage_backend": backend})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
 					map[string]string{"operation": "store", "storage_backend": backend})
@@ -637,7 +637,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 			It("should record validation_error status on Store with empty tokenID", func() {
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "store", "status": "validation_error", "storage_backend": backend})
+					map[string]string{"operation": "store", "status": "validation_error", "error_type": "validation_error", "storage_backend": backend})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
 					map[string]string{"operation": "store", "storage_backend": backend})
@@ -649,7 +649,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 			It("should record counter and duration on Retrieve success", func() {
 				// Setup: Store the token (expect those metrics too)
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "store", "status": "success", "storage_backend": backend})
+					map[string]string{"operation": "store", "status": "success", "error_type": "", "storage_backend": backend})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
 					map[string]string{"operation": "store", "storage_backend": backend})
@@ -660,7 +660,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 				// Retrieve expectations
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "retrieve", "status": "success", "storage_backend": backend})
+					map[string]string{"operation": "retrieve", "status": "success", "error_type": "", "storage_backend": backend})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
 					map[string]string{"operation": "retrieve", "storage_backend": backend})
@@ -672,7 +672,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 			It("should record not_found status on Retrieve for nonexistent token", func() {
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "retrieve", "status": "not_found", "storage_backend": backend})
+					map[string]string{"operation": "retrieve", "status": "not_found", "error_type": "not_found", "storage_backend": backend})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
 					map[string]string{"operation": "retrieve", "storage_backend": backend})
@@ -684,7 +684,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 			It("should record revoked status on Retrieve for revoked token", func() {
 				// Store
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "store", "status": "success", "storage_backend": backend})
+					map[string]string{"operation": "store", "status": "success", "error_type": "", "storage_backend": backend})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
 					map[string]string{"operation": "store", "storage_backend": backend})
@@ -695,7 +695,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 				// Revoke
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "revoke", "status": "success", "storage_backend": backend})
+					map[string]string{"operation": "revoke", "status": "success", "error_type": "", "storage_backend": backend})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
 					map[string]string{"operation": "revoke", "storage_backend": backend})
@@ -703,7 +703,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 				// Retrieve
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "retrieve", "status": "revoked", "storage_backend": backend})
+					map[string]string{"operation": "retrieve", "status": "revoked", "error_type": "revoked", "storage_backend": backend})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
 					map[string]string{"operation": "retrieve", "storage_backend": backend})
@@ -715,7 +715,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 			It("should record counter and duration on Revoke success", func() {
 				// Store
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "store", "status": "success", "storage_backend": backend})
+					map[string]string{"operation": "store", "status": "success", "error_type": "", "storage_backend": backend})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
 					map[string]string{"operation": "store", "storage_backend": backend})
@@ -726,7 +726,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 				// Revoke
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "revoke", "status": "success", "storage_backend": backend})
+					map[string]string{"operation": "revoke", "status": "success", "error_type": "", "storage_backend": backend})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
 					map[string]string{"operation": "revoke", "storage_backend": backend})
@@ -737,7 +737,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 			It("should record counter and duration on RevokeAllForUser success", func() {
 				// Store
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "store", "status": "success", "storage_backend": backend})
+					map[string]string{"operation": "store", "status": "success", "error_type": "", "storage_backend": backend})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
 					map[string]string{"operation": "store", "storage_backend": backend})
@@ -748,7 +748,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 				// RevokeAllForUser
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "revoke_all", "status": "success", "storage_backend": backend})
+					map[string]string{"operation": "revoke_all", "status": "success", "error_type": "", "storage_backend": backend})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
 					map[string]string{"operation": "revoke_all", "storage_backend": backend})
@@ -761,7 +761,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 				// Store short-lived token
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "store", "status": "success", "storage_backend": backend})
+					map[string]string{"operation": "store", "status": "success", "error_type": "", "storage_backend": backend})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
 					map[string]string{"operation": "store", "storage_backend": backend})
@@ -778,7 +778,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 				// Cleanup expectations
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "cleanup", "status": "success", "storage_backend": backend})
+					map[string]string{"operation": "cleanup", "status": "success", "error_type": "", "storage_backend": backend})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
 					map[string]string{"operation": "cleanup", "storage_backend": backend})
@@ -796,7 +796,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 			It("should record zero removed count and gauge on Cleanup with no tokens", func() {
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "cleanup", "status": "success", "storage_backend": backend})
+					map[string]string{"operation": "cleanup", "status": "success", "error_type": "", "storage_backend": backend})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
 					map[string]string{"operation": "cleanup", "storage_backend": backend})

--- a/pkg/tokens/service.go
+++ b/pkg/tokens/service.go
@@ -71,7 +71,6 @@ var (
 	ErrInvalidUserID       = errors.New("invalid user ID")
 	ErrServiceNotRunning   = errors.New("service is not running")
 	ErrInvalidToken        = errors.New("invalid token")
-	ErrInvalidSignature    = errors.New("invalid signature")
 	ErrInvalidRefreshToken = errors.New("invalid refresh token")
 	ErrRefreshTokenExpired = errors.New("token has expired")
 	ErrTokenRevoked        = errors.New("token revoked")
@@ -321,16 +320,7 @@ func (s *Service) IssueAccessToken(ctx context.Context, userID string) (string, 
 		}
 	}()
 
-	// ===== STEP 1: Validate user id ====
-	// validate user ID Split into two to optimize in the event of high volume of invalid requests
-	if len(userID) == 0 {
-		status = "invalid_input"
-		errorType = "invalid_input"
-		if s.logger != nil {
-			s.logger.Warn("attempted to get token with empty userID")
-		}
-		return "", ErrInvalidUserID
-	}
+	// ===== STEP 1: Validate User ID =====
 	if len(strings.TrimSpace(userID)) == 0 {
 		status = "invalid_input"
 		errorType = "invalid_input"
@@ -340,7 +330,7 @@ func (s *Service) IssueAccessToken(ctx context.Context, userID string) (string, 
 		return "", ErrInvalidUserID
 	}
 
-	//===== STEP 2: Service State Check =====
+	// ===== STEP 2: Service State Check =====
 	if !s.IsRunning() {
 		status = "not_running"
 		errorType = "not_running"
@@ -381,12 +371,6 @@ func (s *Service) IssueAccessToken(ctx context.Context, userID string) (string, 
 			"keyID", keyID)
 	}
 
-	if s.logger != nil {
-		s.logger.Debug("signing key retrieved",
-			"userID", userID,
-			"keyID", keyID)
-	}
-
 	// ===== STEP 5: Create JWT Claims =====
 	now := time.Now()
 	expiresAt := now.Add(s.accessTokenDuration)
@@ -413,13 +397,6 @@ func (s *Service) IssueAccessToken(ctx context.Context, userID string) (string, 
 	}
 	if s.logger != nil {
 		s.logger.Debug("access token claims created",
-			"userID", userID,
-			"tokenID", tokenID,
-			"expiresAt", expiresAt)
-	}
-
-	if s.logger != nil {
-		s.logger.Debug("claims constructed",
 			"userID", userID,
 			"tokenID", tokenID,
 			"expiresAt", expiresAt)
@@ -488,14 +465,6 @@ func (s *Service) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 	}()
 
 	// ===== STEP 1: Validate User ID =====
-	if len(userID) == 0 {
-		status = "invalid_input"
-		errorType = "invalid_input"
-		if s.logger != nil {
-			s.logger.Warn("attempted to get token with empty userID")
-		}
-		return "", ErrInvalidUserID
-	}
 	if len(strings.TrimSpace(userID)) == 0 {
 		status = "invalid_input"
 		errorType = "invalid_input"
@@ -649,16 +618,7 @@ func (s *Service) IssueRefreshToken(ctx context.Context, userID string) (string,
 		}
 	}()
 
-	// ===== STEP 1: Validate user id ====
-	// validate user ID Split into two to optimize in the event of high volume of invalid requests
-	if len(userID) == 0 {
-		status = "invalid_input"
-		errorType = "invalid_input"
-		if s.logger != nil {
-			s.logger.Warn("attempted to get token with empty userID")
-		}
-		return "", ErrInvalidUserID
-	}
+	// ===== STEP 1: Validate User ID =====
 	if len(strings.TrimSpace(userID)) == 0 {
 		status = "invalid_input"
 		errorType = "invalid_input"
@@ -668,7 +628,7 @@ func (s *Service) IssueRefreshToken(ctx context.Context, userID string) (string,
 		return "", ErrInvalidUserID
 	}
 
-	//===== STEP 2: Service State Check =====
+	// ===== STEP 2: Service State Check =====
 
 	if !s.IsRunning() {
 		status = "not_running"
@@ -780,16 +740,7 @@ func (s *Service) IssueRefreshTokenWithMetadata(ctx context.Context, userID stri
 		}
 	}()
 
-	// ===== STEP 1: Validate user id ====
-	// validate user ID Split into two to optimize in the event of high volume of invalid requests
-	if len(userID) == 0 {
-		status = "invalid_input"
-		errorType = "invalid_input"
-		if s.logger != nil {
-			s.logger.Warn("attempted to get token with empty userID")
-		}
-		return "", ErrInvalidUserID
-	}
+	// ===== STEP 1: Validate User ID =====
 	if len(strings.TrimSpace(userID)) == 0 {
 		status = "invalid_input"
 		errorType = "invalid_input"
@@ -799,7 +750,7 @@ func (s *Service) IssueRefreshTokenWithMetadata(ctx context.Context, userID stri
 		return "", ErrInvalidUserID
 	}
 
-	//===== STEP 2: Service State Check =====
+	// ===== STEP 2: Service State Check =====
 	if !s.IsRunning() {
 		status = "not_running"
 		errorType = "not_running"
@@ -912,16 +863,7 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 		}
 	}()
 
-	// ===== STEP 1: Validate user id ====
-	// validate user ID Split into two to optimize in the event of high volume of invalid requests
-	if len(userID) == 0 {
-		status = "invalid_input"
-		errorType = "invalid_input"
-		if s.logger != nil {
-			s.logger.Warn("attempted to get token with empty userID")
-		}
-		return "", "", ErrInvalidUserID
-	}
+	// ===== STEP 1: Validate User ID =====
 	if len(strings.TrimSpace(userID)) == 0 {
 		status = "invalid_input"
 		errorType = "invalid_input"
@@ -931,7 +873,7 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 		return "", "", ErrInvalidUserID
 	}
 
-	//===== STEP 2: Service State Check =====
+	// ===== STEP 2: Service State Check =====
 	if !s.IsRunning() {
 		status = "not_running"
 		errorType = "not_running"
@@ -1070,9 +1012,10 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 // It verifies the RS256 signature using the public key identified by the token's
 // "kid" header, then checks expiration, issuer, and audience claims.
 //
-// Returns the parsed RegisteredClaims on success, or one of: ErrServiceNotRunning,
-// ErrTokenExpired, ErrTokenNotYetValid, ErrInvalidSignature, ErrInvalidIssuer,
-// ErrInvalidAudience, ErrInvalidToken, or the context error.
+/// Returns the parsed RegisteredClaims on success, or one of: ErrServiceNotRunning,
+// ErrTokenExpired, ErrTokenNotYetValid, ErrInvalidIssuer, ErrInvalidAudience,
+// ErrInvalidToken (covers malformed tokens, wrong signing method, and unknown key IDs),
+// or the context error.
 func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (*jwt.RegisteredClaims, error) {
 	start := time.Now()
 	status := "error"
@@ -1183,8 +1126,11 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 		}
 		if errors.Is(err, keymanager.ErrKeyNotFound) {
 			status = "error"
-			errorType = "invalid_signature"
-			return nil, ErrInvalidSignature
+			errorType = "key_not_found"
+			if s.logger != nil {
+				s.logger.Warn("token references unknown key ID")
+			}
+			return nil, ErrInvalidToken
 		}
 
 		return nil, ErrInvalidToken

--- a/pkg/tokens/service_test.go
+++ b/pkg/tokens/service_test.go
@@ -758,15 +758,14 @@ var _ = Describe("TokenService", func() {
 		})
 
 		Context("with key not found", func() {
-			It("should return error", func() {
+			It("should return ErrInvalidToken", func() {
 				mockKM.EXPECT().
 					GetPublicKey(gomock.Any(), gomock.Any()).
 					Return(nil, keymanager.ErrKeyNotFound)
 
 				_, err := service.ValidateAccessToken(ctx, validToken)
 
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(Equal(tokens.ErrInvalidSignature))
+				Expect(err).To(Equal(tokens.ErrInvalidToken))
 			})
 		})
 


### PR DESCRIPTION
## Summary

- Add `error_type` label to `storage_operations_total` counter — mirrors the same label on KeyManager, aligns with OTEL `error.type` convention (`""` on success, mirrors `status` on failure). Updates Prometheus schema, both storage backends, and all Phase 10 test assertions.
- Remove duplicate debug log calls in `IssueAccessToken` (audit item 4)
- Collapse redundant two-check UserID validation to single `strings.TrimSpace` check across 5 issue methods (audit item 5)
- Remap `ErrKeyNotFound` → `ErrInvalidToken` in `ValidateAccessToken`; add warn log; remove dead `ErrInvalidSignature` sentinel (audit item 6)

## Test plan

- [x] 537 tests passing with `-race` detection
- [x] `./run-ci-locally.sh` green (lint + all packages)