### PR TITLE
Add ClockSkew leeway support to ValidateAccessToken

### DIFF
--- a/pkg/tokens/service.go
+++ b/pkg/tokens/service.go
@@ -36,6 +36,9 @@ type ServiceConfig struct {
 	RefreshTokenDuration time.Duration // Default: 30 days
 	CleanupInterval      time.Duration // How often expired tokens are purged; default: 1 hour
 
+	// Clock skew tolerance
+	ClockSkew time.Duration // Leeway for exp/nbf validation; zero means strict. Default: 0
+
 	// JWT claims
 	Issuer   string   // Value for the "iss" claim
 	Audience []string // Values for the "aud" claim
@@ -59,6 +62,7 @@ type Service struct {
 	cleanupInterval      time.Duration // e.g., 1 hour
 	issuer               string        // JWT "iss" claim
 	audience             []string      // JWT "aud" claim
+	clockSkew            time.Duration // Leeway applied to exp and nbf validation
 
 	// ===== State Management =====
 	isRunning    atomic.Bool    // Thread-safe running state
@@ -134,6 +138,10 @@ func NewService(config ServiceConfig) (*Service, error) {
 		return nil, ErrInvalidConfig("CleanupInterval must be non-negative")
 	}
 
+	if config.ClockSkew < 0 {
+		return nil, ErrInvalidConfig("ClockSkew must be non-negative")
+	}
+
 	s := &Service{
 		keyManager:           config.KeyManager,
 		refreshStore:         config.RefreshStore,
@@ -142,6 +150,7 @@ func NewService(config ServiceConfig) (*Service, error) {
 		accessTokenDuration:  config.AccessTokenDuration,
 		refreshTokenDuration: config.RefreshTokenDuration,
 		cleanupInterval:      config.CleanupInterval,
+		clockSkew:            config.ClockSkew,
 		issuer:               config.Issuer,
 		audience:             config.Audience,
 		shutdownChan:         make(chan struct{}),
@@ -1058,6 +1067,11 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 	}
 
 	// ===== STEP 3: Parse JWT Token =====
+	parseOpts := []jwt.ParserOption{}
+	if s.clockSkew > 0 {
+		parseOpts = append(parseOpts, jwt.WithLeeway(s.clockSkew))
+	}
+
 	token, err := jwt.ParseWithClaims(
 		tokenString,
 		&jwt.RegisteredClaims{},
@@ -1101,6 +1115,7 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 
 			return publicKey, nil
 		},
+		parseOpts...,
 	)
 
 	// ===== STEP 5: Check Parsing Errors =====

--- a/pkg/tokens/service_test.go
+++ b/pkg/tokens/service_test.go
@@ -187,6 +187,19 @@ var _ = Describe("TokenService", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("RefreshTokenDuration"))
 			})
+
+			It("should return error for negative ClockSkew", func() {
+				config := tokens.ServiceConfig{
+					KeyManager: mockKM,
+					RefreshStore: mockStore,
+					ClockSkew:  -1 * time.Second,
+				}
+
+				_, err := tokens.NewService(config)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("ClockSkew"))
+			})
 		})
 	})
 
@@ -731,6 +744,65 @@ var _ = Describe("TokenService", func() {
 				}).Should(BeTrue())
 			})
 
+		})
+
+		Context("with clock skew leeway configured", func() {
+			var leewayService *tokens.Service
+
+			BeforeEach(func() {
+				config := tokens.ServiceConfig{
+					KeyManager:          mockKM,
+					RefreshStore:        mockStore,
+					Logger:              mockLogger,
+					AccessTokenDuration: 15 * time.Minute,
+					CleanupInterval:     100 * time.Millisecond,
+					Issuer:              "test-issuer",
+					Audience:            []string{"test-audience"},
+					ClockSkew:           30 * time.Second,
+				}
+				var err error
+				leewayService, err = tokens.NewService(config)
+				Expect(err).NotTo(HaveOccurred())
+
+				mockKM.EXPECT().Start(gomock.Any()).Return(nil)
+				mockStore.EXPECT().Cleanup(gomock.Any()).Return(0, nil).AnyTimes()
+				Expect(leewayService.Start(ctx)).To(Succeed())
+			})
+
+			AfterEach(func() {
+				mockKM.EXPECT().Shutdown(gomock.Any()).Return(nil).AnyTimes()
+				leewayService.Shutdown(context.Background())
+			})
+
+			It("should accept a token expired within the leeway window", func() {
+				// Token expired 10 seconds ago — within the 30s leeway
+				recentToken := createRecentlyExpiredToken(testKey, testKeyID, testUserID, 10*time.Second)
+				mockKM.EXPECT().GetPublicKey(gomock.Any(), testKeyID).Return(&testKey.PublicKey, nil)
+
+				_, err := leewayService.ValidateAccessToken(ctx, recentToken)
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should reject a token expired beyond the leeway window", func() {
+				// Token expired 60 seconds ago — exceeds the 30s leeway
+				oldToken := createRecentlyExpiredToken(testKey, testKeyID, testUserID, 60*time.Second)
+				mockKM.EXPECT().GetPublicKey(gomock.Any(), testKeyID).Return(&testKey.PublicKey, nil)
+
+				_, err := leewayService.ValidateAccessToken(ctx, oldToken)
+
+				Expect(err).To(Equal(tokens.ErrTokenExpired))
+			})
+
+			It("should reject a token with zero clock skew that expired 10 seconds ago", func() {
+				// Same token, but strict service (no leeway) must reject it
+				recentToken := createRecentlyExpiredToken(testKey, testKeyID, testUserID, 10*time.Second)
+				mockKM.EXPECT().GetPublicKey(gomock.Any(), testKeyID).Return(&testKey.PublicKey, nil)
+
+				_, err := service.ValidateAccessToken(ctx, recentToken)
+
+				Expect(err).To(Equal(tokens.ErrTokenExpired))
+			})
 		})
 
 		Context("when public key retrieval fails", func() {
@@ -1546,6 +1618,32 @@ func createTokenWithAudience(key *rsa.PrivateKey, keyID string, audience []strin
 	token.Header["kid"] = keyID
 	signed, _ := token.SignedString(key)
 	return signed
+}
+
+// createRecentlyExpiredToken creates a token that expired the given duration ago.
+func createRecentlyExpiredToken(key *rsa.PrivateKey, keyID, userID string, expiredAgo time.Duration) string {
+	now := time.Now()
+	expiresAt := now.Add(-expiredAgo)
+
+	claims := jwt.RegisteredClaims{
+		Subject:   userID,
+		Issuer:    "test-issuer",
+		Audience:  jwt.ClaimStrings{"test-audience"},
+		ExpiresAt: jwt.NewNumericDate(expiresAt),
+		IssuedAt:  jwt.NewNumericDate(now.Add(-expiredAgo - time.Minute)),
+		NotBefore: jwt.NewNumericDate(now.Add(-expiredAgo - time.Minute)),
+		ID:        "test-recently-expired-jti",
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = keyID
+
+	signedToken, err := token.SignedString(key)
+	if err != nil {
+		return ""
+	}
+
+	return signedToken
 }
 
 func createExpiredToken(key *rsa.PrivateKey, keyID, userID string) string {


### PR DESCRIPTION
Closes #53

## Summary

- Adds `ClockSkew time.Duration` to `ServiceConfig` — optional leeway applied to `exp` and `nbf` validation
- Zero value preserves current strict behavior (no regression)
- Wired via `jwt.WithLeeway()` in `ValidateAccessToken`'s `ParseWithClaims` options
- `NewService` rejects negative `ClockSkew` values

## Test plan

- [x] Token expired within leeway window → accepted
- [x] Token expired beyond leeway window → `ErrTokenExpired`
- [x] Strict service (zero `ClockSkew`) rejects same recently-expired token
- [x] Negative `ClockSkew` rejected at construction time
- [x] 148/148 token tests passing with `-race`
- [x] `./run-ci-locally.sh` green (all packages)