### PR TITLE
Map sentinel errors to specific JSON codes in example middleware

### DIFF
--- a/examples/chi-example/auth/middleware.go
+++ b/examples/chi-example/auth/middleware.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -9,28 +11,28 @@ import (
 )
 
 // AuthMiddleware validates JWT tokens in the Authorization header
-// and attaches claims to the request context
+// and attaches claims to the request context.
 func AuthMiddleware(svc *tokens.Service) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Extract token from Authorization header
 			authHeader := r.Header.Get("Authorization")
 			if authHeader == "" {
-				http.Error(w, "missing authorization header", http.StatusUnauthorized)
+				writeJSONError(w, "missing_token", http.StatusUnauthorized)
 				return
 			}
 
 			// Remove "Bearer " prefix
 			token := strings.TrimPrefix(authHeader, "Bearer ")
 			if token == authHeader {
-				http.Error(w, "invalid authorization format", http.StatusUnauthorized)
+				writeJSONError(w, "invalid_authorization_format", http.StatusUnauthorized)
 				return
 			}
 
 			// Validate token using jwtauth
 			claims, err := svc.ValidateAccessToken(r.Context(), token)
 			if err != nil {
-				http.Error(w, "invalid token", http.StatusUnauthorized)
+				writeJSONError(w, tokenErrorCode(err), http.StatusUnauthorized)
 				return
 			}
 
@@ -41,4 +43,29 @@ func AuthMiddleware(svc *tokens.Service) func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
+}
+
+// tokenErrorCode maps a ValidateAccessToken error to a machine-readable error code.
+func tokenErrorCode(err error) string {
+	switch {
+	case errors.Is(err, tokens.ErrTokenExpired):
+		return "token_expired"
+	case errors.Is(err, tokens.ErrTokenNotYetValid):
+		return "token_not_yet_valid"
+	case errors.Is(err, tokens.ErrTokenRevoked):
+		return "token_revoked"
+	case errors.Is(err, tokens.ErrInvalidIssuer):
+		return "invalid_issuer"
+	case errors.Is(err, tokens.ErrInvalidAudience):
+		return "invalid_audience"
+	default:
+		return "invalid_token"
+	}
+}
+
+// writeJSONError writes a JSON error response with the given code and status.
+func writeJSONError(w http.ResponseWriter, code string, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(map[string]string{"error": code}) //nolint:errcheck
 }

--- a/examples/echo-example/middleware/auth.go
+++ b/examples/echo-example/middleware/auth.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
@@ -10,7 +11,7 @@ import (
 )
 
 // AuthMiddleware validates JWT tokens in the Authorization header
-// and attaches claims to the Echo context
+// and attaches claims to the Echo context.
 func AuthMiddleware(svc *tokens.Service) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
@@ -18,7 +19,7 @@ func AuthMiddleware(svc *tokens.Service) echo.MiddlewareFunc {
 			authHeader := c.Request().Header.Get("Authorization")
 			if authHeader == "" {
 				return c.JSON(http.StatusUnauthorized, map[string]string{
-					"error": "missing authorization header",
+					"error": "missing_token",
 				})
 			}
 
@@ -26,7 +27,7 @@ func AuthMiddleware(svc *tokens.Service) echo.MiddlewareFunc {
 			token := strings.TrimPrefix(authHeader, "Bearer ")
 			if token == authHeader {
 				return c.JSON(http.StatusUnauthorized, map[string]string{
-					"error": "invalid authorization format",
+					"error": "invalid_authorization_format",
 				})
 			}
 
@@ -34,7 +35,7 @@ func AuthMiddleware(svc *tokens.Service) echo.MiddlewareFunc {
 			claims, err := svc.ValidateAccessToken(c.Request().Context(), token)
 			if err != nil {
 				return c.JSON(http.StatusUnauthorized, map[string]string{
-					"error": "invalid token",
+					"error": tokenErrorCode(err),
 				})
 			}
 
@@ -44,5 +45,23 @@ func AuthMiddleware(svc *tokens.Service) echo.MiddlewareFunc {
 
 			return next(c)
 		}
+	}
+}
+
+// tokenErrorCode maps a ValidateAccessToken error to a machine-readable error code.
+func tokenErrorCode(err error) string {
+	switch {
+	case errors.Is(err, tokens.ErrTokenExpired):
+		return "token_expired"
+	case errors.Is(err, tokens.ErrTokenNotYetValid):
+		return "token_not_yet_valid"
+	case errors.Is(err, tokens.ErrTokenRevoked):
+		return "token_revoked"
+	case errors.Is(err, tokens.ErrInvalidIssuer):
+		return "invalid_issuer"
+	case errors.Is(err, tokens.ErrInvalidAudience):
+		return "invalid_audience"
+	default:
+		return "invalid_token"
 	}
 }

--- a/examples/gin-example/middleware/auth.go
+++ b/examples/gin-example/middleware/auth.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
@@ -10,14 +11,14 @@ import (
 )
 
 // AuthMiddleware validates JWT tokens in the Authorization header
-// and attaches claims to the Gin context
+// and attaches claims to the Gin context.
 func AuthMiddleware(svc *tokens.Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Extract token from Authorization header
 		authHeader := c.GetHeader("Authorization")
 		if authHeader == "" {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-				"error": "missing authorization header",
+				"error": "missing_token",
 			})
 			return
 		}
@@ -26,7 +27,7 @@ func AuthMiddleware(svc *tokens.Service) gin.HandlerFunc {
 		token := strings.TrimPrefix(authHeader, "Bearer ")
 		if token == authHeader {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-				"error": "invalid authorization format",
+				"error": "invalid_authorization_format",
 			})
 			return
 		}
@@ -35,7 +36,7 @@ func AuthMiddleware(svc *tokens.Service) gin.HandlerFunc {
 		claims, err := svc.ValidateAccessToken(c.Request.Context(), token)
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-				"error": "invalid token",
+				"error": tokenErrorCode(err),
 			})
 			return
 		}
@@ -44,5 +45,23 @@ func AuthMiddleware(svc *tokens.Service) gin.HandlerFunc {
 		c.Set("userID", claims.Subject)
 		c.Set("claims", claims)
 		c.Next()
+	}
+}
+
+// tokenErrorCode maps a ValidateAccessToken error to a machine-readable error code.
+func tokenErrorCode(err error) string {
+	switch {
+	case errors.Is(err, tokens.ErrTokenExpired):
+		return "token_expired"
+	case errors.Is(err, tokens.ErrTokenNotYetValid):
+		return "token_not_yet_valid"
+	case errors.Is(err, tokens.ErrTokenRevoked):
+		return "token_revoked"
+	case errors.Is(err, tokens.ErrInvalidIssuer):
+		return "invalid_issuer"
+	case errors.Is(err, tokens.ErrInvalidAudience):
+		return "invalid_audience"
+	default:
+		return "invalid_token"
 	}
 }


### PR DESCRIPTION
Closes #54

## Summary

- All three framework examples (chi, echo, gin) previously returned a generic `"invalid token"` body for every auth failure
- Now map library sentinel errors to specific machine-readable JSON codes via `errors.Is()`:
  - `token_expired`, `token_not_yet_valid`, `token_revoked`, `invalid_issuer`, `invalid_audience`, `invalid_token` (fallback)
- Standardised missing-header → `missing_token`, bad Bearer format → `invalid_authorization_format`
- Chi middleware now returns `application/json` instead of plain text

## Test plan

- [x] `go build ./...` clean
- [x] `./run-ci-locally.sh` green (all packages, lint, race)