### PR TITLE
Add ValidateAccessTokenWithClaims to surface custom claims after validation

### DIFF
--- a/pkg/tokens/service.go
+++ b/pkg/tokens/service.go
@@ -1231,6 +1231,54 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 	return claims, nil
 }
 
+// ValidateAccessTokenWithClaims validates the token and returns both the registered
+// claims and any custom claims embedded at issuance via IssueAccessTokenWithClaims.
+// Reserved claim keys (sub, exp, nbf, iat, jti, iss, aud) are excluded from the
+// custom claims map so callers receive only the application-defined fields.
+// Returns an empty map when no custom claims were embedded.
+//
+// Returns ErrServiceNotRunning if the service has not been started, ErrTokenExpired
+// if the token has expired beyond the configured ClockSkew, ErrTokenNotYetValid if
+// the nbf claim has not been reached, ErrInvalidIssuer or ErrInvalidAudience if
+// configured values do not match, ErrInvalidToken for malformed tokens or unknown
+// key IDs, or the context error if the context is cancelled.
+func (s *Service) ValidateAccessTokenWithClaims(ctx context.Context, tokenString string) (*jwt.RegisteredClaims, map[string]interface{}, error) {
+	// ===== STEP 1: Validate via Standard Path =====
+	// All error handling (signature, expiry, issuer, audience, metrics, logging)
+	// is handled by ValidateAccessToken — no duplication needed.
+	registered, err := s.ValidateAccessToken(ctx, tokenString)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// ===== STEP 2: Re-Parse for Custom Claims =====
+	// Signature is already verified above; ParseUnverified is safe here and
+	// avoids a second key-manager round-trip.
+	rawToken, _, parseErr := jwt.NewParser().ParseUnverified(tokenString, jwt.MapClaims{})
+	if parseErr != nil {
+		// Token validated above — treat missing custom claims as empty rather than error.
+		return registered, map[string]interface{}{}, nil
+	}
+
+	mapClaims, ok := rawToken.Claims.(jwt.MapClaims)
+	if !ok {
+		return registered, map[string]interface{}{}, nil
+	}
+
+	// ===== STEP 3: Strip Reserved Claims =====
+	reserved := map[string]struct{}{
+		"sub": {}, "exp": {}, "nbf": {}, "iat": {}, "jti": {}, "iss": {}, "aud": {},
+	}
+	custom := make(map[string]interface{}, len(mapClaims))
+	for k, v := range mapClaims {
+		if _, isReserved := reserved[k]; !isReserved {
+			custom[k] = v
+		}
+	}
+
+	return registered, custom, nil
+}
+
 // RefreshAccessToken exchanges a valid refresh token for a new access token.
 // It retrieves the refresh token from storage, checks expiration and revocation
 // status, then calls IssueAccessToken for the token's owner.

--- a/pkg/tokens/service_test.go
+++ b/pkg/tokens/service_test.go
@@ -805,6 +805,79 @@ var _ = Describe("TokenService", func() {
 			})
 		})
 
+		// ======================================================================
+		// ValidateAccessTokenWithClaims
+		// ======================================================================
+
+		Describe("ValidateAccessTokenWithClaims", func() {
+			Context("with custom claims embedded at issuance", func() {
+				It("should return custom claims alongside registered claims", func() {
+					mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
+					customClaims := map[string]interface{}{
+						"role":   "admin",
+						"tenant": "org-123",
+					}
+					tokenStr, err := service.IssueAccessTokenWithClaims(ctx, testUserID, customClaims)
+					Expect(err).NotTo(HaveOccurred())
+
+					mockKM.EXPECT().GetPublicKey(gomock.Any(), testKeyID).Return(&testKey.PublicKey, nil)
+
+					registered, custom, err := service.ValidateAccessTokenWithClaims(ctx, tokenStr)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(registered).NotTo(BeNil())
+					Expect(registered.Subject).To(Equal(testUserID))
+					Expect(custom["role"]).To(Equal("admin"))
+					Expect(custom["tenant"]).To(Equal("org-123"))
+				})
+
+				It("should exclude reserved claim keys from custom claims map", func() {
+					mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
+					tokenStr, err := service.IssueAccessToken(ctx, testUserID)
+					Expect(err).NotTo(HaveOccurred())
+
+					mockKM.EXPECT().GetPublicKey(gomock.Any(), testKeyID).Return(&testKey.PublicKey, nil)
+
+					_, custom, err := service.ValidateAccessTokenWithClaims(ctx, tokenStr)
+
+					Expect(err).NotTo(HaveOccurred())
+					for _, reserved := range []string{"sub", "exp", "nbf", "iat", "jti", "iss", "aud"} {
+						Expect(custom).NotTo(HaveKey(reserved))
+					}
+				})
+
+				It("should return empty map when no custom claims were embedded", func() {
+					mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
+					tokenStr, err := service.IssueAccessToken(ctx, testUserID)
+					Expect(err).NotTo(HaveOccurred())
+
+					mockKM.EXPECT().GetPublicKey(gomock.Any(), testKeyID).Return(&testKey.PublicKey, nil)
+
+					_, custom, err := service.ValidateAccessTokenWithClaims(ctx, tokenStr)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(custom).NotTo(BeNil())
+					Expect(custom).To(BeEmpty())
+				})
+			})
+
+			Context("when validation fails", func() {
+				It("should propagate errors from ValidateAccessToken", func() {
+					_, _, err := service.ValidateAccessTokenWithClaims(ctx, "not-a-jwt")
+
+					Expect(err).To(Equal(tokens.ErrInvalidToken))
+				})
+
+				It("should return nil claims and nil map on error", func() {
+					registered, custom, err := service.ValidateAccessTokenWithClaims(ctx, "malformed")
+
+					Expect(err).To(HaveOccurred())
+					Expect(registered).To(BeNil())
+					Expect(custom).To(BeNil())
+				})
+			})
+		})
+
 		Context("when public key retrieval fails", func() {
 			It("should return error", func() {
 				mockKM.EXPECT().


### PR DESCRIPTION
Closes #55

## Summary

`IssueAccessTokenWithClaims` lets callers embed custom claims at issuance, but `ValidateAccessToken` returned only `*jwt.RegisteredClaims` — custom claims were silently dropped. This adds `ValidateAccessTokenWithClaims` to close that gap.

**Design decisions:**
- Delegates all validation to `ValidateAccessToken` — no logic duplication, all error semantics and metrics preserved
- Uses `ParseUnverified` on the already-verified token to read `MapClaims` — avoids a second key-manager round-trip
- Strips reserved claim keys (`sub`, `exp`, `nbf`, `iat`, `jti`, `iss`, `aud`) from returned map
- Returns empty `map[string]interface{}` (not `nil`) when no custom claims were embedded

## Test plan

- [x] Custom claims round-trip: issued → validated → returned
- [x] Reserved keys excluded from custom claims map
- [x] Empty map returned when no custom claims
- [x] Errors propagated from `ValidateAccessToken` unchanged
- [x] 153/153 token tests passing with `-race`
- [x] `./run-ci-locally.sh` green