### PR TITLE
Add correlation ID support for log correlation across distributed operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,62 @@ func (m *MyZapAdapter) Info(msg string, args ...interface{}) {
 // ... implement Warn, Error
 ```
 
+### Correlation ID
+
+Correlation IDs let you filter all log lines from a single request across every internal component — KeyManager, RefreshStore, and TokenService — with a single `jq` query.
+
+**Quick start**:
+
+```go
+// 1. Build a logger with CorrelationIDHandler pre-wired
+logger := logging.NewCorrelationJSONLogger(slog.LevelInfo)
+
+// 2. HTTP middleware: extract or generate an ID, inject into context
+func correlationMiddleware(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        id := r.Header.Get("X-Correlation-ID")
+        if id == "" {
+            id = uuid.NewString() // or any unique ID
+        }
+        ctx := logging.WithCorrelationID(r.Context(), id)
+        w.Header().Set("X-Correlation-ID", id)
+        next.ServeHTTP(w, r.WithContext(ctx))
+    })
+}
+
+// 3. Pass ctx through — all internal logs automatically carry correlation_id
+accessToken, refreshToken, err := svc.IssueTokenPair(ctx, userID)
+```
+
+**Before** (hard to correlate):
+```json
+{"level":"INFO","msg":"refresh token stored","userID":"alice"}
+{"level":"INFO","msg":"access token issued","userID":"bob"}
+{"level":"INFO","msg":"refresh token stored","userID":"alice"}
+```
+
+**After** (trivial to filter):
+```json
+{"level":"INFO","msg":"refresh token stored","userID":"alice","correlation_id":"req-001"}
+{"level":"INFO","msg":"access token issued","userID":"bob","correlation_id":"req-002"}
+{"level":"INFO","msg":"refresh token stored","userID":"alice","correlation_id":"req-001"}
+```
+
+```bash
+# Isolate a single request across all components
+jq 'select(.correlation_id=="req-001")' app.log
+```
+
+**Key design points**:
+- `logging.WithCorrelationID(ctx, id)` — attaches the ID to a context
+- `logging.GetCorrelationID(ctx)` — retrieves it (returns `""` if absent)
+- `logging.NewCorrelationIDHandler(h slog.Handler)` — wraps any `slog.Handler`; use this when building your own `slog.Logger`
+- `logging.NewCorrelationJSONLogger(level)` / `logging.NewCorrelationTextLogger(level)` — convenience constructors with the handler pre-wired
+- Background operations (cleanup goroutines) use `context.Background()` — no ID is emitted, no spurious empty fields
+- Zero breaking changes — the `Logger` interface is unchanged; custom implementations continue to work
+
+See [examples/correlation-example/](examples/correlation-example/) for a complete stdlib HTTP server demonstrating middleware, login, refresh, and validate endpoints with correlated logs.
+
 ### Metrics
 
 **Interface** (`pkg/metrics/Metrics`):

--- a/examples/correlation-example/main.go
+++ b/examples/correlation-example/main.go
@@ -1,0 +1,180 @@
+// correlation-example demonstrates end-to-end correlation ID support using only
+// the standard library. Every log line produced during a request carries the
+// same correlation_id, making production log filtering trivial:
+//
+//	jq 'select(.correlation_id=="<id>")' app.log
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math/rand"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/aetomala/jwtauth/pkg/keymanager"
+	"github.com/aetomala/jwtauth/pkg/logging"
+	"github.com/aetomala/jwtauth/pkg/storage"
+	"github.com/aetomala/jwtauth/pkg/tokens"
+)
+
+func main() {
+	// ===== Logger: JSON with CorrelationIDHandler pre-wired =====
+	// NewCorrelationJSONLogger wraps slog.NewJSONHandler with CorrelationIDHandler
+	// so every *Context call automatically injects correlation_id into the record.
+	logger := logging.NewCorrelationJSONLogger(slog.LevelDebug)
+
+	// ===== KeyManager =====
+	ks, err := keymanager.NewDiskKeyStore("./keys", 2048, logger, nil)
+	if err != nil {
+		slog.Error("failed to create key store", "error", err)
+		os.Exit(1)
+	}
+	km, err := keymanager.NewManager(keymanager.ManagerConfig{
+		KeyStore:            ks,
+		KeyRotationInterval: 30 * 24 * time.Hour,
+		KeySize:             2048,
+		Logger:              logger,
+	})
+	if err != nil {
+		slog.Error("failed to create key manager", "error", err)
+		os.Exit(1)
+	}
+
+	// ===== TokenService =====
+	store := storage.NewMemoryRefreshStore(logger, nil)
+	svc, err := tokens.NewService(tokens.ServiceConfig{
+		KeyManager:           km,
+		RefreshStore:         store,
+		AccessTokenDuration:  15 * time.Minute,
+		RefreshTokenDuration: 7 * 24 * time.Hour,
+		CleanupInterval:      1 * time.Hour,
+		Issuer:               "correlation-example",
+		Audience:             []string{"correlation-example"},
+		Logger:               logger,
+	})
+	if err != nil {
+		slog.Error("failed to create token service", "error", err)
+		os.Exit(1)
+	}
+
+	startCtx := context.Background()
+	if err := svc.Start(startCtx); err != nil {
+		slog.Error("failed to start token service", "error", err)
+		os.Exit(1)
+	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = svc.Shutdown(shutdownCtx)
+	}()
+
+	// ===== HTTP Handlers =====
+	mux := http.NewServeMux()
+
+	// Correlation ID middleware wraps every handler. It extracts the
+	// X-Correlation-ID request header (or generates one) and injects it into
+	// the request context. The response echoes the ID back so the caller can
+	// correlate client-side logs as well.
+	withCorrelation := func(next http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			id := r.Header.Get("X-Correlation-ID")
+			if id == "" {
+				id = newCorrelationID()
+			}
+			ctx := logging.WithCorrelationID(r.Context(), id)
+			w.Header().Set("X-Correlation-ID", id)
+			next(w, r.WithContext(ctx))
+		}
+	}
+
+	// POST /login — issues a token pair; all internal logs carry correlation_id.
+	mux.HandleFunc("POST /login", withCorrelation(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		var req struct {
+			UserID string `json:"user_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.UserID == "" {
+			http.Error(w, `{"error":"user_id required"}`, http.StatusBadRequest)
+			return
+		}
+
+		accessToken, refreshToken, err := svc.IssueTokenPair(ctx, req.UserID)
+		if err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"access_token":  accessToken,
+			"refresh_token": refreshToken,
+		})
+	}))
+
+	// POST /refresh — exchanges a refresh token for a new access token.
+	mux.HandleFunc("POST /refresh", withCorrelation(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		var req struct {
+			RefreshToken string `json:"refresh_token"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.RefreshToken == "" {
+			http.Error(w, `{"error":"refresh_token required"}`, http.StatusBadRequest)
+			return
+		}
+
+		newAccessToken, err := svc.RefreshAccessToken(ctx, req.RefreshToken)
+		if err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"access_token": newAccessToken,
+		})
+	}))
+
+	// GET /validate — validates an access token passed in the Authorization header.
+	mux.HandleFunc("GET /validate", withCorrelation(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		bearer := r.Header.Get("Authorization")
+		if len(bearer) < 8 || bearer[:7] != "Bearer " {
+			http.Error(w, `{"error":"Authorization header required"}`, http.StatusUnauthorized)
+			return
+		}
+
+		claims, err := svc.ValidateAccessToken(ctx, bearer[7:])
+		if err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"subject": claims.Subject,
+			"issuer":  claims.Issuer,
+		})
+	}))
+
+	addr := ":8080"
+	slog.Info("correlation-example server starting", "addr", addr)
+	slog.Info("try: curl -s -X POST http://localhost:8080/login -d '{\"user_id\":\"alice\"}' -H 'X-Correlation-ID: req-001'")
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		slog.Error("server error", "error", err)
+		os.Exit(1)
+	}
+}
+
+// newCorrelationID returns a short pseudo-random hex ID suitable for use as a
+// correlation ID when the caller does not supply X-Correlation-ID. For
+// production use, replace this with a UUID library (e.g. github.com/google/uuid).
+func newCorrelationID() string {
+	return fmt.Sprintf("%08x-%04x", rand.Uint32(), rand.Uint32()&0xffff) //nolint:gosec
+}

--- a/internal/testutil/mock_keymanager.go
+++ b/internal/testutil/mock_keymanager.go
@@ -59,18 +59,18 @@ func (mr *MockKeyManagerMockRecorder) GetCurrentSigningKey(ctx any) *gomock.Call
 }
 
 // GetJWKS mocks base method.
-func (m *MockKeyManager) GetJWKS() (*keymanager.JWKS, error) {
+func (m *MockKeyManager) GetJWKS(ctx context.Context) (*keymanager.JWKS, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetJWKS")
+	ret := m.ctrl.Call(m, "GetJWKS", ctx)
 	ret0, _ := ret[0].(*keymanager.JWKS)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetJWKS indicates an expected call of GetJWKS.
-func (mr *MockKeyManagerMockRecorder) GetJWKS() *gomock.Call {
+func (mr *MockKeyManagerMockRecorder) GetJWKS(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetJWKS", reflect.TypeOf((*MockKeyManager)(nil).GetJWKS))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetJWKS", reflect.TypeOf((*MockKeyManager)(nil).GetJWKS), ctx)
 }
 
 // GetPublicKey mocks base method.

--- a/pkg/keymanager/disk.go
+++ b/pkg/keymanager/disk.go
@@ -103,7 +103,7 @@ func (d *DiskKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 	matches, err := filepath.Glob(pattern)
 	if err != nil {
 		if d.logger != nil {
-			d.logger.Error("failed to glob key files", "error", err)
+			d.logger.Error("failed to glob key files", ctx, "error", err)
 		}
 		return nil, fmt.Errorf("glob key files: %w", err)
 	}
@@ -114,7 +114,7 @@ func (d *DiskKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 		privateKey, keyID, err := d.readKeyFile(file)
 		if err != nil {
 			if d.logger != nil {
-				d.logger.Warn("skipping key file: failed to load",
+				d.logger.Warn("skipping key file: failed to load", ctx,
 					"file", filepath.Base(file),
 					"error", err)
 			}
@@ -124,7 +124,7 @@ func (d *DiskKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 		meta, err := d.readMetadata(keyID)
 		if err != nil {
 			if d.logger != nil {
-				d.logger.Warn("skipping key: failed to load metadata",
+				d.logger.Warn("skipping key: failed to load metadata", ctx,
 					"keyID", keyID,
 					"error", err)
 			}
@@ -134,7 +134,7 @@ func (d *DiskKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 		// Skip already-expired keys
 		if !meta.ExpiresAt.IsZero() && time.Now().After(meta.ExpiresAt) {
 			if d.logger != nil {
-				d.logger.Info("skipping expired key",
+				d.logger.Info("skipping expired key", ctx,
 					"keyID", keyID,
 					"expiredAt", meta.ExpiresAt.Format(time.RFC3339))
 			}
@@ -148,7 +148,7 @@ func (d *DiskKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 		})
 
 		if d.logger != nil {
-			d.logger.Debug("loaded key from disk", "keyID", keyID)
+			d.logger.Debug("loaded key from disk", ctx, "keyID", keyID)
 		}
 	}
 
@@ -157,7 +157,7 @@ func (d *DiskKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 	errorType = ""
 	keyCount = len(keys)
 	if d.logger != nil {
-		d.logger.Info("loaded keys from disk", "count", keyCount)
+		d.logger.Info("loaded keys from disk", ctx, "count", keyCount)
 	}
 	return keys, nil
 }
@@ -203,7 +203,7 @@ func (d *DiskKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.P
 	file, err := os.OpenFile(pemPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		if d.logger != nil {
-			d.logger.Error("failed to create key file",
+			d.logger.Error("failed to create key file", ctx,
 				"keyID", keyID,
 				"error", err)
 		}
@@ -213,7 +213,7 @@ func (d *DiskKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.P
 
 	if err := pem.Encode(file, pemBlock); err != nil {
 		if d.logger != nil {
-			d.logger.Error("failed to write key file",
+			d.logger.Error("failed to write key file", ctx,
 				"keyID", keyID,
 				"error", err)
 		}
@@ -225,7 +225,7 @@ func (d *DiskKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.P
 		// Rollback: remove the PEM file to maintain consistency
 		os.Remove(pemPath)
 		if d.logger != nil {
-			d.logger.Warn("failed to save key metadata — rolling back PEM",
+			d.logger.Warn("failed to save key metadata — rolling back PEM", ctx,
 				"keyID", keyID,
 				"error", err)
 		}
@@ -236,7 +236,7 @@ func (d *DiskKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.P
 	status = "success"
 	errorType = ""
 	if d.logger != nil {
-		d.logger.Info("saved key to disk", "keyID", keyID)
+		d.logger.Info("saved key to disk", ctx, "keyID", keyID)
 	}
 	return nil
 }
@@ -282,7 +282,7 @@ func (d *DiskKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta Ke
 	// ===== STEP 3: Write Updated Metadata =====
 	if err := d.writeMetadata(keyID, meta); err != nil {
 		if d.logger != nil {
-			d.logger.Error("failed to update metadata",
+			d.logger.Error("failed to update metadata", ctx,
 				"keyID", keyID,
 				"error", err)
 		}
@@ -293,7 +293,7 @@ func (d *DiskKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta Ke
 	status = "success"
 	errorType = ""
 	if d.logger != nil {
-		d.logger.Info("updated key metadata", "keyID", keyID)
+		d.logger.Info("updated key metadata", ctx, "keyID", keyID)
 	}
 	return nil
 }
@@ -344,7 +344,7 @@ func (d *DiskKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.PrivateK
 			return nil, nil, ErrKeyStoreKeyNotFound
 		}
 		if d.logger != nil {
-			d.logger.Error("failed to load key file",
+			d.logger.Error("failed to load key file", ctx,
 				"keyID", keyID,
 				"error", err)
 		}
@@ -355,7 +355,7 @@ func (d *DiskKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.PrivateK
 	meta, err := d.readMetadata(keyID)
 	if err != nil {
 		if d.logger != nil {
-			d.logger.Error("failed to load key metadata",
+			d.logger.Error("failed to load key metadata", ctx,
 				"keyID", keyID,
 				"error", err)
 		}
@@ -366,7 +366,7 @@ func (d *DiskKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.PrivateK
 	status = "success"
 	errorType = ""
 	if d.logger != nil {
-		d.logger.Debug("loaded key from disk", "keyID", keyID)
+		d.logger.Debug("loaded key from disk", ctx, "keyID", keyID)
 	}
 	return privateKey, &meta, nil
 }
@@ -404,7 +404,7 @@ func (d *DiskKeyStore) Delete(ctx context.Context, keyID string) error {
 	pemPath := filepath.Join(d.dir, keyID+".pem")
 	if err := os.Remove(pemPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 		if d.logger != nil {
-			d.logger.Error("failed to delete key file",
+			d.logger.Error("failed to delete key file", ctx,
 				"keyID", keyID,
 				"error", err)
 		}
@@ -415,7 +415,7 @@ func (d *DiskKeyStore) Delete(ctx context.Context, keyID string) error {
 	metaPath := filepath.Join(d.dir, keyID+".json")
 	if err := os.Remove(metaPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 		if d.logger != nil {
-			d.logger.Error("failed to delete metadata file",
+			d.logger.Error("failed to delete metadata file", ctx,
 				"keyID", keyID,
 				"error", err)
 		}
@@ -426,7 +426,7 @@ func (d *DiskKeyStore) Delete(ctx context.Context, keyID string) error {
 	status = "success"
 	errorType = ""
 	if d.logger != nil {
-		d.logger.Info("deleted key from disk", "keyID", keyID)
+		d.logger.Info("deleted key from disk", ctx, "keyID", keyID)
 	}
 	return nil
 }

--- a/pkg/keymanager/interface.go
+++ b/pkg/keymanager/interface.go
@@ -32,7 +32,7 @@ type KeyManager interface {
 	// Returns:
 	//   - jwks: Set of public keys in JWKS format
 	//   - error: If JWKS generation fails
-	GetJWKS() (*JWKS, error)
+	GetJWKS(ctx context.Context) (*JWKS, error)
 
 	// RotateKeys generates a new signing key and marks the old key for expiration.
 	//

--- a/pkg/keymanager/keymanager.go
+++ b/pkg/keymanager/keymanager.go
@@ -216,7 +216,7 @@ func (m *Manager) Start(ctx context.Context) error {
 	if err != nil {
 		atomic.StoreInt32(&m.state, StateStopped)
 		if m.config.Logger != nil {
-			m.config.Logger.Error("failed to load keys from store", "error", err)
+			m.config.Logger.Error("failed to load keys from store", ctx, "error", err)
 		}
 		return fmt.Errorf("load keys: %w", err)
 	}
@@ -245,7 +245,7 @@ func (m *Manager) Start(ctx context.Context) error {
 		m.mu.Unlock()
 
 		if m.config.Logger != nil {
-			m.config.Logger.Info("loaded existing keys from store",
+			m.config.Logger.Info("loaded existing keys from store", ctx,
 				"keyID", m.currentKeyID,
 				"keyCount", len(storedKeys))
 		}
@@ -258,7 +258,7 @@ func (m *Manager) Start(ctx context.Context) error {
 		if err != nil {
 			atomic.StoreInt32(&m.state, StateStopped)
 			if m.config.Logger != nil {
-				m.config.Logger.Error("failed to generate initial key", "error", err)
+				m.config.Logger.Error("failed to generate initial key", ctx, "error", err)
 			}
 			return fmt.Errorf("generate key: %w", err)
 		}
@@ -283,13 +283,13 @@ func (m *Manager) Start(ctx context.Context) error {
 		if err := m.config.KeyStore.Save(ctx, keyID, privateKey, meta); err != nil {
 			atomic.StoreInt32(&m.state, StateStopped)
 			if m.config.Logger != nil {
-				m.config.Logger.Error("failed to save initial key", "error", err)
+				m.config.Logger.Error("failed to save initial key", ctx, "error", err)
 			}
 			return fmt.Errorf("save initial key: %w", err)
 		}
 
 		if m.config.Logger != nil {
-			m.config.Logger.Info("generated new RSA key pair",
+			m.config.Logger.Info("generated new RSA key pair", ctx,
 				"keyID", keyID,
 				"keySize", m.config.KeySize)
 		}
@@ -304,7 +304,7 @@ func (m *Manager) Start(ctx context.Context) error {
 	go m.rotationSchedulerLoop(ctx)
 
 	if m.config.Logger != nil {
-		m.config.Logger.Info("key manager started",
+		m.config.Logger.Info("key manager started", ctx,
 			"rotationInterval", m.config.KeyRotationInterval)
 	}
 
@@ -335,7 +335,7 @@ func (m *Manager) GetCurrentSigningKey(ctx context.Context) (*rsa.PrivateKey, st
 
 	// ===== STEP 3: Acquire Read Lock and Retrieve Key =====
 	if m.config.Logger != nil {
-		m.config.Logger.Debug("getting current signing key")
+		m.config.Logger.Debug("getting current signing key", ctx)
 	}
 
 	m.mu.RLock()
@@ -367,7 +367,7 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 	}
 
 	if m.config.Logger != nil {
-		m.config.Logger.Info("initiating graceful shutdown")
+		m.config.Logger.Info("initiating graceful shutdown", ctx)
 	}
 
 	// ===== STEP 2: Signal Rotation Scheduler to Stop =====
@@ -391,7 +391,7 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 	m.stopRotationCh = make(chan struct{})
 
 	if m.config.Logger != nil {
-		m.config.Logger.Info("key manager stopped")
+		m.config.Logger.Info("key manager stopped", ctx)
 	}
 
 	return nil
@@ -435,7 +435,7 @@ func (m *Manager) GetPublicKey(ctx context.Context, keyID string) (*rsa.PublicKe
 	if keyPair, exists := m.keys[keyID]; exists {
 		m.mu.RUnlock()
 		if m.config.Logger != nil {
-			m.config.Logger.Debug("public key cache hit", "keyID", keyID)
+			m.config.Logger.Debug("public key cache hit", ctx, "keyID", keyID)
 		}
 		status = "success"
 		errorType = ""
@@ -445,7 +445,7 @@ func (m *Manager) GetPublicKey(ctx context.Context, keyID string) (*rsa.PublicKe
 
 	// ===== STEP 4: Load from KeyStore =====
 	if m.config.Logger != nil {
-		m.config.Logger.Debug("public key not in cache, loading from store", "keyID", keyID)
+		m.config.Logger.Debug("public key not in cache, loading from store", ctx, "keyID", keyID)
 	}
 	privateKey, meta, err := m.config.KeyStore.LoadKey(ctx, keyID)
 	if err != nil {
@@ -489,14 +489,14 @@ func (m *Manager) GetPublicKey(ctx context.Context, keyID string) (*rsa.PublicKe
 // GetJWKS returns a JSON Web Key Set (JWKS) containing all non-expired public keys.
 // Returns ErrManagerNotRunning if the Manager is not running. The returned JWKS
 // is suitable for serving at /.well-known/jwks.json for OAuth/OIDC compliance.
-func (m *Manager) GetJWKS() (*JWKS, error) {
+func (m *Manager) GetJWKS(ctx context.Context) (*JWKS, error) {
 	// ===== STEP 1: Check Manager is Running =====
 	if !m.IsRunning() {
 		return nil, ErrManagerNotRunning
 	}
 
 	if m.config.Logger != nil {
-		m.config.Logger.Debug("getting JWKS")
+		m.config.Logger.Debug("getting JWKS", ctx)
 	}
 
 	// ===== STEP 2: Acquire Read Lock and Collect Keys =====
@@ -558,7 +558,7 @@ func (m *Manager) RotateKeys(ctx context.Context) error {
 		status = "cancelled"
 		errorType = "cancelled"
 		if m.config.Logger != nil {
-			m.config.Logger.Warn("key rotation cancelled")
+			m.config.Logger.Warn("key rotation cancelled", ctx)
 		}
 		return ctx.Err()
 	default:
@@ -577,7 +577,7 @@ func (m *Manager) RotateKeys(ctx context.Context) error {
 	privateKey, err := rsa.GenerateKey(rand.Reader, m.config.KeySize)
 	if err != nil {
 		if m.config.Logger != nil {
-			m.config.Logger.Error("key rotation failed", "error", err)
+			m.config.Logger.Error("key rotation failed", ctx, "error", err)
 		}
 		return fmt.Errorf("generate key: %w", err)
 	}
@@ -590,7 +590,7 @@ func (m *Manager) RotateKeys(ctx context.Context) error {
 	newMeta := KeyMetadata{ID: keyID, CreatedAt: now}
 	if err := m.config.KeyStore.Save(ctx, keyID, privateKey, newMeta); err != nil {
 		if m.config.Logger != nil {
-			m.config.Logger.Error("key rotation failed: could not save new key", "error", err)
+			m.config.Logger.Error("key rotation failed: could not save new key", ctx, "error", err)
 		}
 		return fmt.Errorf("save new key: %w", err)
 	}
@@ -608,13 +608,13 @@ func (m *Manager) RotateKeys(ctx context.Context) error {
 		if err := m.config.KeyStore.UpdateMetadata(ctx, oldKeyID, updatedMeta); err != nil {
 			// Log but continue — in-memory expiration is sufficient for correctness
 			if m.config.Logger != nil {
-				m.config.Logger.Warn("failed to persist expiration for old key",
+				m.config.Logger.Warn("failed to persist expiration for old key", ctx,
 					"oldKeyID", oldKeyID,
 					"error", err)
 			}
 		} else {
 			if m.config.Logger != nil {
-				m.config.Logger.Info("old key marked for expiration",
+				m.config.Logger.Info("old key marked for expiration", ctx,
 					"keyID", oldKeyID,
 					"expiresAt", oldKey.ExpiresAt)
 			}
@@ -639,7 +639,7 @@ func (m *Manager) RotateKeys(ctx context.Context) error {
 	}
 
 	if m.config.Logger != nil {
-		m.config.Logger.Info("key rotation successful",
+		m.config.Logger.Info("key rotation successful", ctx,
 			"newKeyID", keyID,
 			"oldKeyID", oldKeyID,
 			"duration", time.Since(start))
@@ -675,20 +675,20 @@ func (m *Manager) rotationSchedulerLoop(ctx context.Context) {
 		select {
 		case <-m.rotationTicker.C:
 			if m.config.Logger != nil {
-				m.config.Logger.Info("automatic rotation triggered")
+				m.config.Logger.Info("automatic rotation triggered", ctx)
 			}
 			if err := m.RotateKeys(ctx); err != nil {
 				if m.config.Logger != nil {
-					m.config.Logger.Error("rotation failed", "error", err)
+					m.config.Logger.Error("rotation failed", ctx, "error", err)
 				}
 			}
-			m.cleanupExpiredKeys()
+			m.cleanupExpiredKeys(ctx)
 
 		case <-cleanupTicker.C:
 			if m.config.Logger != nil {
-				m.config.Logger.Debug("rotation cleanup tick fired")
+				m.config.Logger.Debug("rotation cleanup tick fired", ctx)
 			}
-			m.cleanupExpiredKeys()
+			m.cleanupExpiredKeys(ctx)
 
 		case <-ctx.Done():
 			return
@@ -702,7 +702,7 @@ func (m *Manager) rotationSchedulerLoop(ctx context.Context) {
 // KeyStore. It is called periodically by the rotation scheduler and immediately
 // after each rotation. The current signing key is never removed. Removals are
 // logged at Info level; a no-op sweep is logged at Debug level.
-func (m *Manager) cleanupExpiredKeys() {
+func (m *Manager) cleanupExpiredKeys(ctx context.Context) {
 	// ===== STEP 1: Check Manager is Running =====
 	if !m.IsRunning() {
 		return
@@ -723,9 +723,9 @@ func (m *Manager) cleanupExpiredKeys() {
 		}
 		if !key.ExpiresAt.IsZero() && now.After(key.ExpiresAt) {
 			delete(m.keys, keyID)
-			if err := m.config.KeyStore.Delete(context.Background(), keyID); err != nil {
+			if err := m.config.KeyStore.Delete(ctx, keyID); err != nil {
 				if m.config.Logger != nil {
-					m.config.Logger.Error("failed to delete expired key from store",
+					m.config.Logger.Error("failed to delete expired key from store", ctx,
 						"keyID", keyID,
 						"error", err)
 				}
@@ -739,11 +739,11 @@ func (m *Manager) cleanupExpiredKeys() {
 	// ===== STEP 4: Log Results =====
 	if m.config.Logger != nil {
 		if count == 0 {
-			m.config.Logger.Debug("no expired keys found during cleanup")
+			m.config.Logger.Debug("no expired keys found during cleanup", ctx)
 		} else {
-			m.config.Logger.Info("expired key cleanup executed", "deletedCount", count)
+			m.config.Logger.Info("expired key cleanup executed", ctx, "deletedCount", count)
 			for _, key := range deletedKeys {
-				m.config.Logger.Info("deleted expired key", "keyID", key)
+				m.config.Logger.Info("deleted expired key", ctx, "keyID", key)
 			}
 		}
 	}

--- a/pkg/keymanager/keymanager_test.go
+++ b/pkg/keymanager/keymanager_test.go
@@ -493,7 +493,7 @@ var _ = Describe("Manager", func() {
 			})
 
 			It("should return ErrManagerNotRunning", func() {
-				_, err := manager.GetJWKS()
+				_, err := manager.GetJWKS(ctx)
 				Expect(err).To(MatchError(keymanager.ErrManagerNotRunning))
 			})
 		})
@@ -533,7 +533,7 @@ var _ = Describe("Manager", func() {
 				manager.Keys()["active-key"].ExpiresAt = time.Now().Add(-1 * time.Hour)
 				manager.Mu().Unlock()
 
-				jwks, err := manager.GetJWKS()
+				jwks, err := manager.GetJWKS(ctx)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(jwks.Keys).To(HaveLen(1))
 				Expect(jwks.Keys[0].KeyID).To(Equal("current-key"))

--- a/pkg/keymanager/redis.go
+++ b/pkg/keymanager/redis.go
@@ -105,7 +105,7 @@ func (r *RedisKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 		pemStr, err := r.client.Get(ctx, redisKey).Result()
 		if err != nil {
 			if r.logger != nil {
-				r.logger.Warn("skipping key: failed to load PEM",
+				r.logger.Warn("skipping key: failed to load PEM", ctx,
 					"keyID", keyID,
 					"error", err)
 			}
@@ -115,7 +115,7 @@ func (r *RedisKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 		privateKey, err := decodePEM(pemStr)
 		if err != nil {
 			if r.logger != nil {
-				r.logger.Warn("skipping key: failed to parse PEM",
+				r.logger.Warn("skipping key: failed to parse PEM", ctx,
 					"keyID", keyID,
 					"error", err)
 			}
@@ -126,7 +126,7 @@ func (r *RedisKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 		metaStr, err := r.client.Get(ctx, keyMetaPrefix+keyID).Result()
 		if err != nil {
 			if r.logger != nil {
-				r.logger.Warn("skipping key: failed to load metadata",
+				r.logger.Warn("skipping key: failed to load metadata", ctx,
 					"keyID", keyID,
 					"error", err)
 			}
@@ -136,7 +136,7 @@ func (r *RedisKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 		var meta KeyMetadata
 		if err := json.Unmarshal([]byte(metaStr), &meta); err != nil {
 			if r.logger != nil {
-				r.logger.Warn("skipping key: failed to parse metadata",
+				r.logger.Warn("skipping key: failed to parse metadata", ctx,
 					"keyID", keyID,
 					"error", err)
 			}
@@ -146,7 +146,7 @@ func (r *RedisKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 		// ===== STEP 5: Skip Expired Keys =====
 		if !meta.ExpiresAt.IsZero() && time.Now().After(meta.ExpiresAt) {
 			if r.logger != nil {
-				r.logger.Info("skipping expired key",
+				r.logger.Info("skipping expired key", ctx,
 					"keyID", keyID,
 					"expiredAt", meta.ExpiresAt.Format(time.RFC3339))
 			}
@@ -160,13 +160,13 @@ func (r *RedisKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 		})
 
 		if r.logger != nil {
-			r.logger.Debug("loaded key from redis", "keyID", keyID)
+			r.logger.Debug("loaded key from redis", ctx, "keyID", keyID)
 		}
 	}
 
 	if err := iter.Err(); err != nil {
 		if r.logger != nil {
-			r.logger.Error("failed to scan redis keys", "error", err)
+			r.logger.Error("failed to scan redis keys", ctx, "error", err)
 		}
 		return nil, fmt.Errorf("scan redis keys: %w", err)
 	}
@@ -176,7 +176,7 @@ func (r *RedisKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 	errorType = ""
 	keyCount = len(keys)
 	if r.logger != nil {
-		r.logger.Info("loaded keys from redis", "count", keyCount)
+		r.logger.Info("loaded keys from redis", ctx, "count", keyCount)
 	}
 	return keys, nil
 }
@@ -217,7 +217,7 @@ func (r *RedisKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.
 	metaBytes, err := json.Marshal(meta)
 	if err != nil {
 		if r.logger != nil {
-			r.logger.Error("failed to marshal key metadata",
+			r.logger.Error("failed to marshal key metadata", ctx,
 				"keyID", keyID,
 				"error", err)
 		}
@@ -231,7 +231,7 @@ func (r *RedisKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.
 
 	if _, err := pipe.Exec(ctx); err != nil {
 		if r.logger != nil {
-			r.logger.Error("failed to save key to redis",
+			r.logger.Error("failed to save key to redis", ctx,
 				"keyID", keyID,
 				"error", err)
 		}
@@ -242,7 +242,7 @@ func (r *RedisKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.
 	status = "success"
 	errorType = ""
 	if r.logger != nil {
-		r.logger.Info("saved key to redis", "keyID", keyID)
+		r.logger.Info("saved key to redis", ctx, "keyID", keyID)
 	}
 	return nil
 }
@@ -281,7 +281,7 @@ func (r *RedisKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta K
 	exists, err := r.client.Exists(ctx, keyPEMPrefix+keyID).Result()
 	if err != nil {
 		if r.logger != nil {
-			r.logger.Error("failed to check key existence",
+			r.logger.Error("failed to check key existence", ctx,
 				"keyID", keyID,
 				"error", err)
 		}
@@ -297,7 +297,7 @@ func (r *RedisKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta K
 	metaBytes, err := json.Marshal(meta)
 	if err != nil {
 		if r.logger != nil {
-			r.logger.Error("failed to marshal key metadata",
+			r.logger.Error("failed to marshal key metadata", ctx,
 				"keyID", keyID,
 				"error", err)
 		}
@@ -306,7 +306,7 @@ func (r *RedisKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta K
 
 	if err := r.client.Set(ctx, keyMetaPrefix+keyID, string(metaBytes), 0).Err(); err != nil {
 		if r.logger != nil {
-			r.logger.Error("failed to update metadata in redis",
+			r.logger.Error("failed to update metadata in redis", ctx,
 				"keyID", keyID,
 				"error", err)
 		}
@@ -317,7 +317,7 @@ func (r *RedisKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta K
 	status = "success"
 	errorType = ""
 	if r.logger != nil {
-		r.logger.Info("updated key metadata", "keyID", keyID)
+		r.logger.Info("updated key metadata", ctx, "keyID", keyID)
 	}
 	return nil
 }
@@ -368,7 +368,7 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 			return nil, nil, ErrKeyStoreKeyNotFound
 		}
 		if r.logger != nil {
-			r.logger.Error("failed to load key from redis",
+			r.logger.Error("failed to load key from redis", ctx,
 				"keyID", keyID,
 				"error", err)
 		}
@@ -378,7 +378,7 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 	privateKey, err := decodePEM(pemStr)
 	if err != nil {
 		if r.logger != nil {
-			r.logger.Error("failed to parse PEM for key",
+			r.logger.Error("failed to parse PEM for key", ctx,
 				"keyID", keyID,
 				"error", err)
 		}
@@ -394,7 +394,7 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 			return nil, nil, ErrKeyStoreKeyNotFound
 		}
 		if r.logger != nil {
-			r.logger.Error("failed to load key metadata from redis",
+			r.logger.Error("failed to load key metadata from redis", ctx,
 				"keyID", keyID,
 				"error", err)
 		}
@@ -404,7 +404,7 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 	var meta KeyMetadata
 	if err := json.Unmarshal([]byte(metaStr), &meta); err != nil {
 		if r.logger != nil {
-			r.logger.Error("failed to parse key metadata",
+			r.logger.Error("failed to parse key metadata", ctx,
 				"keyID", keyID,
 				"error", err)
 		}
@@ -415,7 +415,7 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 	status = "success"
 	errorType = ""
 	if r.logger != nil {
-		r.logger.Debug("loaded key from redis", "keyID", keyID)
+		r.logger.Debug("loaded key from redis", ctx, "keyID", keyID)
 	}
 	return privateKey, &meta, nil
 }
@@ -452,7 +452,7 @@ func (r *RedisKeyStore) Delete(ctx context.Context, keyID string) error {
 	// ===== STEP 2: Delete Both Keys =====
 	if err := r.client.Del(ctx, keyPEMPrefix+keyID, keyMetaPrefix+keyID).Err(); err != nil {
 		if r.logger != nil {
-			r.logger.Error("failed to delete key from redis",
+			r.logger.Error("failed to delete key from redis", ctx,
 				"keyID", keyID,
 				"error", err)
 		}
@@ -463,7 +463,7 @@ func (r *RedisKeyStore) Delete(ctx context.Context, keyID string) error {
 	status = "success"
 	errorType = ""
 	if r.logger != nil {
-		r.logger.Info("deleted key from redis", "keyID", keyID)
+		r.logger.Info("deleted key from redis", ctx, "keyID", keyID)
 	}
 	return nil
 }

--- a/pkg/logging/correlation.go
+++ b/pkg/logging/correlation.go
@@ -1,0 +1,25 @@
+package logging
+
+import "context"
+
+// contextKey is an unexported type for context keys in this package.
+// Using a package-local type prevents key collisions with other packages.
+type contextKey string
+
+const correlationIDKey contextKey = "correlation_id"
+
+// WithCorrelationID returns a copy of ctx with the given correlation ID attached.
+// The ID is later extracted by GetCorrelationID and injected into log records
+// by CorrelationIDHandler.
+func WithCorrelationID(ctx context.Context, correlationID string) context.Context {
+	return context.WithValue(ctx, correlationIDKey, correlationID)
+}
+
+// GetCorrelationID extracts the correlation ID from ctx.
+// Returns "" if no correlation ID has been set.
+func GetCorrelationID(ctx context.Context) string {
+	if id, ok := ctx.Value(correlationIDKey).(string); ok {
+		return id
+	}
+	return ""
+}

--- a/pkg/logging/correlation_handler.go
+++ b/pkg/logging/correlation_handler.go
@@ -1,0 +1,56 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+)
+
+// CorrelationIDHandler is a slog.Handler wrapper that injects the correlation_id
+// field from context into every log record. It is suitable for production use
+// with any slog.Handler backend (JSON, text, custom). All methods are safe for
+// concurrent use.
+type CorrelationIDHandler struct {
+	// handler is the inner slog.Handler that receives the enriched records.
+	handler slog.Handler
+}
+
+// Compile-time check that CorrelationIDHandler implements slog.Handler.
+var _ slog.Handler = (*CorrelationIDHandler)(nil)
+
+// NewCorrelationIDHandler returns a CorrelationIDHandler that wraps h.
+// When Handle is called, correlation_id is extracted from the context via
+// GetCorrelationID and appended to the record before delegating to h.
+// If no correlation ID is present in the context, the field is omitted.
+func NewCorrelationIDHandler(h slog.Handler) *CorrelationIDHandler {
+	return &CorrelationIDHandler{handler: h}
+}
+
+// Enabled reports whether the inner handler is enabled for the given level.
+func (h *CorrelationIDHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.handler.Enabled(ctx, level)
+}
+
+// Handle extracts the correlation_id from ctx and appends it to a clone of r
+// before forwarding to the inner handler. If the context carries no correlation
+// ID, the record is forwarded unchanged.
+func (h *CorrelationIDHandler) Handle(ctx context.Context, r slog.Record) error {
+	if id := GetCorrelationID(ctx); id != "" {
+		r = r.Clone()
+		r.AddAttrs(slog.String("correlation_id", id))
+	}
+	return h.handler.Handle(ctx, r)
+}
+
+// WithAttrs returns a new CorrelationIDHandler whose inner handler has the
+// given attributes pre-applied. The returned handler continues to inject
+// correlation_id on every record.
+func (h *CorrelationIDHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &CorrelationIDHandler{handler: h.handler.WithAttrs(attrs)}
+}
+
+// WithGroup returns a new CorrelationIDHandler whose inner handler scopes
+// subsequent attributes under the given group name. The returned handler
+// continues to inject correlation_id on every record.
+func (h *CorrelationIDHandler) WithGroup(name string) slog.Handler {
+	return &CorrelationIDHandler{handler: h.handler.WithGroup(name)}
+}

--- a/pkg/logging/correlation_handler_test.go
+++ b/pkg/logging/correlation_handler_test.go
@@ -1,0 +1,96 @@
+package logging_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/aetomala/jwtauth/pkg/logging"
+)
+
+var _ = Describe("CorrelationIDHandler", func() {
+	var (
+		buf         *bytes.Buffer
+		innerHandler slog.Handler
+		corrHandler  *logging.CorrelationIDHandler
+		adapter      logging.Logger
+	)
+
+	BeforeEach(func() {
+		buf = &bytes.Buffer{}
+		innerHandler = slog.NewJSONHandler(buf, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})
+		corrHandler = logging.NewCorrelationIDHandler(innerHandler)
+		adapter = logging.NewSlogAdapter(slog.New(corrHandler))
+	})
+
+	// Phase 1: Handle injects correlation_id when present in ctx
+	It("should inject correlation_id into the log record when set in context", func() {
+		ctx := logging.WithCorrelationID(context.Background(), "req-abc-123")
+
+		adapter.Info("token refreshed", ctx, "user_id", "user-456")
+
+		var entry map[string]interface{}
+		Expect(json.Unmarshal(buf.Bytes(), &entry)).To(Succeed())
+		Expect(entry["correlation_id"]).To(Equal("req-abc-123"))
+		Expect(entry["user_id"]).To(Equal("user-456"))
+		Expect(entry["msg"]).To(Equal("token refreshed"))
+	})
+
+	// Phase 2: Handle omits field when ctx has no correlation ID
+	It("should not emit correlation_id when the context carries none", func() {
+		adapter.Info("background operation", context.Background(), "task", "cleanup")
+
+		var entry map[string]interface{}
+		Expect(json.Unmarshal(buf.Bytes(), &entry)).To(Succeed())
+		Expect(entry).NotTo(HaveKey("correlation_id"))
+		Expect(entry["task"]).To(Equal("cleanup"))
+	})
+
+	// Phase 3: WithAttrs preserves the CorrelationIDHandler wrapper
+	It("should return a CorrelationIDHandler from WithAttrs", func() {
+		enriched := corrHandler.WithAttrs([]slog.Attr{slog.String("service", "auth")})
+
+		_, ok := enriched.(*logging.CorrelationIDHandler)
+		Expect(ok).To(BeTrue())
+	})
+
+	It("should still inject correlation_id after WithAttrs", func() {
+		enriched := corrHandler.WithAttrs([]slog.Attr{slog.String("service", "auth")})
+		enrichedAdapter := logging.NewSlogAdapter(slog.New(enriched))
+
+		ctx := logging.WithCorrelationID(context.Background(), "enriched-corr-id")
+		enrichedAdapter.Info("test", ctx)
+
+		var entry map[string]interface{}
+		Expect(json.Unmarshal(buf.Bytes(), &entry)).To(Succeed())
+		Expect(entry["correlation_id"]).To(Equal("enriched-corr-id"))
+		Expect(entry["service"]).To(Equal("auth"))
+	})
+
+	// Phase 4: WithGroup preserves the CorrelationIDHandler wrapper
+	It("should return a CorrelationIDHandler from WithGroup", func() {
+		grouped := corrHandler.WithGroup("request")
+
+		_, ok := grouped.(*logging.CorrelationIDHandler)
+		Expect(ok).To(BeTrue())
+	})
+
+	// Phase 5: Enabled delegates to inner handler
+	It("should delegate Enabled to the inner handler", func() {
+		warnHandler := slog.NewJSONHandler(&bytes.Buffer{}, &slog.HandlerOptions{
+			Level: slog.LevelWarn,
+		})
+		warnCorrHandler := logging.NewCorrelationIDHandler(warnHandler)
+
+		Expect(warnCorrHandler.Enabled(context.Background(), slog.LevelDebug)).To(BeFalse())
+		Expect(warnCorrHandler.Enabled(context.Background(), slog.LevelInfo)).To(BeFalse())
+		Expect(warnCorrHandler.Enabled(context.Background(), slog.LevelWarn)).To(BeTrue())
+		Expect(warnCorrHandler.Enabled(context.Background(), slog.LevelError)).To(BeTrue())
+	})
+})

--- a/pkg/logging/correlation_test.go
+++ b/pkg/logging/correlation_test.go
@@ -1,0 +1,52 @@
+package logging_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/aetomala/jwtauth/pkg/logging"
+)
+
+var _ = Describe("Correlation ID context helpers", func() {
+	// Phase 1: WithCorrelationID and GetCorrelationID round-trip
+	It("should store and retrieve the correlation ID", func() {
+		ctx := logging.WithCorrelationID(context.Background(), "req-abc-123")
+
+		Expect(logging.GetCorrelationID(ctx)).To(Equal("req-abc-123"))
+	})
+
+	// Phase 2: missing ID returns empty string
+	It("should return empty string when no correlation ID is set", func() {
+		Expect(logging.GetCorrelationID(context.Background())).To(Equal(""))
+	})
+
+	// Phase 3: key isolation — external packages cannot accidentally read or overwrite our key
+	It("should not collide with keys set by other packages", func() {
+		type externalKey string
+		const externalCorrelationKey externalKey = "correlation_id"
+
+		ctx := context.WithValue(context.Background(), externalCorrelationKey, "external-value")
+
+		// Our helper must return "" because the key type is different
+		Expect(logging.GetCorrelationID(ctx)).To(Equal(""))
+	})
+
+	// Phase 4: later value overwrites earlier value
+	It("should return the most recently set correlation ID", func() {
+		ctx := logging.WithCorrelationID(context.Background(), "first-id")
+		ctx = logging.WithCorrelationID(ctx, "second-id")
+
+		Expect(logging.GetCorrelationID(ctx)).To(Equal("second-id"))
+	})
+
+	// Phase 5: child context inherits the correlation ID from parent
+	It("should be inherited by child contexts", func() {
+		parent := logging.WithCorrelationID(context.Background(), "parent-corr-id")
+		child, cancel := context.WithCancel(parent)
+		defer cancel()
+
+		Expect(logging.GetCorrelationID(child)).To(Equal("parent-corr-id"))
+	})
+})

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -2,6 +2,7 @@ package logging_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -856,6 +857,133 @@ var _ = Describe("Integration", func() {
 			for i := 0; i < 10; i++ {
 				Eventually(done).Should(Receive())
 			}
+		})
+	})
+})
+
+// ============================================================================
+// SlogAdapter — Context Detection Tests
+// ============================================================================
+
+var _ = Describe("SlogAdapter — context detection", func() {
+	var buf *bytes.Buffer
+
+	newAdapter := func(level slog.Level) logging.Logger {
+		inner := slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: level})
+		return logging.NewSlogAdapter(slog.New(logging.NewCorrelationIDHandler(inner)))
+	}
+
+	BeforeEach(func() {
+		buf = &bytes.Buffer{}
+	})
+
+	Describe("Info", func() {
+		It("should inject correlation_id when context is the first arg", func() {
+			ctx := logging.WithCorrelationID(context.Background(), "corr-info-1")
+			newAdapter(slog.LevelInfo).Info("token issued", ctx, "user_id", "u-1")
+
+			var entry map[string]interface{}
+			Expect(json.Unmarshal(buf.Bytes(), &entry)).To(Succeed())
+			Expect(entry["correlation_id"]).To(Equal("corr-info-1"))
+			Expect(entry["user_id"]).To(Equal("u-1"))
+		})
+
+		It("should omit correlation_id when context carries none", func() {
+			newAdapter(slog.LevelInfo).Info("background op", context.Background(), "task", "cleanup")
+
+			var entry map[string]interface{}
+			Expect(json.Unmarshal(buf.Bytes(), &entry)).To(Succeed())
+			Expect(entry).NotTo(HaveKey("correlation_id"))
+		})
+
+		It("should log normally when no context arg is present", func() {
+			newAdapter(slog.LevelInfo).Info("plain log", "key", "value")
+
+			var entry map[string]interface{}
+			Expect(json.Unmarshal(buf.Bytes(), &entry)).To(Succeed())
+			Expect(entry["key"]).To(Equal("value"))
+			Expect(entry).NotTo(HaveKey("correlation_id"))
+		})
+	})
+
+	Describe("Debug", func() {
+		It("should inject correlation_id when context is the first arg", func() {
+			ctx := logging.WithCorrelationID(context.Background(), "corr-debug-1")
+			newAdapter(slog.LevelDebug).Debug("cache hit", ctx, "key_id", "k-1")
+
+			var entry map[string]interface{}
+			Expect(json.Unmarshal(buf.Bytes(), &entry)).To(Succeed())
+			Expect(entry["correlation_id"]).To(Equal("corr-debug-1"))
+			Expect(entry["key_id"]).To(Equal("k-1"))
+		})
+
+		It("should log normally when no context arg is present", func() {
+			newAdapter(slog.LevelDebug).Debug("plain debug", "component", "keymanager")
+
+			var entry map[string]interface{}
+			Expect(json.Unmarshal(buf.Bytes(), &entry)).To(Succeed())
+			Expect(entry["component"]).To(Equal("keymanager"))
+			Expect(entry).NotTo(HaveKey("correlation_id"))
+		})
+	})
+
+	Describe("Warn", func() {
+		It("should inject correlation_id when context is the first arg", func() {
+			ctx := logging.WithCorrelationID(context.Background(), "corr-warn-1")
+			newAdapter(slog.LevelWarn).Warn("store rejected", ctx, "reason", "empty token")
+
+			var entry map[string]interface{}
+			Expect(json.Unmarshal(buf.Bytes(), &entry)).To(Succeed())
+			Expect(entry["correlation_id"]).To(Equal("corr-warn-1"))
+			Expect(entry["reason"]).To(Equal("empty token"))
+		})
+	})
+
+	Describe("Error", func() {
+		It("should inject correlation_id when context is the first arg", func() {
+			ctx := logging.WithCorrelationID(context.Background(), "corr-error-1")
+			newAdapter(slog.LevelError).Error("rotation failed", ctx, "error", "disk full")
+
+			var entry map[string]interface{}
+			Expect(json.Unmarshal(buf.Bytes(), &entry)).To(Succeed())
+			Expect(entry["correlation_id"]).To(Equal("corr-error-1"))
+			Expect(entry["error"]).To(Equal("disk full"))
+		})
+	})
+})
+
+// ============================================================================
+// NewCorrelationJSONLogger / NewCorrelationTextLogger Tests
+// ============================================================================
+
+var _ = Describe("Correlation convenience constructors", func() {
+	Describe("NewCorrelationJSONLogger", func() {
+		It("should return a non-nil adapter", func() {
+			Expect(logging.NewCorrelationJSONLogger(slog.LevelInfo)).NotTo(BeNil())
+		})
+
+		It("should not panic when logging with a correlation context", func() {
+			logger := logging.NewCorrelationJSONLogger(slog.LevelInfo)
+			ctx := logging.WithCorrelationID(context.Background(), "req-test")
+
+			Expect(func() {
+				logger.Info("test", ctx, "key", "value")
+			}).NotTo(Panic())
+		})
+	})
+
+	Describe("NewCorrelationTextLogger", func() {
+		It("should return a non-nil adapter", func() {
+			Expect(logging.NewCorrelationTextLogger(slog.LevelInfo)).NotTo(BeNil())
+		})
+
+		It("should not panic when logging with a correlation context", func() {
+			logger := logging.NewCorrelationTextLogger(slog.LevelInfo)
+			ctx := logging.WithCorrelationID(context.Background(), "req-test")
+
+			Expect(func() {
+				logger.Info("test", ctx, "key", "value")
+			}).NotTo(Panic())
 		})
 	})
 })

--- a/pkg/logging/slog_adapter.go
+++ b/pkg/logging/slog_adapter.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"context"
 	"log/slog"
 	"os"
 )
@@ -8,6 +9,11 @@ import (
 // SlogAdapter adapts Go's standard library log/slog to the Logger interface.
 // This is the recommended logger for production use as it has no external
 // dependencies and performs well.
+//
+// Context-aware logging: if the first element of keysAndValues is a
+// context.Context, the adapter calls the corresponding *Context method on the
+// underlying slog.Logger so that any handler wrapping (e.g. CorrelationIDHandler)
+// can extract request-scoped values from the context.
 //
 // Example Usage (JSON for production/Kubernetes):
 //
@@ -20,20 +26,16 @@ import (
 //	    Logger: logger,
 //	}
 //
-// Example Usage (Text for development):
+// Example Usage (with correlation ID support):
 //
-//	handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-//	    Level: slog.LevelInfo,
-//	})
-//	logger := logging.NewSlogAdapter(slog.New(handler))
+//	logger := logging.NewCorrelationJSONLogger(slog.LevelInfo)
+//	// In your HTTP handler:
+//	ctx = logging.WithCorrelationID(r.Context(), r.Header.Get("X-Correlation-ID"))
+//	tokenService.RefreshAccessToken(ctx, refreshToken) // logs include correlation_id
 //
 // JSON output (for log aggregators like ELK, Loki):
 //
-//	{"time":"2025-01-07T10:30:00Z","level":"INFO","msg":"key rotation successful","keyID":"abc-123"}
-//
-// Text output (human-readable for development):
-//
-//	time=2025-01-07T10:30:00.000Z level=INFO msg="key rotation successful" keyID=abc-123
+//	{"time":"2025-01-07T10:30:00Z","level":"INFO","msg":"key rotation successful","keyID":"abc-123","correlation_id":"req-xyz"}
 type SlogAdapter struct {
 	logger *slog.Logger
 }
@@ -49,22 +51,54 @@ func NewSlogAdapter(logger *slog.Logger) *SlogAdapter {
 }
 
 // Debug logs a verbose diagnostic message with structured key-value pairs.
+// If the first element of keysAndValues is a context.Context, it is used to
+// propagate request-scoped values (e.g. correlation ID) to the handler.
 func (s *SlogAdapter) Debug(msg string, keysAndValues ...interface{}) {
+	if len(keysAndValues) > 0 {
+		if ctx, ok := keysAndValues[0].(context.Context); ok {
+			s.logger.DebugContext(ctx, msg, keysAndValues[1:]...)
+			return
+		}
+	}
 	s.logger.Debug(msg, keysAndValues...)
 }
 
 // Info logs an informational message with structured key-value pairs.
+// If the first element of keysAndValues is a context.Context, it is used to
+// propagate request-scoped values (e.g. correlation ID) to the handler.
 func (s *SlogAdapter) Info(msg string, keysAndValues ...interface{}) {
+	if len(keysAndValues) > 0 {
+		if ctx, ok := keysAndValues[0].(context.Context); ok {
+			s.logger.InfoContext(ctx, msg, keysAndValues[1:]...)
+			return
+		}
+	}
 	s.logger.Info(msg, keysAndValues...)
 }
 
 // Warn logs a warning message with structured key-value pairs.
+// If the first element of keysAndValues is a context.Context, it is used to
+// propagate request-scoped values (e.g. correlation ID) to the handler.
 func (s *SlogAdapter) Warn(msg string, keysAndValues ...interface{}) {
+	if len(keysAndValues) > 0 {
+		if ctx, ok := keysAndValues[0].(context.Context); ok {
+			s.logger.WarnContext(ctx, msg, keysAndValues[1:]...)
+			return
+		}
+	}
 	s.logger.Warn(msg, keysAndValues...)
 }
 
 // Error logs an error message with structured key-value pairs.
+// If the first element of keysAndValues is a context.Context, it is used to
+// propagate request-scoped values (e.g. correlation ID) to the handler.
 func (s *SlogAdapter) Error(msg string, keysAndValues ...interface{}) {
+	if len(keysAndValues) > 0 {
+		if ctx, ok := keysAndValues[0].(context.Context); ok {
+			s.logger.ErrorContext(ctx, msg, keysAndValues[1:]...)
+			return
+		}
+	}
 	s.logger.Error(msg, keysAndValues...)
 }
 
@@ -96,4 +130,35 @@ func NewTextLogger(level slog.Level) *SlogAdapter {
 		Level: level,
 	})
 	return NewSlogAdapter(slog.New(handler))
+}
+
+// NewCorrelationJSONLogger creates a production-ready JSON logger with
+// CorrelationIDHandler pre-wired. When component methods pass a context as the
+// first logging arg, correlation_id is automatically injected into each record.
+//
+// Example:
+//
+//	logger := logging.NewCorrelationJSONLogger(slog.LevelInfo)
+//	ctx = logging.WithCorrelationID(r.Context(), r.Header.Get("X-Correlation-ID"))
+//	// Output: {"time":"...","level":"INFO","msg":"...","correlation_id":"req-xyz","key":"value"}
+func NewCorrelationJSONLogger(level slog.Level) *SlogAdapter {
+	inner := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: level,
+	})
+	return NewSlogAdapter(slog.New(NewCorrelationIDHandler(inner)))
+}
+
+// NewCorrelationTextLogger creates a development-friendly text logger with
+// CorrelationIDHandler pre-wired. When component methods pass a context as the
+// first logging arg, correlation_id is automatically injected into each record.
+//
+// Example:
+//
+//	logger := logging.NewCorrelationTextLogger(slog.LevelDebug)
+//	// Output: time=... level=INFO msg=... correlation_id=req-xyz key=value
+func NewCorrelationTextLogger(level slog.Level) *SlogAdapter {
+	inner := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: level,
+	})
+	return NewSlogAdapter(slog.New(NewCorrelationIDHandler(inner)))
 }

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -85,7 +85,7 @@ func (m *MemoryRefreshStore) Store(ctx context.Context, tokenID, userID string, 
 		status = "cancelled"
 		errorType = "cancelled"
 		if m.logger != nil {
-			m.logger.Warn("store aborted: context cancelled",
+			m.logger.Warn("store aborted: context cancelled", ctx,
 				"reason", err)
 		}
 		return err
@@ -96,7 +96,7 @@ func (m *MemoryRefreshStore) Store(ctx context.Context, tokenID, userID string, 
 		status = "validation_error"
 		errorType = "validation_error"
 		if m.logger != nil {
-			m.logger.Warn("store rejected: tokenID is empty or whitespace",
+			m.logger.Warn("store rejected: tokenID is empty or whitespace", ctx,
 				"userID", userID)
 		}
 		return ErrInvalidTokenID
@@ -106,7 +106,7 @@ func (m *MemoryRefreshStore) Store(ctx context.Context, tokenID, userID string, 
 		status = "validation_error"
 		errorType = "validation_error"
 		if m.logger != nil {
-			m.logger.Warn("store rejected: userID is empty or whitespace",
+			m.logger.Warn("store rejected: userID is empty or whitespace", ctx,
 				"tokenID", tokenID)
 		}
 		return ErrInvalidUserID
@@ -116,7 +116,7 @@ func (m *MemoryRefreshStore) Store(ctx context.Context, tokenID, userID string, 
 		status = "validation_error"
 		errorType = "validation_error"
 		if m.logger != nil {
-			m.logger.Warn("store rejected: token is already expired",
+			m.logger.Warn("store rejected: token is already expired", ctx,
 				"tokenID", tokenID,
 				"userID", userID,
 				"expiresAt", expiresAt)
@@ -138,7 +138,7 @@ func (m *MemoryRefreshStore) Store(ctx context.Context, tokenID, userID string, 
 	defer m.mu.Unlock()
 
 	if m.logger != nil {
-		m.logger.Debug("storing token in memory",
+		m.logger.Debug("storing token in memory", ctx,
 			"tokenID", tokenID,
 			"userID", userID)
 	}
@@ -160,7 +160,7 @@ func (m *MemoryRefreshStore) Store(ctx context.Context, tokenID, userID string, 
 	status = "success"
 	errorType = ""
 	if m.logger != nil {
-		m.logger.Info("refresh token stored",
+		m.logger.Info("refresh token stored", ctx,
 			"tokenID", tokenID,
 			"userID", userID,
 			"expiresAt", expiresAt)
@@ -199,7 +199,7 @@ func (m *MemoryRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Ref
 		status = "cancelled"
 		errorType = "cancelled"
 		if m.logger != nil {
-			m.logger.Warn("retrieve aborted: context cancelled",
+			m.logger.Warn("retrieve aborted: context cancelled", ctx,
 				"tokenID", tokenID,
 				"reason", err)
 		}
@@ -211,7 +211,7 @@ func (m *MemoryRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Ref
 		status = "validation_error"
 		errorType = "validation_error"
 		if m.logger != nil {
-			m.logger.Warn("retrieve rejected: tokenID is empty or whitespace")
+			m.logger.Warn("retrieve rejected: tokenID is empty or whitespace", ctx)
 		}
 		return nil, ErrInvalidTokenID
 	}
@@ -221,7 +221,7 @@ func (m *MemoryRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Ref
 	defer m.mu.RUnlock()
 
 	if m.logger != nil {
-		m.logger.Debug("looking up token in memory",
+		m.logger.Debug("looking up token in memory", ctx,
 			"tokenID", tokenID)
 	}
 
@@ -231,7 +231,7 @@ func (m *MemoryRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Ref
 		status = "not_found"
 		errorType = "not_found"
 		if m.logger != nil {
-			m.logger.Warn("retrieve: token not found",
+			m.logger.Warn("retrieve: token not found", ctx,
 				"tokenID", tokenID)
 		}
 		return nil, ErrTokenNotFound
@@ -242,7 +242,7 @@ func (m *MemoryRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Ref
 		status = "revoked"
 		errorType = "revoked"
 		if m.logger != nil {
-			m.logger.Warn("retrieve: token has been revoked",
+			m.logger.Warn("retrieve: token has been revoked", ctx,
 				"tokenID", tokenID,
 				"userID", token.UserID)
 		}
@@ -254,7 +254,7 @@ func (m *MemoryRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Ref
 		status = "expired"
 		errorType = "expired"
 		if m.logger != nil {
-			m.logger.Warn("retrieve: token has expired",
+			m.logger.Warn("retrieve: token has expired", ctx,
 				"tokenID", tokenID,
 				"expiredAt", token.ExpiresAt)
 		}
@@ -281,7 +281,7 @@ func (m *MemoryRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Ref
 	status = "success"
 	errorType = ""
 	if m.logger != nil {
-		m.logger.Info("retrieve: token retrieved successfully",
+		m.logger.Info("retrieve: token retrieved successfully", ctx,
 			"tokenID", tokenID)
 	}
 
@@ -315,7 +315,7 @@ func (m *MemoryRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 		status = "cancelled"
 		errorType = "cancelled"
 		if m.logger != nil {
-			m.logger.Warn("revoke aborted: context cancelled",
+			m.logger.Warn("revoke aborted: context cancelled", ctx,
 				"tokenID", tokenID)
 		}
 		return ctx.Err()
@@ -326,7 +326,7 @@ func (m *MemoryRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 		status = "validation_error"
 		errorType = "validation_error"
 		if m.logger != nil {
-			m.logger.Warn("revoke rejected: tokenID is empty or whitespace")
+			m.logger.Warn("revoke rejected: tokenID is empty or whitespace", ctx)
 		}
 		return ErrInvalidTokenID
 	}
@@ -341,7 +341,7 @@ func (m *MemoryRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 		status = "success" // idempotent: not-found is not an error
 		errorType = ""
 		if m.logger != nil {
-			m.logger.Warn("revoke: token not found",
+			m.logger.Warn("revoke: token not found", ctx,
 				"tokenID", tokenID)
 		}
 		return nil
@@ -354,7 +354,7 @@ func (m *MemoryRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 	status = "success"
 	errorType = ""
 	if m.logger != nil {
-		m.logger.Info("revoke: successfully revoked",
+		m.logger.Info("revoke: successfully revoked", ctx,
 			"tokenID", tokenID)
 	}
 
@@ -389,7 +389,7 @@ func (m *MemoryRefreshStore) RevokeAllForUser(ctx context.Context, userID string
 		status = "cancelled"
 		errorType = "cancelled"
 		if m.logger != nil {
-			m.logger.Warn("revokeAllForUser aborted: context cancelled",
+			m.logger.Warn("revokeAllForUser aborted: context cancelled", ctx,
 				"userID", userID,
 				"reason", err)
 		}
@@ -401,7 +401,7 @@ func (m *MemoryRefreshStore) RevokeAllForUser(ctx context.Context, userID string
 		status = "validation_error"
 		errorType = "validation_error"
 		if m.logger != nil {
-			m.logger.Warn("revokeAllForUser rejected: userID is empty or whitespace")
+			m.logger.Warn("revokeAllForUser rejected: userID is empty or whitespace", ctx)
 		}
 		return ErrInvalidUserID
 	}
@@ -415,7 +415,7 @@ func (m *MemoryRefreshStore) RevokeAllForUser(ctx context.Context, userID string
 	for _, tokenID := range tokensIDs {
 		if token, exists := m.tokens[tokenID]; exists {
 			if m.logger != nil {
-				m.logger.Debug("revoking token for user",
+				m.logger.Debug("revoking token for user", ctx,
 					"tokenID", tokenID,
 					"userID", userID)
 			}
@@ -427,7 +427,7 @@ func (m *MemoryRefreshStore) RevokeAllForUser(ctx context.Context, userID string
 	status = "success"
 	errorType = ""
 	if m.logger != nil {
-		m.logger.Info("revokeAllForUser: all tokens revoked",
+		m.logger.Info("revokeAllForUser: all tokens revoked", ctx,
 			"userID", userID,
 			"count", len(tokensIDs))
 	}
@@ -473,7 +473,7 @@ func (m *MemoryRefreshStore) Cleanup(ctx context.Context) (int, error) {
 		status = "cancelled"
 		errorType = "cancelled"
 		if m.logger != nil {
-			m.logger.Warn("cleanup aborted: context cancelled")
+			m.logger.Warn("cleanup aborted: context cancelled", ctx)
 		}
 		return 0, err
 	}
@@ -488,7 +488,7 @@ func (m *MemoryRefreshStore) Cleanup(ctx context.Context) (int, error) {
 	for tokenID, token := range m.tokens {
 		if token.ExpiresAt.Before(now) || token.ExpiresAt.Equal(now) {
 			if m.logger != nil {
-				m.logger.Debug("removing expired token",
+				m.logger.Debug("removing expired token", ctx,
 					"tokenID", token.TokenID,
 					"expiredAt", token.ExpiresAt)
 			}
@@ -504,7 +504,7 @@ func (m *MemoryRefreshStore) Cleanup(ctx context.Context) (int, error) {
 	status = "success"
 	errorType = ""
 	if m.logger != nil {
-		m.logger.Info("cleanup: successful",
+		m.logger.Info("cleanup: successful", ctx,
 			"count", count)
 	}
 

--- a/pkg/storage/redis.go
+++ b/pkg/storage/redis.go
@@ -80,7 +80,7 @@ func (r *RedisRefreshStore) Store(ctx context.Context, tokenID, userID string, e
 		status = "cancelled"
 		errorType = "cancelled"
 		if r.logger != nil {
-			r.logger.Warn("store aborted: context cancelled",
+			r.logger.Warn("store aborted: context cancelled", ctx,
 				"reason", err)
 		}
 		return err
@@ -91,7 +91,7 @@ func (r *RedisRefreshStore) Store(ctx context.Context, tokenID, userID string, e
 		status = "validation_error"
 		errorType = "validation_error"
 		if r.logger != nil {
-			r.logger.Warn("store rejected: tokenID is empty or whitespace",
+			r.logger.Warn("store rejected: tokenID is empty or whitespace", ctx,
 				"userID", userID)
 		}
 		return ErrInvalidTokenID
@@ -101,7 +101,7 @@ func (r *RedisRefreshStore) Store(ctx context.Context, tokenID, userID string, e
 		status = "validation_error"
 		errorType = "validation_error"
 		if r.logger != nil {
-			r.logger.Warn("store rejected: userID is empty or whitespace",
+			r.logger.Warn("store rejected: userID is empty or whitespace", ctx,
 				"tokenID", tokenID)
 		}
 		return ErrInvalidUserID
@@ -111,7 +111,7 @@ func (r *RedisRefreshStore) Store(ctx context.Context, tokenID, userID string, e
 		status = "validation_error"
 		errorType = "validation_error"
 		if r.logger != nil {
-			r.logger.Warn("store rejected: token is already expired",
+			r.logger.Warn("store rejected: token is already expired", ctx,
 				"tokenID", tokenID,
 				"userID", userID,
 				"expiresAt", expiresAt)
@@ -131,7 +131,7 @@ func (r *RedisRefreshStore) Store(ctx context.Context, tokenID, userID string, e
 		jsonBytes, err := json.Marshal(metadataCopy)
 		if err != nil {
 			if r.logger != nil {
-				r.logger.Error("store failed: metadata marshal error",
+				r.logger.Error("store failed: metadata marshal error", ctx,
 					"tokenID", tokenID,
 					"error", err)
 			}
@@ -162,7 +162,7 @@ func (r *RedisRefreshStore) Store(ctx context.Context, tokenID, userID string, e
 	pipe.Expire(ctx, tokenKey, duration)
 
 	if r.logger != nil {
-		r.logger.Debug("executing redis pipeline for token store",
+		r.logger.Debug("executing redis pipeline for token store", ctx,
 			"tokenID", tokenID,
 			"userID", userID)
 	}
@@ -170,7 +170,7 @@ func (r *RedisRefreshStore) Store(ctx context.Context, tokenID, userID string, e
 	_, err := pipe.Exec(ctx)
 	if err != nil {
 		if r.logger != nil {
-			r.logger.Error("store failed: redis pipeline error",
+			r.logger.Error("store failed: redis pipeline error", ctx,
 				"tokenID", tokenID,
 				"error", err)
 		}
@@ -181,7 +181,7 @@ func (r *RedisRefreshStore) Store(ctx context.Context, tokenID, userID string, e
 	status = "success"
 	errorType = ""
 	if r.logger != nil {
-		r.logger.Info("refresh token stored",
+		r.logger.Info("refresh token stored", ctx,
 			"tokenID", tokenID,
 			"userID", userID,
 			"expiresAt", expiresAt)
@@ -221,7 +221,7 @@ func (r *RedisRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Refr
 		status = "cancelled"
 		errorType = "cancelled"
 		if r.logger != nil {
-			r.logger.Warn("retrieve aborted: context cancelled",
+			r.logger.Warn("retrieve aborted: context cancelled", ctx,
 				"tokenID", tokenID,
 				"reason", err)
 		}
@@ -233,7 +233,7 @@ func (r *RedisRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Refr
 		status = "validation_error"
 		errorType = "validation_error"
 		if r.logger != nil {
-			r.logger.Warn("retrieve rejected: tokenID is empty or whitespace")
+			r.logger.Warn("retrieve rejected: tokenID is empty or whitespace", ctx)
 		}
 		return nil, ErrInvalidTokenID
 	}
@@ -243,7 +243,7 @@ func (r *RedisRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Refr
 	hash, err := r.client.HGetAll(ctx, tokenKey).Result()
 	if err != nil {
 		if r.logger != nil {
-			r.logger.Error("retrieve failed: redis error",
+			r.logger.Error("retrieve failed: redis error", ctx,
 				"tokenID", tokenID,
 				"error", err)
 		}
@@ -251,7 +251,7 @@ func (r *RedisRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Refr
 	}
 
 	if r.logger != nil {
-		r.logger.Debug("redis hash retrieved",
+		r.logger.Debug("redis hash retrieved", ctx,
 			"tokenID", tokenID,
 			"fieldCount", len(hash))
 	}
@@ -261,7 +261,7 @@ func (r *RedisRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Refr
 		status = "not_found"
 		errorType = "not_found"
 		if r.logger != nil {
-			r.logger.Warn("retrieve: token not found",
+			r.logger.Warn("retrieve: token not found", ctx,
 				"tokenID", tokenID)
 		}
 		return nil, ErrTokenNotFound
@@ -273,7 +273,7 @@ func (r *RedisRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Refr
 		status = "revoked"
 		errorType = "revoked"
 		if r.logger != nil {
-			r.logger.Warn("retrieve: token has been revoked",
+			r.logger.Warn("retrieve: token has been revoked", ctx,
 				"tokenID", tokenID,
 				"userID", hash["userID"])
 		}
@@ -284,7 +284,7 @@ func (r *RedisRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Refr
 	expiresAtMillis, err := strconv.ParseInt(hash["expiresAt"], 10, 64)
 	if err != nil {
 		if r.logger != nil {
-			r.logger.Error("retrieve failed: invalid expiration timestamp",
+			r.logger.Error("retrieve failed: invalid expiration timestamp", ctx,
 				"tokenID", tokenID,
 				"error", err)
 		}
@@ -296,7 +296,7 @@ func (r *RedisRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Refr
 		status = "expired"
 		errorType = "expired"
 		if r.logger != nil {
-			r.logger.Warn("retrieve: token has expired",
+			r.logger.Warn("retrieve: token has expired", ctx,
 				"tokenID", tokenID,
 				"expiredAt", expiresAt)
 		}
@@ -307,7 +307,7 @@ func (r *RedisRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Refr
 	createdAtMillis, err := strconv.ParseInt(hash["createdAt"], 10, 64)
 	if err != nil {
 		if r.logger != nil {
-			r.logger.Error("retrieve failed: invalid creation timestamp",
+			r.logger.Error("retrieve failed: invalid creation timestamp", ctx,
 				"tokenID", tokenID,
 				"error", err)
 		}
@@ -330,7 +330,7 @@ func (r *RedisRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Refr
 		var metadata map[string]interface{}
 		if err := json.Unmarshal([]byte(metadataJSON), &metadata); err != nil {
 			if r.logger != nil {
-				r.logger.Error("retrieve failed: metadata unmarshal error",
+				r.logger.Error("retrieve failed: metadata unmarshal error", ctx,
 					"tokenID", tokenID,
 					"error", err)
 			}
@@ -343,7 +343,7 @@ func (r *RedisRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Refr
 	status = "success"
 	errorType = ""
 	if r.logger != nil {
-		r.logger.Info("retrieve: token retrieved successfully",
+		r.logger.Info("retrieve: token retrieved successfully", ctx,
 			"tokenID", tokenID)
 	}
 
@@ -377,7 +377,7 @@ func (r *RedisRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 		status = "cancelled"
 		errorType = "cancelled"
 		if r.logger != nil {
-			r.logger.Warn("revoke aborted: context cancelled",
+			r.logger.Warn("revoke aborted: context cancelled", ctx,
 				"tokenID", tokenID)
 		}
 		return ctx.Err()
@@ -388,7 +388,7 @@ func (r *RedisRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 		status = "validation_error"
 		errorType = "validation_error"
 		if r.logger != nil {
-			r.logger.Warn("revoke rejected: tokenID is empty or whitespace")
+			r.logger.Warn("revoke rejected: tokenID is empty or whitespace", ctx)
 		}
 		return ErrInvalidTokenID
 	}
@@ -400,7 +400,7 @@ func (r *RedisRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 	exists, err := r.client.Exists(ctx, tokenKey).Result()
 	if err != nil {
 		if r.logger != nil {
-			r.logger.Error("revoke failed: redis error",
+			r.logger.Error("revoke failed: redis error", ctx,
 				"tokenID", tokenID,
 				"error", err)
 		}
@@ -412,7 +412,7 @@ func (r *RedisRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 		status = "success" // idempotent: not-found is not an error
 		errorType = ""
 		if r.logger != nil {
-			r.logger.Warn("revoke: token not found",
+			r.logger.Warn("revoke: token not found", ctx,
 				"tokenID", tokenID)
 		}
 		return nil
@@ -422,7 +422,7 @@ func (r *RedisRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 	err = r.client.HSet(ctx, tokenKey, "revoked", "true").Err()
 	if err != nil {
 		if r.logger != nil {
-			r.logger.Error("revoke failed: redis hset error",
+			r.logger.Error("revoke failed: redis hset error", ctx,
 				"tokenID", tokenID,
 				"error", err)
 		}
@@ -433,7 +433,7 @@ func (r *RedisRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 	status = "success"
 	errorType = ""
 	if r.logger != nil {
-		r.logger.Info("revoke: successfully revoked",
+		r.logger.Info("revoke: successfully revoked", ctx,
 			"tokenID", tokenID)
 	}
 
@@ -468,7 +468,7 @@ func (r *RedisRefreshStore) RevokeAllForUser(ctx context.Context, userID string)
 		status = "cancelled"
 		errorType = "cancelled"
 		if r.logger != nil {
-			r.logger.Warn("revokeAllForUser aborted: context cancelled",
+			r.logger.Warn("revokeAllForUser aborted: context cancelled", ctx,
 				"userID", userID,
 				"reason", err)
 		}
@@ -480,7 +480,7 @@ func (r *RedisRefreshStore) RevokeAllForUser(ctx context.Context, userID string)
 		status = "validation_error"
 		errorType = "validation_error"
 		if r.logger != nil {
-			r.logger.Warn("revokeAllForUser rejected: userID is empty or whitespace")
+			r.logger.Warn("revokeAllForUser rejected: userID is empty or whitespace", ctx)
 		}
 		return ErrInvalidUserID
 	}
@@ -490,7 +490,7 @@ func (r *RedisRefreshStore) RevokeAllForUser(ctx context.Context, userID string)
 	tokenIDs, err := r.client.SMembers(ctx, userSetKey).Result()
 	if err != nil {
 		if r.logger != nil {
-			r.logger.Error("revokeAllForUser failed: redis smembers error",
+			r.logger.Error("revokeAllForUser failed: redis smembers error", ctx,
 				"userID", userID,
 				"error", err)
 		}
@@ -498,7 +498,7 @@ func (r *RedisRefreshStore) RevokeAllForUser(ctx context.Context, userID string)
 	}
 
 	if r.logger != nil {
-		r.logger.Debug("found tokens to revoke for user",
+		r.logger.Debug("found tokens to revoke for user", ctx,
 			"userID", userID,
 			"count", len(tokenIDs))
 	}
@@ -515,7 +515,7 @@ func (r *RedisRefreshStore) RevokeAllForUser(ctx context.Context, userID string)
 		_, err := pipe.Exec(ctx)
 		if err != nil {
 			if r.logger != nil {
-				r.logger.Error("revokeAllForUser failed: redis pipeline error",
+				r.logger.Error("revokeAllForUser failed: redis pipeline error", ctx,
 					"userID", userID,
 					"error", err)
 			}
@@ -527,7 +527,7 @@ func (r *RedisRefreshStore) RevokeAllForUser(ctx context.Context, userID string)
 	status = "success"
 	errorType = ""
 	if r.logger != nil {
-		r.logger.Info("revokeAllForUser: all tokens revoked",
+		r.logger.Info("revokeAllForUser: all tokens revoked", ctx,
 			"userID", userID,
 			"count", len(tokenIDs))
 	}
@@ -573,7 +573,7 @@ func (r *RedisRefreshStore) Cleanup(ctx context.Context) (int, error) {
 		status = "cancelled"
 		errorType = "cancelled"
 		if r.logger != nil {
-			r.logger.Warn("cleanup aborted: context cancelled")
+			r.logger.Warn("cleanup aborted: context cancelled", ctx)
 		}
 		return 0, err
 	}
@@ -595,7 +595,7 @@ func (r *RedisRefreshStore) Cleanup(ctx context.Context) (int, error) {
 		hash, err := r.client.HGetAll(ctx, key).Result()
 		if err != nil {
 			if r.logger != nil {
-				r.logger.Error("cleanup failed: redis hgetall error",
+				r.logger.Error("cleanup failed: redis hgetall error", ctx,
 					"key", key,
 					"error", err)
 			}
@@ -605,7 +605,7 @@ func (r *RedisRefreshStore) Cleanup(ctx context.Context) (int, error) {
 		expiresAtMillis, err := strconv.ParseInt(hash["expiresAt"], 10, 64)
 		if err != nil {
 			if r.logger != nil {
-				r.logger.Error("cleanup failed: invalid expiration timestamp",
+				r.logger.Error("cleanup failed: invalid expiration timestamp", ctx,
 					"key", key,
 					"error", err)
 			}
@@ -627,7 +627,7 @@ func (r *RedisRefreshStore) Cleanup(ctx context.Context) (int, error) {
 
 	if err := iter.Err(); err != nil {
 		if r.logger != nil {
-			r.logger.Error("cleanup failed: redis scan error",
+			r.logger.Error("cleanup failed: redis scan error", ctx,
 				"error", err)
 		}
 		return 0, fmt.Errorf("failed to scan tokens: %w", err)
@@ -636,13 +636,13 @@ func (r *RedisRefreshStore) Cleanup(ctx context.Context) (int, error) {
 	// ===== STEP 3: Delete Expired Tokens =====
 	if len(expiredKeys) == 0 {
 		if r.logger != nil {
-			r.logger.Debug("cleanup: no expired tokens found")
+			r.logger.Debug("cleanup: no expired tokens found", ctx)
 		}
 	} else {
 		err := r.client.Del(ctx, expiredKeys...).Err()
 		if err != nil {
 			if r.logger != nil {
-				r.logger.Error("cleanup failed: redis delete error",
+				r.logger.Error("cleanup failed: redis delete error", ctx,
 					"count", len(expiredKeys),
 					"error", err)
 			}
@@ -657,7 +657,7 @@ func (r *RedisRefreshStore) Cleanup(ctx context.Context) (int, error) {
 	status = "success"
 	errorType = ""
 	if r.logger != nil {
-		r.logger.Info("cleanup: successful",
+		r.logger.Info("cleanup: successful", ctx,
 			"count", count)
 	}
 

--- a/pkg/tokens/service.go
+++ b/pkg/tokens/service.go
@@ -170,14 +170,14 @@ func (s *Service) Start(ctx context.Context) error {
 	if !s.isRunning.CompareAndSwap(false, true) {
 		// Already running — idempotent no-op, no metric recorded
 		if s.logger != nil {
-			s.logger.Warn("start called but service already running")
+			s.logger.Warn("start called but service already running", ctx)
 		}
 		return nil // Already running, not an error
 	}
 
 	// ===== STEP 2: Log Startup =====
 	if s.logger != nil {
-		s.logger.Info("starting token service")
+		s.logger.Info("starting token service", ctx)
 	}
 
 	// ===== STEP 3: Start KeyManager =====
@@ -185,7 +185,7 @@ func (s *Service) Start(ctx context.Context) error {
 		s.isRunning.Store(false) // Revert state
 
 		if s.logger != nil {
-			s.logger.Error("failed to start token service",
+			s.logger.Error("failed to start token service", ctx,
 				"error", err)
 		}
 		return fmt.Errorf("failed to start keymanager: %w", err)
@@ -200,7 +200,7 @@ func (s *Service) Start(ctx context.Context) error {
 		s.metrics.SetGauge(metricServiceRunning, 1.0, map[string]string{})
 	}
 	if s.logger != nil {
-		s.logger.Info("token service started")
+		s.logger.Info("token service started", ctx)
 	}
 
 	return nil
@@ -217,28 +217,28 @@ func (s *Service) cleanupLoop(ctx context.Context) {
 		select {
 		case <-ticker.C:
 			if s.logger != nil {
-				s.logger.Debug("cleanup loop tick started")
+				s.logger.Debug("cleanup loop tick started", ctx)
 			}
 			// Cleanup expired refresh tokens
 			if s.logger != nil {
-				s.logger.Debug("cleanup ticker fired")
+				s.logger.Debug("cleanup ticker fired", ctx)
 			}
 			if count, err := s.refreshStore.Cleanup(ctx); err != nil {
 				if s.logger != nil {
-					s.logger.Error("refresh token cleanup failed",
+					s.logger.Error("refresh token cleanup failed", ctx,
 						"error", err)
 				}
 			} else {
 
 				if s.logger != nil {
-					s.logger.Info("refresh token cleanup completed",
+					s.logger.Info("refresh token cleanup completed", ctx,
 						"tokens", count)
 				}
 			}
 
 		case <-s.shutdownChan:
 			if s.logger != nil {
-				s.logger.Info("cleanup loop stopping")
+				s.logger.Info("cleanup loop stopping", ctx)
 			}
 			return
 		}
@@ -255,14 +255,14 @@ func (s *Service) Shutdown(ctx context.Context) error {
 	// ===== STEP 1: Check If Running (Idempotent) =====
 	if !s.isRunning.CompareAndSwap(true, false) {
 		if s.logger != nil {
-			s.logger.Warn("shutdown called but service not running")
+			s.logger.Warn("shutdown called but service not running", ctx)
 		}
 		return nil // Already stopped, not an error
 	}
 
 	// ===== STEP 2: Log Shutdown =====
 	if s.logger != nil {
-		s.logger.Info("shutting down token service")
+		s.logger.Info("shutting down token service", ctx)
 	}
 
 	// ===== STEP 3: Signal Background Goroutines =====
@@ -281,7 +281,7 @@ func (s *Service) Shutdown(ctx context.Context) error {
 	case <-ctx.Done():
 		// Timeout
 		if s.logger != nil {
-			s.logger.Warn("shutdown timeout waiting for goroutines",
+			s.logger.Warn("shutdown timeout waiting for goroutines", ctx,
 				"error", ctx.Err())
 		}
 		return ctx.Err()
@@ -290,7 +290,7 @@ func (s *Service) Shutdown(ctx context.Context) error {
 	// ===== STEP 5: Shutdown KeyManager =====
 	if err := s.keyManager.Shutdown(ctx); err != nil {
 		if s.logger != nil {
-			s.logger.Error("failed to shutdown keymanager",
+			s.logger.Error("failed to shutdown keymanager", ctx,
 				"error", err)
 		}
 		return fmt.Errorf("failed to shutdown keymanager: %w", err)
@@ -301,7 +301,7 @@ func (s *Service) Shutdown(ctx context.Context) error {
 		s.metrics.SetGauge(metricServiceRunning, 0.0, map[string]string{})
 	}
 	if s.logger != nil {
-		s.logger.Info("token service stopped")
+		s.logger.Info("token service stopped", ctx)
 	}
 
 	return nil
@@ -334,7 +334,7 @@ func (s *Service) IssueAccessToken(ctx context.Context, userID string) (string, 
 		status = "invalid_input"
 		errorType = "invalid_input"
 		if s.logger != nil {
-			s.logger.Warn("attempted to get token with empty userID")
+			s.logger.Warn("attempted to get token with empty userID", ctx)
 		}
 		return "", ErrInvalidUserID
 	}
@@ -344,7 +344,7 @@ func (s *Service) IssueAccessToken(ctx context.Context, userID string) (string, 
 		status = "not_running"
 		errorType = "not_running"
 		if s.logger != nil {
-			s.logger.Warn("service not running")
+			s.logger.Warn("service not running", ctx)
 		}
 		return "", ErrServiceNotRunning
 	}
@@ -355,7 +355,7 @@ func (s *Service) IssueAccessToken(ctx context.Context, userID string) (string, 
 		status = "cancelled"
 		errorType = "cancelled"
 		if s.logger != nil {
-			s.logger.Warn("context cancelled during token issuance",
+			s.logger.Warn("context cancelled during token issuance", ctx,
 				"userID", userID,
 				"error", err)
 		}
@@ -368,14 +368,14 @@ func (s *Service) IssueAccessToken(ctx context.Context, userID string) (string, 
 	privateKey, keyID, err := s.keyManager.GetCurrentSigningKey(ctx)
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Error("failed to get signing key",
+			s.logger.Error("failed to get signing key", ctx,
 				"userID", userID,
 				"error", err)
 		}
 		return "", fmt.Errorf("failed to get signing key: %w", err)
 	}
 	if s.logger != nil {
-		s.logger.Debug("signing key retrieved",
+		s.logger.Debug("signing key retrieved", ctx,
 			"userID", userID,
 			"keyID", keyID)
 	}
@@ -387,7 +387,7 @@ func (s *Service) IssueAccessToken(ctx context.Context, userID string) (string, 
 	tokenID, err := generateTokenID()
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Error("failed to generate token ID",
+			s.logger.Error("failed to generate token ID", ctx,
 				"userID", userID,
 				"error", err)
 		}
@@ -405,7 +405,7 @@ func (s *Service) IssueAccessToken(ctx context.Context, userID string) (string, 
 		ID:        tokenID,                       // "jti" - unique token identifier
 	}
 	if s.logger != nil {
-		s.logger.Debug("access token claims created",
+		s.logger.Debug("access token claims created", ctx,
 			"userID", userID,
 			"tokenID", tokenID,
 			"expiresAt", expiresAt)
@@ -424,7 +424,7 @@ func (s *Service) IssueAccessToken(ctx context.Context, userID string) (string, 
 
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Error("failed to sign token",
+			s.logger.Error("failed to sign token", ctx,
 				"userID", userID,
 				"keyID", keyID,
 				"error", err)
@@ -432,7 +432,7 @@ func (s *Service) IssueAccessToken(ctx context.Context, userID string) (string, 
 		return "", fmt.Errorf("failed to sign token: %w", err)
 	}
 	if s.logger != nil {
-		s.logger.Debug("access token signed",
+		s.logger.Debug("access token signed", ctx,
 			"userID", userID,
 			"tokenID", tokenID)
 	}
@@ -441,7 +441,7 @@ func (s *Service) IssueAccessToken(ctx context.Context, userID string) (string, 
 	status = "success"
 	errorType = ""
 	if s.logger != nil {
-		s.logger.Info("access token issued",
+		s.logger.Info("access token issued", ctx,
 			"userID", userID,
 			"tokenID", tokenID,
 			"keyID", keyID,
@@ -478,7 +478,7 @@ func (s *Service) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 		status = "invalid_input"
 		errorType = "invalid_input"
 		if s.logger != nil {
-			s.logger.Warn("attempted to get token with empty userID")
+			s.logger.Warn("attempted to get token with empty userID", ctx)
 		}
 		return "", ErrInvalidUserID
 	}
@@ -488,7 +488,7 @@ func (s *Service) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 		status = "not_running"
 		errorType = "not_running"
 		if s.logger != nil {
-			s.logger.Warn("service not running")
+			s.logger.Warn("service not running", ctx)
 		}
 		return "", ErrServiceNotRunning
 	}
@@ -498,7 +498,7 @@ func (s *Service) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 		status = "cancelled"
 		errorType = "cancelled"
 		if s.logger != nil {
-			s.logger.Warn("context cancelled during token issuance",
+			s.logger.Warn("context cancelled during token issuance", ctx,
 				"userID", userID,
 				"error", err)
 		}
@@ -509,14 +509,14 @@ func (s *Service) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 	privateKey, keyID, err := s.keyManager.GetCurrentSigningKey(ctx)
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Error("failed to get signing key",
+			s.logger.Error("failed to get signing key", ctx,
 				"userID", userID,
 				"error", err)
 		}
 		return "", fmt.Errorf("failed to get signing key: %w", err)
 	}
 	if s.logger != nil {
-		s.logger.Debug("signing key retrieved",
+		s.logger.Debug("signing key retrieved", ctx,
 			"userID", userID,
 			"keyID", keyID)
 	}
@@ -526,7 +526,7 @@ func (s *Service) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 	tokenID, err := generateTokenID()
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Error("failed to generate token ID",
+			s.logger.Error("failed to generate token ID", ctx,
 				"userID", userID,
 				"error", err)
 		}
@@ -558,14 +558,14 @@ func (s *Service) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 			customClaimsCount++
 		} else {
 			if s.logger != nil {
-				s.logger.Warn("attempted to override reserved claim",
+				s.logger.Warn("attempted to override reserved claim", ctx,
 					"userID", userID,
 					"claim", key)
 			}
 		}
 	}
 	if s.logger != nil {
-		s.logger.Debug("access token claims created with custom claims",
+		s.logger.Debug("access token claims created with custom claims", ctx,
 			"userID", userID,
 			"tokenID", tokenID,
 			"customClaimsCount", customClaimsCount,
@@ -579,7 +579,7 @@ func (s *Service) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 	signedToken, err := token.SignedString(privateKey)
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Error("failed to sign token with custom claims",
+			s.logger.Error("failed to sign token with custom claims", ctx,
 				"userID", userID,
 				"keyID", keyID,
 				"error", err)
@@ -587,7 +587,7 @@ func (s *Service) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 		return "", fmt.Errorf("failed to sign token: %w", err)
 	}
 	if s.logger != nil {
-		s.logger.Debug("access token with custom claims signed",
+		s.logger.Debug("access token with custom claims signed", ctx,
 			"userID", userID,
 			"tokenID", tokenID)
 	}
@@ -595,7 +595,7 @@ func (s *Service) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 	status = "success"
 	errorType = ""
 	if s.logger != nil {
-		s.logger.Info("access token with custom claims issued",
+		s.logger.Info("access token with custom claims issued", ctx,
 			"userID", userID,
 			"tokenID", tokenID,
 			"keyID", keyID,
@@ -632,7 +632,7 @@ func (s *Service) IssueRefreshToken(ctx context.Context, userID string) (string,
 		status = "invalid_input"
 		errorType = "invalid_input"
 		if s.logger != nil {
-			s.logger.Warn("attempted to get token with empty userID")
+			s.logger.Warn("attempted to get token with empty userID", ctx)
 		}
 		return "", ErrInvalidUserID
 	}
@@ -643,7 +643,7 @@ func (s *Service) IssueRefreshToken(ctx context.Context, userID string) (string,
 		status = "not_running"
 		errorType = "not_running"
 		if s.logger != nil {
-			s.logger.Warn("service not running")
+			s.logger.Warn("service not running", ctx)
 		}
 		return "", ErrServiceNotRunning
 	}
@@ -655,7 +655,7 @@ func (s *Service) IssueRefreshToken(ctx context.Context, userID string) (string,
 		status = "cancelled"
 		errorType = "cancelled"
 		if s.logger != nil {
-			s.logger.Warn("context cancelled during token issuance",
+			s.logger.Warn("context cancelled during token issuance", ctx,
 				"userID", userID,
 				"error", err)
 		}
@@ -663,7 +663,7 @@ func (s *Service) IssueRefreshToken(ctx context.Context, userID string) (string,
 	}
 
 	if s.logger != nil {
-		s.logger.Debug("issuing refresh token", "userID", userID)
+		s.logger.Debug("issuing refresh token", ctx, "userID", userID)
 	}
 
 	// ===== STEP 4: Generate Refresh Token =====
@@ -672,14 +672,14 @@ func (s *Service) IssueRefreshToken(ctx context.Context, userID string) (string,
 	refreshToken, err := generateRefreshToken()
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Error("failed to generate refresh token",
+			s.logger.Error("failed to generate refresh token", ctx,
 				"userID", userID,
 				"error", err)
 		}
 		return "", fmt.Errorf("failed to generate refresh token: %w", err)
 	}
 	if s.logger != nil {
-		s.logger.Debug("refresh token generated",
+		s.logger.Debug("refresh token generated", ctx,
 			"userID", userID)
 	}
 
@@ -703,14 +703,14 @@ func (s *Service) IssueRefreshToken(ctx context.Context, userID string) (string,
 	)
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Error("failed to store refresh token",
+			s.logger.Error("failed to store refresh token", ctx,
 				"userID", userID,
 				"error", err)
 		}
 		return "", fmt.Errorf("failed to store refresh token: %w", err)
 	}
 	if s.logger != nil {
-		s.logger.Debug("refresh token stored",
+		s.logger.Debug("refresh token stored", ctx,
 			"userID", userID,
 			"expiresAt", expiresAt)
 	}
@@ -719,7 +719,7 @@ func (s *Service) IssueRefreshToken(ctx context.Context, userID string) (string,
 	status = "success"
 	errorType = ""
 	if s.logger != nil {
-		s.logger.Info("refresh token issued",
+		s.logger.Info("refresh token issued", ctx,
 			"userID", userID,
 			"tokenID", refreshToken,
 			"expiresAt", expiresAt)
@@ -754,7 +754,7 @@ func (s *Service) IssueRefreshTokenWithMetadata(ctx context.Context, userID stri
 		status = "invalid_input"
 		errorType = "invalid_input"
 		if s.logger != nil {
-			s.logger.Warn("attempted to get token with empty userID")
+			s.logger.Warn("attempted to get token with empty userID", ctx)
 		}
 		return "", ErrInvalidUserID
 	}
@@ -764,7 +764,7 @@ func (s *Service) IssueRefreshTokenWithMetadata(ctx context.Context, userID stri
 		status = "not_running"
 		errorType = "not_running"
 		if s.logger != nil {
-			s.logger.Warn("service not running")
+			s.logger.Warn("service not running", ctx)
 		}
 		return "", ErrServiceNotRunning
 	}
@@ -776,7 +776,7 @@ func (s *Service) IssueRefreshTokenWithMetadata(ctx context.Context, userID stri
 		status = "cancelled"
 		errorType = "cancelled"
 		if s.logger != nil {
-			s.logger.Warn("context cancelled during token issuance",
+			s.logger.Warn("context cancelled during token issuance", ctx,
 				"userID", userID,
 				"error", err)
 		}
@@ -784,7 +784,7 @@ func (s *Service) IssueRefreshTokenWithMetadata(ctx context.Context, userID stri
 	}
 
 	if s.logger != nil {
-		s.logger.Debug("issuing refresh token with metadata", "userID", userID)
+		s.logger.Debug("issuing refresh token with metadata", ctx, "userID", userID)
 	}
 
 	// ===== STEP 4: Generate Refresh Token =====
@@ -793,14 +793,14 @@ func (s *Service) IssueRefreshTokenWithMetadata(ctx context.Context, userID stri
 	refreshToken, err := generateRefreshToken()
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Error("failed to generate refresh token",
+			s.logger.Error("failed to generate refresh token", ctx,
 				"userID", userID,
 				"error", err)
 		}
 		return "", fmt.Errorf("failed to generate refresh token: %w", err)
 	}
 	if s.logger != nil {
-		s.logger.Debug("refresh token generated",
+		s.logger.Debug("refresh token generated", ctx,
 			"userID", userID)
 	}
 
@@ -824,14 +824,14 @@ func (s *Service) IssueRefreshTokenWithMetadata(ctx context.Context, userID stri
 	)
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Error("failed to store refresh token with metadata",
+			s.logger.Error("failed to store refresh token with metadata", ctx,
 				"userID", userID,
 				"error", err)
 		}
 		return "", fmt.Errorf("failed to store refresh token with metadata: %w", err)
 	}
 	if s.logger != nil {
-		s.logger.Debug("refresh token with metadata stored",
+		s.logger.Debug("refresh token with metadata stored", ctx,
 			"userID", userID,
 			"metadataKeys", len(metadata),
 			"expiresAt", expiresAt)
@@ -841,7 +841,7 @@ func (s *Service) IssueRefreshTokenWithMetadata(ctx context.Context, userID stri
 	status = "success"
 	errorType = ""
 	if s.logger != nil {
-		s.logger.Info("refresh token with metadata issued",
+		s.logger.Info("refresh token with metadata issued", ctx,
 			"userID", userID,
 			"tokenID", refreshToken,
 			"expiresAt", expiresAt,
@@ -877,7 +877,7 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 		status = "invalid_input"
 		errorType = "invalid_input"
 		if s.logger != nil {
-			s.logger.Warn("attempted to get token with empty userID")
+			s.logger.Warn("attempted to get token with empty userID", ctx)
 		}
 		return "", "", ErrInvalidUserID
 	}
@@ -887,7 +887,7 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 		status = "not_running"
 		errorType = "not_running"
 		if s.logger != nil {
-			s.logger.Warn("service not running")
+			s.logger.Warn("service not running", ctx)
 		}
 		return "", "", ErrServiceNotRunning
 	}
@@ -899,7 +899,7 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 		status = "cancelled"
 		errorType = "cancelled"
 		if s.logger != nil {
-			s.logger.Warn("context cancelled during token issuance",
+			s.logger.Warn("context cancelled during token issuance", ctx,
 				"userID", userID,
 				"error", err)
 		}
@@ -907,14 +907,14 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 	}
 
 	if s.logger != nil {
-		s.logger.Debug("issuing token pair", "userID", userID)
+		s.logger.Debug("issuing token pair", ctx, "userID", userID)
 	}
 
 	// ===== STEP 4: Get Signing Key =====
 	privateKey, keyID, err := s.keyManager.GetCurrentSigningKey(ctx)
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Error("failed to get signing key",
+			s.logger.Error("failed to get signing key", ctx,
 				"userID", userID,
 				"error", err)
 		}
@@ -928,7 +928,7 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 	tokenID, err := generateTokenID()
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Error("failed to generate token ID",
+			s.logger.Error("failed to generate token ID", ctx,
 				"userID", userID,
 				"error", err)
 		}
@@ -959,7 +959,7 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Error("failed to sign token",
+			s.logger.Error("failed to sign token", ctx,
 				"userID", userID,
 				"keyID", keyID,
 				"error", err)
@@ -971,7 +971,7 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 	refreshToken, err := generateRefreshToken()
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Error("failed to generate refresh token",
+			s.logger.Error("failed to generate refresh token", ctx,
 				"userID", userID,
 				"error", err)
 		}
@@ -998,7 +998,7 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 	)
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Error("failed to store refresh token",
+			s.logger.Error("failed to store refresh token", ctx,
 				"userID", userID,
 				"error", err)
 		}
@@ -1009,7 +1009,7 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 	status = "success"
 	errorType = ""
 	if s.logger != nil {
-		s.logger.Info("token pair issued",
+		s.logger.Info("token pair issued", ctx,
 			"userID", userID,
 			"tokenID", refreshToken,
 			"expiresAt", expiresAt)
@@ -1046,7 +1046,7 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 		status = "not_running"
 		errorType = "not_running"
 		if s.logger != nil {
-			s.logger.Warn("attempted token validation while service stopped")
+			s.logger.Warn("attempted token validation while service stopped", ctx)
 		}
 		return nil, ErrServiceNotRunning
 	}
@@ -1056,14 +1056,14 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 		status = "cancelled"
 		errorType = "cancelled"
 		if s.logger != nil {
-			s.logger.Info("context cancelled during token validation",
+			s.logger.Info("context cancelled during token validation", ctx,
 				"error", err)
 		}
 		return nil, err
 	}
 
 	if s.logger != nil {
-		s.logger.Debug("validating access token")
+		s.logger.Debug("validating access token", ctx)
 	}
 
 	// ===== STEP 3: Parse JWT Token =====
@@ -1079,7 +1079,7 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 			// ===== STEP 4a: Verify Signing Method =====
 			if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
 				if s.logger != nil {
-					s.logger.Warn("token uses unexpected signing method",
+					s.logger.Warn("token uses unexpected signing method", ctx,
 						"method", token.Header["alg"])
 				}
 				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
@@ -1089,12 +1089,12 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 			kid, ok := token.Header["kid"].(string)
 			if !ok {
 				if s.logger != nil {
-					s.logger.Warn("token missing kid in header")
+					s.logger.Warn("token missing kid in header", ctx)
 				}
 				return nil, errors.New("missing kid in token header")
 			}
 			if s.logger != nil {
-				s.logger.Debug("token kid extracted from header",
+				s.logger.Debug("token kid extracted from header", ctx,
 					"kid", kid)
 			}
 
@@ -1102,14 +1102,14 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 			publicKey, err := s.keyManager.GetPublicKey(ctx, kid)
 			if err != nil {
 				if s.logger != nil {
-					s.logger.Error("failed to get public key",
+					s.logger.Error("failed to get public key", ctx,
 						"kid", kid,
 						"error", err)
 				}
 				return nil, fmt.Errorf("failed to get public key: %w", err)
 			}
 			if s.logger != nil {
-				s.logger.Debug("public key retrieved for token validation",
+				s.logger.Debug("public key retrieved for token validation", ctx,
 					"kid", kid)
 			}
 
@@ -1121,7 +1121,7 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 	// ===== STEP 5: Check Parsing Errors =====
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Warn("token parsing failed",
+			s.logger.Warn("token parsing failed", ctx,
 				"error", err)
 		}
 
@@ -1130,7 +1130,7 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 			status = "expired"
 			errorType = "expired"
 			if s.logger != nil {
-				s.logger.Warn("token expired")
+				s.logger.Warn("token expired", ctx)
 			}
 			return nil, ErrTokenExpired
 		}
@@ -1143,7 +1143,7 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 			status = "error"
 			errorType = "key_not_found"
 			if s.logger != nil {
-				s.logger.Warn("token references unknown key ID")
+				s.logger.Warn("token references unknown key ID", ctx)
 			}
 			return nil, ErrInvalidToken
 		}
@@ -1154,24 +1154,24 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 	// ===== STEP 6: Verify Token is Valid =====
 	if !token.Valid {
 		if s.logger != nil {
-			s.logger.Warn("token marked as invalid")
+			s.logger.Warn("token marked as invalid", ctx)
 		}
 		return nil, ErrInvalidToken
 	}
 	if s.logger != nil {
-		s.logger.Debug("token signature and structure validated")
+		s.logger.Debug("token signature and structure validated", ctx)
 	}
 
 	// ===== STEP 7: Extract Claims =====
 	claims, ok := token.Claims.(*jwt.RegisteredClaims)
 	if !ok {
 		if s.logger != nil {
-			s.logger.Error("failed to extract claims from token")
+			s.logger.Error("failed to extract claims from token", ctx)
 		}
 		return nil, ErrInvalidToken
 	}
 	if s.logger != nil {
-		s.logger.Debug("claims extracted from token",
+		s.logger.Debug("claims extracted from token", ctx,
 			"tokenID", claims.ID,
 			"userID", claims.Subject)
 	}
@@ -1179,14 +1179,14 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 	// ===== STEP 8: Validate Issuer =====
 	if s.issuer != "" && claims.Issuer != s.issuer {
 		if s.logger != nil {
-			s.logger.Warn("token issuer mismatch",
+			s.logger.Warn("token issuer mismatch", ctx,
 				"expected", s.issuer,
 				"actual", claims.Issuer)
 		}
 		return nil, ErrInvalidIssuer
 	}
 	if s.logger != nil {
-		s.logger.Debug("token issuer validated",
+		s.logger.Debug("token issuer validated", ctx,
 			"issuer", claims.Issuer)
 	}
 
@@ -1207,14 +1207,14 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 
 		if !validAudience {
 			if s.logger != nil {
-				s.logger.Warn("token audience mismatch",
+				s.logger.Warn("token audience mismatch", ctx,
 					"expected", s.audience,
 					"actual", claims.Audience)
 			}
 			return nil, ErrInvalidAudience
 		}
 		if s.logger != nil {
-			s.logger.Debug("token audience validated",
+			s.logger.Debug("token audience validated", ctx,
 				"audience", claims.Audience)
 		}
 	}
@@ -1223,7 +1223,7 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 	status = "success"
 	errorType = ""
 	if s.logger != nil {
-		s.logger.Info("access token validated",
+		s.logger.Info("access token validated", ctx,
 			"userID", claims.Subject,
 			"tokenID", claims.ID)
 	}
@@ -1306,7 +1306,7 @@ func (s *Service) RefreshAccessToken(ctx context.Context, refreshToken string) (
 		status = "not_running"
 		errorType = "not_running"
 		if s.logger != nil {
-			s.logger.Warn("attempted to refresh while service was stopped")
+			s.logger.Warn("attempted to refresh while service was stopped", ctx)
 		}
 		return "", ErrServiceNotRunning
 	}
@@ -1316,13 +1316,13 @@ func (s *Service) RefreshAccessToken(ctx context.Context, refreshToken string) (
 		status = "cancelled"
 		errorType = "cancelled"
 		if s.logger != nil {
-			s.logger.Info("context cancelled during token refresh")
+			s.logger.Info("context cancelled during token refresh", ctx)
 		}
 		return "", err
 	}
 
 	if s.logger != nil {
-		s.logger.Debug("attempting token refresh")
+		s.logger.Debug("attempting token refresh", ctx)
 	}
 
 	// ===== STEP 3: Input Validation =====
@@ -1330,7 +1330,7 @@ func (s *Service) RefreshAccessToken(ctx context.Context, refreshToken string) (
 		status = "invalid_input"
 		errorType = "invalid_input"
 		if s.logger != nil {
-			s.logger.Warn("empty refresh token provided")
+			s.logger.Warn("empty refresh token provided", ctx)
 		}
 		return "", ErrInvalidRefreshToken
 	}
@@ -1339,7 +1339,7 @@ func (s *Service) RefreshAccessToken(ctx context.Context, refreshToken string) (
 	token, err := s.refreshStore.Retrieve(ctx, refreshToken)
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Warn("refresh token not found in store",
+			s.logger.Warn("refresh token not found in store", ctx,
 				"error", err)
 		}
 		// Propagate specific errors, default to invalid token for generic errors
@@ -1354,7 +1354,7 @@ func (s *Service) RefreshAccessToken(ctx context.Context, refreshToken string) (
 	}
 
 	if s.logger != nil {
-		s.logger.Debug("refresh token retrieved from store",
+		s.logger.Debug("refresh token retrieved from store", ctx,
 			"userID", token.UserID,
 			"tokenID", token.TokenID)
 	}
@@ -1364,7 +1364,7 @@ func (s *Service) RefreshAccessToken(ctx context.Context, refreshToken string) (
 		status = "expired"
 		errorType = "expired"
 		if s.logger != nil {
-			s.logger.Warn("refresh token has expired",
+			s.logger.Warn("refresh token has expired", ctx,
 				"tokenID", refreshToken,
 				"expiredAt", token.ExpiresAt)
 		}
@@ -1380,7 +1380,7 @@ func (s *Service) RefreshAccessToken(ctx context.Context, refreshToken string) (
 		status = "revoked"
 		errorType = "revoked"
 		if s.logger != nil {
-			s.logger.Warn("refresh token has been revoked",
+			s.logger.Warn("refresh token has been revoked", ctx,
 				"tokenID", refreshToken)
 		}
 		return "", ErrTokenRevoked
@@ -1390,7 +1390,7 @@ func (s *Service) RefreshAccessToken(ctx context.Context, refreshToken string) (
 	newAccessToken, err := s.IssueAccessToken(ctx, token.UserID)
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Error("failed to issue new access token",
+			s.logger.Error("failed to issue new access token", ctx,
 				"userID", token.UserID,
 				"error", err)
 		}
@@ -1401,7 +1401,7 @@ func (s *Service) RefreshAccessToken(ctx context.Context, refreshToken string) (
 	status = "success"
 	errorType = ""
 	if s.logger != nil {
-		s.logger.Info("access token refreshed",
+		s.logger.Info("access token refreshed", ctx,
 			"userID", token.UserID,
 			"tokenID", refreshToken)
 	}
@@ -1434,7 +1434,7 @@ func (s *Service) RevokeRefreshToken(ctx context.Context, tokenID string) error 
 	if !s.isRunning.Load() {
 		status = "not_running"
 		if s.logger != nil {
-			s.logger.Warn("attempted to revoke token while service stopped")
+			s.logger.Warn("attempted to revoke token while service stopped", ctx)
 		}
 		return ErrServiceNotRunning
 	}
@@ -1443,7 +1443,7 @@ func (s *Service) RevokeRefreshToken(ctx context.Context, tokenID string) error 
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
 		if s.logger != nil {
-			s.logger.Info("context cancelled during token revocation")
+			s.logger.Info("context cancelled during token revocation", ctx)
 		}
 		return err
 	}
@@ -1452,7 +1452,7 @@ func (s *Service) RevokeRefreshToken(ctx context.Context, tokenID string) error 
 	if tokenID == "" {
 		status = "invalid_input"
 		if s.logger != nil {
-			s.logger.Warn("empty token ID provided for revocation")
+			s.logger.Warn("empty token ID provided for revocation", ctx)
 		}
 		return ErrInvalidRefreshToken
 	}
@@ -1462,7 +1462,7 @@ func (s *Service) RevokeRefreshToken(ctx context.Context, tokenID string) error 
 	if err != nil {
 		if s.logger != nil {
 
-			s.logger.Error("failed to revoke refresh token",
+			s.logger.Error("failed to revoke refresh token", ctx,
 				"tokenID", tokenID,
 				"error", err)
 		}
@@ -1472,7 +1472,7 @@ func (s *Service) RevokeRefreshToken(ctx context.Context, tokenID string) error 
 	// ===== STEP 5: Record Success and Log =====
 	status = "success"
 	if s.logger != nil {
-		s.logger.Info("refresh token revoked",
+		s.logger.Info("refresh token revoked", ctx,
 			"tokenID", tokenID)
 	}
 
@@ -1503,7 +1503,7 @@ func (s *Service) RevokeAllUserTokens(ctx context.Context, userID string) error 
 	if !s.isRunning.Load() {
 		status = "not_running"
 		if s.logger != nil {
-			s.logger.Warn("attempted to revoke all user tokens while service stopped")
+			s.logger.Warn("attempted to revoke all user tokens while service stopped", ctx)
 		}
 		return ErrServiceNotRunning
 	}
@@ -1512,7 +1512,7 @@ func (s *Service) RevokeAllUserTokens(ctx context.Context, userID string) error 
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
 		if s.logger != nil {
-			s.logger.Info("context cancelled during bulk token revocation",
+			s.logger.Info("context cancelled during bulk token revocation", ctx,
 				"error", err)
 		}
 		return err
@@ -1522,7 +1522,7 @@ func (s *Service) RevokeAllUserTokens(ctx context.Context, userID string) error 
 	if userID == "" {
 		status = "invalid_input"
 		if s.logger != nil {
-			s.logger.Warn("empty user ID provided for bulk revocation")
+			s.logger.Warn("empty user ID provided for bulk revocation", ctx)
 		}
 		return ErrInvalidUserID // Note: Different error than single revoke
 	}
@@ -1531,7 +1531,7 @@ func (s *Service) RevokeAllUserTokens(ctx context.Context, userID string) error 
 	err := s.refreshStore.RevokeAllForUser(ctx, userID)
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Error("failed to revoke all user tokens",
+			s.logger.Error("failed to revoke all user tokens", ctx,
 				"userID", userID,
 				"error", err)
 		}
@@ -1541,7 +1541,7 @@ func (s *Service) RevokeAllUserTokens(ctx context.Context, userID string) error 
 	// ===== STEP 5: Record Success and Log =====
 	status = "success"
 	if s.logger != nil {
-		s.logger.Info("all refresh tokens revoked for user",
+		s.logger.Info("all refresh tokens revoked for user", ctx,
 			"userID", userID)
 	}
 
@@ -1575,7 +1575,7 @@ func (s *Service) IntrospectToken(ctx context.Context, token string) (*TokenMeta
 	if !s.isRunning.Load() {
 		status = "not_running"
 		if s.logger != nil {
-			s.logger.Warn("attempted to introspect token while service is stopped")
+			s.logger.Warn("attempted to introspect token while service is stopped", ctx)
 		}
 		return nil, ErrServiceNotRunning
 	}
@@ -1584,20 +1584,20 @@ func (s *Service) IntrospectToken(ctx context.Context, token string) (*TokenMeta
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
 		if s.logger != nil {
-			s.logger.Info("context cancelled during token introspection")
+			s.logger.Info("context cancelled during token introspection", ctx)
 		}
 		return nil, err
 	}
 
 	if s.logger != nil {
-		s.logger.Debug("introspecting token")
+		s.logger.Debug("introspecting token", ctx)
 	}
 
 	// ===== STEP 3: Input Validation =====
 	if token == "" {
 		status = "invalid_input"
 		if s.logger != nil {
-			s.logger.Warn("empty token provided for introspection")
+			s.logger.Warn("empty token provided for introspection", ctx)
 		}
 		return nil, ErrInvalidRefreshToken
 	}
@@ -1608,7 +1608,7 @@ func (s *Service) IntrospectToken(ctx context.Context, token string) (*TokenMeta
 		// Return inactive metadata instead of error — introspect never errors on unknown tokens
 		status = "success"
 		if s.logger != nil {
-			s.logger.Info("token not found during introspection",
+			s.logger.Info("token not found during introspection", ctx,
 				"error", err)
 		}
 		return &TokenMetadata{
@@ -1627,7 +1627,7 @@ func (s *Service) IntrospectToken(ctx context.Context, token string) (*TokenMeta
 	if refreshToken.ExpiresAt.Before(now) {
 		status = "success"
 		if s.logger != nil {
-			s.logger.Info("introspect token is expired",
+			s.logger.Info("introspect token is expired", ctx,
 				"token", token,
 				"expiredAt", refreshToken.ExpiresAt)
 		}
@@ -1644,7 +1644,7 @@ func (s *Service) IntrospectToken(ctx context.Context, token string) (*TokenMeta
 	if refreshToken.Revoked {
 		status = "success"
 		if s.logger != nil {
-			s.logger.Info("introspected token is revoked",
+			s.logger.Info("introspected token is revoked", ctx,
 				"tokenID", token)
 		}
 
@@ -1660,7 +1660,7 @@ func (s *Service) IntrospectToken(ctx context.Context, token string) (*TokenMeta
 	// ===== STEP 6: Record Success and Return Active Token Metadata =====
 	status = "success"
 	if s.logger != nil {
-		s.logger.Info("token introspection successfully",
+		s.logger.Info("token introspection successfully", ctx,
 			"tokenID", token,
 			"userID", refreshToken.UserID,
 			"active", true)
@@ -1698,7 +1698,7 @@ func (s *Service) CleanupExpiredTokens(ctx context.Context) (int, error) {
 	if !s.isRunning.Load() {
 		status = "not_running"
 		if s.logger != nil {
-			s.logger.Warn("attempted cleanup while service stopped")
+			s.logger.Warn("attempted cleanup while service stopped", ctx)
 		}
 		return 0, ErrServiceNotRunning
 	}
@@ -1707,7 +1707,7 @@ func (s *Service) CleanupExpiredTokens(ctx context.Context) (int, error) {
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
 		if s.logger != nil {
-			s.logger.Info("context cancelled during cleanup",
+			s.logger.Info("context cancelled during cleanup", ctx,
 				"error", err)
 		}
 		return 0, err
@@ -1717,7 +1717,7 @@ func (s *Service) CleanupExpiredTokens(ctx context.Context) (int, error) {
 	count, err := s.refreshStore.Cleanup(ctx)
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Error("failed to cleanup expired tokens",
+			s.logger.Error("failed to cleanup expired tokens", ctx,
 				"error", err)
 		}
 		return 0, fmt.Errorf("cleanup failed: %w", err)
@@ -1726,7 +1726,7 @@ func (s *Service) CleanupExpiredTokens(ctx context.Context) (int, error) {
 	// ===== STEP 4: Record Success and Log =====
 	status = "success"
 	if s.logger != nil {
-		s.logger.Info("expired tokens cleaned up",
+		s.logger.Info("expired tokens cleaned up", ctx,
 			"deleted", count)
 	}
 


### PR DESCRIPTION
## Summary

- Adds `pkg/logging/correlation.go` — `WithCorrelationID` / `GetCorrelationID` context helpers with unexported key type to prevent external bypass
- Adds `pkg/logging/correlation_handler.go` — `CorrelationIDHandler` slog.Handler wrapper that injects `correlation_id` from context into every record; field is omitted when no ID is present (background ops produce no spurious fields)
- Updates `pkg/logging/slog_adapter.go` — all four methods detect `context.Context` as first variadic arg and route to `*Context` slog methods; adds `NewCorrelationJSONLogger` / `NewCorrelationTextLogger` convenience constructors
- Wires `ctx` through all internal component logger calls across `pkg/tokens`, `pkg/storage`, `pkg/keymanager`
- Updates `cleanupExpiredKeys` and `GetJWKS` (interface + implementation + mock + tests) to accept `context.Context`
- Adds `examples/correlation-example/` — stdlib HTTP server demonstrating end-to-end middleware → login → refresh → validate with correlated logs
- Adds README Correlation ID section under Observability Integration
- 18 new specs; zero breaking changes to the `Logger` interface

Closes #62

## Test plan

- [ ] `ginkgo -r --race pkg/logging/` — 98 specs green
- [ ] `ginkgo -r --race --skip-package=integration pkg/keymanager pkg/tokens pkg/storage pkg/logging pkg/metrics` — all suites green
- [ ] `ginkgo -r --race --timeout=180s --randomize-all --tags=integration ./pkg/tokens/integration/...` — 22 specs green
- [ ] `go build ./...` — clean