### PR TITLE
Advance to v0.3.0: correlation ID logging, context propagation, Redis integration tests, tracing scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## [Unreleased] — v0.2.x
+## [Unreleased] — v0.4.0
+
+### Added
+
+- **`pkg/tracing` package** — `Tracer` and `Span` interfaces defining the distributed tracing contract. `SpanOption` functional options pattern for span configuration. `StatusCode` (`Unset`, `Error`, `OK`) and `SpanKind` (`Internal`, `Server`, `Client`, `Producer`, `Consumer`) enumerations with `String()` methods. `WithAttributes` and `WithSpanKind` option constructors.
+
+- **`NoOpTracer` / `NoOpSpan`** — zero-allocation no-op implementations; safe to use when tracing is disabled. 36 tests covering constructor, span creation, all span methods, concurrency, and edge cases; race-detection clean.
+
+- **`MockTracer` / `MockSpan`** — gomock mocks generated via `go:generate` directive in `pkg/tracing/interface.go`; available in `internal/testutil/mock_tracing.go` for dependency injection in component tests.
+
+- **`pkg/tracing` included in CI** — added to the unit test command in both `.github/workflows/CI.yml` and `run-ci-locally.sh`.
+
+---
+
+## [v0.3.0] — 2026-04-14
 
 ### Added
 
@@ -20,11 +34,21 @@ All notable changes to this project will be documented in this file.
 
 - **Prometheus metrics wired into all example `main.go` files** — all three examples now construct `metrics.NewPrometheusMetrics`, pass it to every constructor, and expose a `/metrics` endpoint.
 
+- **Correlation ID logging** — `logging.WithCorrelationID(ctx, id)` and `logging.GetCorrelationID(ctx)` context helpers with an unexported key type that prevents collisions with external packages. `CorrelationIDHandler` wraps any `slog.Handler` and injects a `correlation_id` field into every log record when a correlation ID is present in the context. `SlogAdapter` now routes to slog's `*Context()` methods when `context.Context` is passed as the first variadic arg. `NewCorrelationJSONLogger` and `NewCorrelationTextLogger` convenience constructors pre-wire the handler. `examples/correlation-example/main.go` demonstrates end-to-end HTTP middleware usage.
+
+- **All internal logging call sites pass `ctx`** — every `logger.Info/Debug/Warn/Error` call in `pkg/keymanager`, `pkg/tokens`, and `pkg/storage` now forwards the in-scope `context.Context` as the first variadic arg, enabling correlation ID injection at all component boundaries without any Logger interface changes.
+
+- **Context cancellation guard in `GetJWKS`** — returns the context error immediately after the running check, before acquiring the read lock.
+
+- **Context cancellation guard in `cleanupExpiredKeys`** — logs a warning and returns early when the context is already cancelled at sweep time.
+
+- **Redis integration tests** — `pkg/tokens/integration` suite using miniredis covers distributed token refresh, revocation, and cleanup across all RefreshStore backends (closes #60).
+
 ### Changed
 
 - **`ErrKeyNotFound` in `ValidateAccessToken` maps to `ErrInvalidToken`** — a token referencing an unknown `kid` now returns `ErrInvalidToken` (was `ErrInvalidSignature`, which was semantically incorrect for a missing-key condition).
 
-- **`KeyManager` interface requires context** — `GetCurrentSigningKey` and `GetPublicKey` signatures changed to accept `context.Context`. Any custom `KeyManager` implementation must be updated.
+- **`KeyManager` interface requires context on all read methods** — `GetCurrentSigningKey`, `GetPublicKey`, and `GetJWKS` signatures now all accept `context.Context`. Any custom `KeyManager` implementation must be updated.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@
   - Structured logging for audit trail
   - **122 total storage tests** (61 × 2 implementations)
 
-### 🚧 In Development
+### 🚧 In Development (v0.4.0)
 
-- **OpenTelemetry**: Distributed tracing integration with span creation and context propagation across token operations
+- **OpenTelemetry / Distributed Tracing**: `pkg/tracing` interfaces (`Tracer`, `Span`) and `NoOpTracer` are scaffolded. Full wiring into KeyManager, TokenService, and RefreshStore — with an OpenTelemetry adapter — is planned for v0.4.0.
 
 ## Architecture Highlights
 
@@ -666,7 +666,7 @@ github.com/aetomala/jwtauth/
 
 ### Test Coverage
 
-**Current**: ~547 comprehensive tests across KeyManager, TokenService, RefreshStore, Metrics, and Logging, all passing with race detection (KeyManager ~90%, TokenService ~87%, RefreshStore 100%, Metrics 100%, Logging 100%)
+**Current**: 605 comprehensive tests across KeyManager, TokenService, RefreshStore, Metrics, Logging, and Tracing, all passing with race detection (KeyManager ~90%, TokenService ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%)
 
 **KeyManager** (3 test suites — 125 total specs):
 - **9-phase Manager tests** (52 specs, MockKeyStore — no I/O):
@@ -801,7 +801,7 @@ Tests follow **progressive phase-based development**:
 - ✅ Comprehensive test coverage with race detection
 - ✅ Architecture documentation
 
-### v0.2.0 (Current - Beta)
+### v0.2.0 ✅ Complete
 - ✅ TokenService: JWT creation with RS256 signing
 - ✅ TokenService: Lifecycle management (Start/Shutdown/IsRunning)
 - ✅ TokenService: Claims management with custom claims support and reserved claim protection
@@ -810,28 +810,35 @@ Tests follow **progressive phase-based development**:
 - ✅ TokenService: Token revocation — single and bulk (RevokeRefreshToken, RevokeAllUserTokens)
 - ✅ TokenService: Token introspection per RFC 7662 (IntrospectToken)
 - ✅ TokenService: Manual cleanup sweep (CleanupExpiredTokens)
-- ✅ TokenService: Clock skew tolerance (`ClockSkew` field, `jwt.WithLeeway()` integration)
-- ✅ TokenService: `ValidateAccessTokenWithClaims` — registered and custom claims returned after validation
-- ✅ TokenService: Comprehensive test coverage (153 tests, ~87% statement coverage, all passing with race detection)
-- ✅ RefreshStore: Shared test suite pattern (51 tests, eliminates duplication, runs against all implementations)
+- ✅ RefreshStore: Shared test suite pattern (eliminates duplication, runs against all implementations)
 - ✅ RefreshStore: MemoryRefreshStore with defensive copying and concurrent safety
 - ✅ RefreshStore: RedisRefreshStore for distributed deployments with go-redis/v9
-- ✅ RefreshStore: Comprehensive test coverage (170 tests across 9 phases, 100% statement coverage, race-detection clean)
-- ✅ Prometheus metrics adapter (`metrics.NewPrometheusMetrics`) with 22 pre-registered jwtauth metrics, 100% test coverage
+- ✅ Prometheus metrics adapter (`metrics.NewPrometheusMetrics`) with 22 pre-registered jwtauth metrics
 - ✅ KeyStore interface extracted from KeyManager — `DiskKeyStore` for single-instance, `RedisKeyStore` for distributed deployments
-- ✅ `RedisKeyStore` — Redis-backed KeyStore using `ks:pem:<id>` / `ks:meta:<id>` layout, atomic Pipeline writes, SCAN-based LoadAll
+
+### v0.3.0 (Current — Beta)
+- ✅ TokenService: Clock skew tolerance (`ClockSkew` field, `jwt.WithLeeway()` integration)
+- ✅ TokenService: `ValidateAccessTokenWithClaims` — registered and custom claims returned after validation
 - ✅ Wire metrics into all components — KeyStore, Manager, TokenService, RefreshStore with `error_type` label and context propagation
 - ✅ Example middleware returns specific JSON error codes (`token_expired`, `token_revoked`, etc.) via sentinel error mapping
+- ✅ `KeyManager` interface extended with context on all read methods (`GetCurrentSigningKey`, `GetPublicKey`, `GetJWKS`)
+- ✅ Correlation ID logging — `CorrelationIDHandler`, `WithCorrelationID`/`GetCorrelationID` helpers, `NewCorrelationJSONLogger`/`NewCorrelationTextLogger`, context-aware `SlogAdapter`
+- ✅ All internal logging call sites forward `ctx` — correlation ID injection works across all component boundaries
+- ✅ Context cancellation guards in `GetJWKS` and `cleanupExpiredKeys`
+- ✅ Redis integration tests via miniredis covering distributed token operations end-to-end
 
-### v0.3.0 (Beta)
-- 🚧 StatsD and CloudWatch metrics adapters
-- 🚧 OpenTelemetry distributed tracing
+### v0.4.0 (Next)
+- ✅ `pkg/tracing` interfaces scaffolded — `Tracer`, `Span`, `SpanOption`, `StatusCode`, `SpanKind`
+- ✅ `NoOpTracer` / `NoOpSpan` implementations (36 tests, race-detection clean)
+- ✅ `MockTracer` / `MockSpan` generated for dependency injection in component tests
+- 🚧 Wire tracing into KeyManager, TokenService, and RefreshStore
+- 🚧 OpenTelemetry adapter (`pkg/tracing/otel`) bridging `pkg/tracing.Tracer` to `go.opentelemetry.io/otel`
 
 ### v1.0.0 (Stable)
 - API stability guarantee
 - Production-ready for all components
 - Comprehensive documentation
-- OpenTelemetry integration
+- OpenTelemetry integration complete
 - Performance benchmarks
 
 ## Architecture
@@ -922,7 +929,7 @@ Built by a Senior Platform Engineer with 28 years of experience in distributed s
 ---
 
 **Status**: Beta (Active Development)
-**Version**: 0.2.0-beta
-**Components**: KeyManager ✅ | TokenService (Beta) 🟡 | RefreshStore (Memory + Redis) ✅ | Metrics (Prometheus) ✅
-**Test Coverage**: 525 tests (KeyManager ~90%, TokenService ~87%, RefreshStore 100%, Metrics 100%, Logging 100%), all passing, race-detection enabled
-**Last Updated**: April 6, 2026
+**Version**: 0.3.0-beta
+**Components**: KeyManager ✅ | TokenService (Beta) 🟡 | RefreshStore (Memory + Redis) ✅ | Metrics (Prometheus) ✅ | Logging (Correlation ID) ✅ | Tracing (scaffold) 🚧
+**Test Coverage**: 605 tests (KeyManager ~90%, TokenService ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%), all passing, race-detection enabled
+**Last Updated**: April 14, 2026

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -905,7 +905,7 @@ Catches:
   - Ensures semantic equivalence across backends
   - Easy to add new implementations
 
-### Phase 5: Metrics Wiring and KeyStore Abstraction (In Progress)
+### Phase 5: Metrics Wiring and KeyStore Abstraction ✅ Complete
 - ✅ Prometheus adapter with `/metrics` endpoint (`PrometheusMetrics`)
 - ✅ `MemoryRefreshStore` and `RedisRefreshStore` fully instrumented
   - Counter + duration on every operation exit path
@@ -919,13 +919,18 @@ Catches:
   - `MockKeyStore` generated via gomock
 - ✅ Wire `PrometheusMetrics` into TokenService — deferred closure pattern with `error_type` label, context propagation
 - ✅ `RedisKeyStore` implementation — `ks:pem:<id>` / `ks:meta:<id>` Redis layout, atomic Pipeline writes, SCAN-based `LoadAll`, full metrics with `storage_backend: "redis"`
-- ⏳ StatsD integration (Datadog, Graphite compatible)
-- ⏳ CloudWatch metrics for AWS environments
+- ✅ Correlation ID logging — `CorrelationIDHandler` wraps any `slog.Handler`; `WithCorrelationID`/`GetCorrelationID` context helpers; `SlogAdapter` context-aware routing; `NewCorrelationJSONLogger`/`NewCorrelationTextLogger` convenience constructors
+- ✅ All component logging call sites forward `ctx` — correlation ID propagates through KeyManager, TokenService, and RefreshStore without Logger interface changes
+- ✅ `KeyManager` interface extended with context on all read methods (`GetCurrentSigningKey`, `GetPublicKey`, `GetJWKS`)
+- ✅ Context cancellation guards in `GetJWKS` and `cleanupExpiredKeys` with warning log on early return
+- ✅ Redis integration tests via miniredis (`pkg/tokens/integration`) covering distributed token operations end-to-end
 
-### Phase 6: OpenTelemetry (Future)
-- ⏳ Distributed tracing
-- ⏳ Span creation across token operations
-- ⏳ Context propagation
+### Phase 6: Distributed Tracing (v0.4.0)
+- ✅ `pkg/tracing` — `Tracer` and `Span` interfaces defined; `SpanOption` functional options; `StatusCode` and `SpanKind` enumerations
+- ✅ `NoOpTracer` / `NoOpSpan` — zero-allocation implementations; 36 tests, race-detection clean
+- ✅ `MockTracer` / `MockSpan` generated via gomock for dependency injection in component tests
+- ⏳ Wire tracing into KeyManager, TokenService, and RefreshStore
+- ⏳ OpenTelemetry adapter (`pkg/tracing/otel`) bridging `pkg/tracing.Tracer` to `go.opentelemetry.io/otel`
 
 ---
 
@@ -1022,6 +1027,6 @@ func (c *Component) Operation() error {
 
 ---
 
-**Last Updated**: April 6, 2026
-**Version**: 0.2.0-beta
-**Status**: Active Development (KeyManager + DiskKeyStore + RedisKeyStore + RefreshStore [Memory + Redis] + Metrics [Prometheus] stable and fully instrumented; TokenService metrics wiring in progress)
+**Last Updated**: April 14, 2026
+**Version**: 0.3.0-beta
+**Status**: Active Development (KeyManager + DiskKeyStore + RedisKeyStore + RefreshStore [Memory + Redis] + Metrics [Prometheus] + Logging [Correlation ID] stable and fully instrumented; Distributed Tracing interfaces scaffolded — full wiring planned for v0.4.0)


### PR DESCRIPTION
## Summary

- Closes out v0.3.0: full Prometheus metrics wiring, correlation ID logging (`CorrelationIDHandler`, `SlogAdapter` context-aware routing, `NewCorrelationJSONLogger`/`NewCorrelationTextLogger`), `GetJWKS(ctx)` interface change, context cancellation guards in `GetJWKS` and `cleanupExpiredKeys`, all internal logging call sites forwarding `ctx`, Redis integration tests via miniredis
- Scaffolds v0.4.0: `pkg/tracing` interfaces (`Tracer`, `Span`, `NoOpTracer`, `NoOpSpan`, MockTracer/MockSpan), CI inclusion
- Updates CHANGELOG (v0.3.0 closed, v0.4.0 unreleased), README (version, test count, roadmap), and ARCHITECTURE docs

## Test plan

- [ ] All 605 unit tests pass with race detection
- [ ] 22 integration tests pass (miniredis)
- [ ] golangci-lint clean
- [ ] CI green on push