### PR TITLE
Merge dev into main: rebranding, logging docs, correlation-example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,18 @@ All notable changes to this project will be documented in this file.
 
 - **`pkg/tracing` included in CI** — added to the unit test command in both `.github/workflows/CI.yml` and `run-ci-locally.sh`.
 
+### Documentation
+
+- **`README.md` — "Why This Library?" rewrite** — new positioning statement (authz layer, not authn), comparison vs. `golang-jwt/jwt` (build-vs-buy table), vs. framework JWT middleware (`gin-jwt`, `echo-jwt`) — previously missing entirely, vs. `lestrrat-go/jwx` / `go-jose/go-jose` JOSE toolkits, concrete security guarantees block (algorithm confusion, reserved claim protection, 10 sentinel errors, instant revocation), horizontal scale path table (`DiskKeyStore`+`MemoryRefreshStore` → `RedisKeyStore`+`RedisRefreshStore`), and "What jwtauth is not" closing paragraph.
+
+- **`pkg/logging/README.md` — brought up to date** — corrected "3 log levels" to 4, added `Debug` level section with examples, updated Quick Start to recommend `NewCorrelationJSONLogger` as the production default, added full Correlation ID section (setup, HTTP middleware pattern, output examples, log aggregator filtering, and API reference table), fixed third-party adapter examples for Zap and Zerolog (both were missing the `Debug` method and would not satisfy the `Logger` interface), fixed broken `See Also` link.
+
+- **`doc/ARCHITECTURE.md` — correlation ID and updated examples** — added `correlation-example/` to the project structure file tree, added Correlation ID subsection to the Logging section explaining the `ctx`-as-first-kwarg convention and `CorrelationIDHandler` wiring, updated the Integration Pattern code example to pass `ctx` as the first logger kwarg.
+
+- **`examples/correlation-example/README.md`** — new file; full README matching the structure of Gin/Chi/Echo example READMEs. Covers setup, API testing with curl and expected JSON log output, implementation details (logger choice, `withCorrelation` middleware, `ctx`-as-first-kwarg convention, auto-generated IDs), and how to apply the same pattern to Gin, Chi, or Echo.
+
+- **`examples/README.md`** — added Correlation ID Example entry, cross-reference note in the Common Pattern section, updated Framework Comparison table with a Correlation ID column, corrected title (jwtauth is an engine, not a framework).
+
 ---
 
 ## [v0.3.0] — 2026-04-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] — v0.4.0
 
+### Changed
+
+- **`tokens.Service` → `tokens.Manager`** — The core token lifecycle type is renamed. Update all call sites:
+  - `tokens.NewService(tokens.ServiceConfig{...})` → `tokens.NewManager(tokens.ManagerConfig{...})`
+  - `tokens.ConfigDefault()` → `tokens.DefaultManagerConfig()`
+  - `tokens.ErrServiceNotRunning` → `tokens.ErrManagerNotRunning`
+  - `*tokens.Service` type references → `*tokens.Manager`
+
+- **`AuthMiddleware` → `BearerMiddleware`** in all example middleware packages (`examples/gin-example/middleware`, `examples/chi-example/auth`, `examples/echo-example/middleware`). Rename call sites accordingly.
+
 ### Added
 
 - **`pkg/tracing` package** — `Tracer` and `Span` interfaces defining the distributed tracing contract. `SpanOption` functional options pattern for span configuration. `StatusCode` (`Unset`, `Error`, `OK`) and `SpanKind` (`Internal`, `Server`, `Client`, `Producer`, `Consumer`) enumerations with `String()` methods. `WithAttributes` and `WithSpanKind` option constructors.
@@ -22,9 +32,9 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- **`ServiceConfig.ClockSkew time.Duration`** — leeway applied to `exp` and `nbf` validation via `jwt.WithLeeway()`. Zero (the default) means strict validation. Negative values are rejected with `ErrInvalidConfig` at construction time.
+- **`ManagerConfig.ClockSkew time.Duration`** — leeway applied to `exp` and `nbf` validation via `jwt.WithLeeway()`. Zero (the default) means strict validation. Negative values are rejected with `ErrInvalidConfig` at construction time.
 
-- **`Service.ValidateAccessTokenWithClaims(ctx, token)`** — validates an access token and returns both the registered claims (`*jwt.RegisteredClaims`) and application-defined custom claims (`map[string]interface{}`). Reserved JWT fields (`sub`, `exp`, `nbf`, `iat`, `jti`, `iss`, `aud`) are excluded from the custom map. Uses `ParseUnverified` after signature verification — no second key-manager round-trip.
+- **`Manager.ValidateAccessTokenWithClaims(ctx, token)`** — validates an access token and returns both the registered claims (`*jwt.RegisteredClaims`) and application-defined custom claims (`map[string]interface{}`). Reserved JWT fields (`sub`, `exp`, `nbf`, `iat`, `jti`, `iss`, `aud`) are excluded from the custom map. Uses `ParseUnverified` after signature verification — no second key-manager round-trip.
 
 - **`error_type` label on all counter metrics** — follows the OpenTelemetry `error.type` semantic convention. Value is `""` on success and mirrors the `status` label value on failure. Added to: `tokens_issued_total`, `tokens_validated_total`, `tokens_refreshed_total`, `storage_operations_total`, `keystore_operations_total`, `key_rotations_total`, `key_signing_operations_total`, `key_validation_operations_total`.
 

--- a/README.md
+++ b/README.md
@@ -756,41 +756,83 @@ Tests follow **progressive phase-based development**:
 
 ## Why This Library?
 
-### Concrete Differentiators
+`jwtauth` occupies a specific layer: it takes a verified subject ID and manages everything after — signing, key rotation, refresh token lifecycle, and revocation. Identity verification (password check, OAuth exchange, SAML assertion) is out of scope and belongs in the layer above.
 
-1. **Algorithm confusion prevented at the library level** — `ValidateAccessToken` performs a `*jwt.SigningMethodRSA` type assertion before any key lookup. HS256, ECDSA, and `none` are rejected unconditionally — not configurably. There is no option to weaken this.
+If that's your gap, here's what you'd be comparing against:
 
-2. **Custom claims round-trip without raw token re-parsing** — `IssueAccessTokenWithClaims` embeds application-defined fields, and `ValidateAccessTokenWithClaims` returns them as `map[string]interface{}` after verifying the signature. Handlers never need to base64-decode the token or type-assert `MapClaims` themselves.
+---
 
-3. **Zero-downtime key rotation** — `KeyManager` keeps the previous key valid for an overlap period (default 1 hour) while signing all new tokens with the rotated key. Tokens issued before rotation continue to validate. No service restart or forced re-login is required.
+### vs. `golang-jwt/jwt` — building the engine yourself
 
-4. **Clock skew tolerance without inflating TTLs** — the `ClockSkew` field on `ManagerConfig` applies `jwt.WithLeeway()` to `exp` and `nbf` validation. Distributed deployments with NTP drift work correctly without extending access token lifetimes.
+`golang-jwt/jwt` signs and validates tokens against a key you supply. It does exactly one thing and does it well. Most teams start here and then spend weeks building the surrounding machinery:
 
-5. **10 granular sentinel errors, all `errors.Is()`-compatible** — callers can distinguish `ErrTokenExpired` from `ErrTokenRevoked` from `ErrInvalidAudience` without string matching. Middleware can return specific JSON error codes (`token_expired`, `token_revoked`, `invalid_audience`) that clients can act on.
+| What you build yourself | What jwtauth provides |
+|---|---|
+| Key generation and storage | `KeyManager` with `DiskKeyStore` / `RedisKeyStore` |
+| Zero-downtime key rotation + overlap | Built in — old key stays valid during overlap period |
+| Refresh token storage and lookup | `MemoryRefreshStore` / `RedisRefreshStore` |
+| Revocation (single token, all user sessions) | `RevokeRefreshToken`, `RevokeAllUserTokens` |
+| Custom claims round-trip without re-parsing | `IssueAccessTokenWithClaims` + `ValidateAccessTokenWithClaims` |
+| Clock skew tolerance for distributed deployments | `ManagerConfig.ClockSkew` |
+| 22 Prometheus metrics across all operations | Pre-registered, zero config |
+| 10 typed sentinel errors for middleware logic | `ErrTokenExpired`, `ErrTokenRevoked`, `ErrInvalidAudience`, … |
 
-6. **Stateful refresh layer with instant revocation** — `RefreshStore` tracks every refresh token by ID and user. `RevokeAllUserTokens` invalidates all sessions for a compromised account in a single call — no waiting for expiry.
+**jwtauth is what you'd build on top of golang-jwt after a few months in production.**
 
-7. **Observability at every exit path** — a deferred closure pattern records `status` and `error_type` labels at every return, including error paths. No silent failures. The `error_type` label follows the OpenTelemetry `error.type` semantic convention for interoperability with OTEL-based pipelines.
+---
 
-8. **JWKS endpoint ready** — `KeyManager.GetJWKS()` returns an RFC 7517-compliant key set that external verifiers (API gateways, other services) can consume without calling your signing service.
+### vs. framework JWT middleware (`gin-jwt`, `echo-jwt`, similar)
 
-### vs. golang-jwt/jwt
+Framework-specific JWT packages bundle signing, validation, and middleware into a single dependency. They're the fastest path to a working login endpoint but carry structural limitations:
 
-**golang-jwt/jwt** handles token operations (create/validate) against a key you supply. **jwtauth** adds:
-- Automatic key rotation with overlap periods — no restart required
-- Stateful refresh token lifecycle (issue, rotate, revoke, clean up)
-- `ValidateAccessTokenWithClaims` for custom claims without re-parsing
-- `ClockSkew` for distributed deployment tolerance
-- 22 pre-registered Prometheus metrics across all operations
-- 10 typed sentinel errors for precise error handling in middleware
+- **No key rotation** — one static secret or key pair for the lifetime of the service
+- **No refresh token state** — revocation requires a separate blocklist you build yourself
+- **Framework lock-in** — the middleware only works with your chosen framework; switching means rewriting auth
+- **No metrics** — you don't know how many tokens are being issued, validated, or rejected
 
-### vs. lestrrat-go/jwx
+`jwtauth` is framework-agnostic. The middleware in the examples is ~20 lines you own; swapping Gin for Chi or Echo is a one-file change.
 
-**lestrrat-go/jwx** is a comprehensive JOSE implementation — JWS, JWE, JWK, JWT. **jwtauth** is narrower and higher-level:
-- Focused API for the auth token lifecycle (issue → validate → refresh → revoke)
-- Key rotation is built in, not assembled from primitives
-- Observability (structured logging, metrics) is first-class, not an afterthought
-- No JOSE surface area you don't need — less API to reason about
+---
+
+### vs. `lestrrat-go/jwx` / `go-jose/go-jose` — JOSE toolkits
+
+Both are comprehensive JOSE implementations covering JWS, JWE, JWK, JWT, and more. `jwtauth` is narrower and higher-level:
+
+- The token lifecycle API (issue → validate → refresh → revoke) is ready — you're not assembling it from primitives
+- Key rotation is built in, not something you wire together from JWK set operations
+- Structured logging and metrics are first-class, not an afterthought
+- Less surface area to reason about if you only need RS256 JWT tokens
+
+If you need JWE (encrypted tokens), JWS detached payloads, or multi-algorithm JOSE operations, reach for one of those libraries instead.
+
+---
+
+### Concrete security guarantees
+
+1. **Algorithm confusion prevented unconditionally** — `ValidateAccessToken` asserts `*jwt.SigningMethodRSA` before any key lookup. HS256, ECDSA, and `none` are rejected — not configurably, unconditionally.
+
+2. **Reserved claim protection** — `IssueAccessTokenWithClaims` rejects custom claims that would overwrite `sub`, `exp`, `iat`, `nbf`, `jti`, `iss`, or `aud`. Application fields cannot collide with registered claims silently.
+
+3. **10 granular sentinel errors, all `errors.Is()`-compatible** — middleware can distinguish `ErrTokenExpired` from `ErrTokenRevoked` from `ErrInvalidAudience` and return specific JSON error codes (`token_expired`, `token_revoked`, `invalid_audience`) that clients can act on.
+
+4. **Instant revocation, not expiry-based** — `RevokeAllUserTokens` invalidates all sessions for a compromised account immediately. No waiting for short-lived tokens to expire.
+
+---
+
+### Horizontal scale path
+
+The storage backends are designed to move from single-instance to distributed without code changes:
+
+| Deployment | KeyStore | RefreshStore |
+|---|---|---|
+| Single instance (dev, small prod) | `DiskKeyStore` | `MemoryRefreshStore` |
+| Multi-instance (Kubernetes, load-balanced) | `RedisKeyStore` | `RedisRefreshStore` |
+
+Swap the constructor arguments. The `KeyManager` and `TokenManager` interfaces are unchanged.
+
+---
+
+**What jwtauth is not:** a full authentication server (no login flows, no OAuth2/OIDC), a session management library, or a rate limiter. For managed auth infrastructure, Keycloak, Dex, or Ory Hydra serve that role. jwtauth is the token engine you'd wire underneath them, or build directly into a service that already verifies identity by other means.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 ![Go Version](https://img.shields.io/badge/go-1.21+-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 
-**Production-ready JWT authentication library for distributed Go applications**
+**Production-grade JWT authorization token engine for distributed Go applications**
 
-> ⚠️ **Beta Status**: KeyManager and RefreshStore are production-ready and fully tested. TokenService is in beta — core operations are complete with comprehensive test coverage. API may change before v1.0.0.
+> ⚠️ **Beta Status**: KeyManager and RefreshStore are production-ready and fully tested. TokenManager is in beta — core operations are complete with comprehensive test coverage. API may change before v1.0.0.
 
 ## Overview
 
-`jwtauth` is a JWT authentication library built from the ground up with **observability, testability, and production operations** as first-class concerns. Unlike traditional JWT libraries that focus solely on token operations, jwtauth provides complete lifecycle management including zero-downtime key rotation, structured logging, metrics integration, and graceful shutdown patterns.
+`jwtauth` is a JWT authorization token engine for Go, built from the ground up with **observability, testability, and production operations** as first-class concerns. It manages the stateful machinery that production token systems require — cryptographic key generation and zero-downtime rotation, access token issuance and validation, and refresh token lifecycle with revocation support. Identity verification is intentionally out of scope: jwtauth takes a verified subject ID and handles everything after.
 
 ### Design Philosophy
 
@@ -36,7 +36,7 @@
 - **Full metrics instrumentation** — KeyStore and Manager operations via `jwtauth_keystore_*` and `jwtauth_key_*` metrics
 - **Comprehensive test coverage** with race detection
 
-**TokenService** (Beta)
+**TokenManager** (Beta)
 - **Access token issuance** (IssueAccessToken, IssueAccessTokenWithClaims, IssueTokenPair)
 - **Refresh token issuance** (IssueRefreshToken, IssueRefreshTokenWithMetadata)
 - **Access token validation** with registered and custom claims extraction (ValidateAccessToken, ValidateAccessTokenWithClaims)
@@ -75,7 +75,7 @@
 
 ### 🚧 In Development (v0.4.0)
 
-- **OpenTelemetry / Distributed Tracing**: `pkg/tracing` interfaces (`Tracer`, `Span`) and `NoOpTracer` are scaffolded. Full wiring into KeyManager, TokenService, and RefreshStore — with an OpenTelemetry adapter — is planned for v0.4.0.
+- **OpenTelemetry / Distributed Tracing**: `pkg/tracing` interfaces (`Tracer`, `Span`) and `NoOpTracer` are scaffolded. Full wiring into KeyManager, TokenManager, and RefreshStore — with an OpenTelemetry adapter — is planned for v0.4.0.
 
 ## Architecture Highlights
 
@@ -253,7 +253,7 @@ func main() {
 }
 ```
 
-### TokenService Usage (Beta)
+### TokenManager Usage (Beta)
 
 ```go
 package main
@@ -268,8 +268,8 @@ import (
 )
 
 func main() {
-    // Create TokenService with storage
-    config := tokens.ServiceConfig{
+    // Create TokenManager with storage
+    config := tokens.ManagerConfig{
         KeyManager:           keyManager,      // from KeyManager above
         RefreshStore:         refreshStore,    // RefreshStore implementation
         Logger:               logger,          // Optional
@@ -282,20 +282,20 @@ func main() {
         Audience:             []string{"my-app-api"},
     }
 
-    service, err := tokens.NewService(config)
+    mgr, err := tokens.NewManager(config)
     if err != nil {
         log.Fatal(err)
     }
 
-    // Start service lifecycle
+    // Start manager lifecycle
     ctx := context.Background()
-    if err := service.Start(ctx); err != nil {
+    if err := mgr.Start(ctx); err != nil {
         log.Fatal(err)
     }
-    defer service.Shutdown(ctx)
+    defer mgr.Shutdown(ctx)
 
     // Issue access token with custom claims
-    token, err := service.IssueAccessTokenWithClaims(ctx, "user-123", map[string]interface{}{
+    token, err := mgr.IssueAccessTokenWithClaims(ctx, "user-123", map[string]interface{}{
         "role": "admin",
         "tenant": "org-456",
     })
@@ -304,7 +304,7 @@ func main() {
     }
 
     // Validate token and retrieve custom claims
-    registered, custom, err := service.ValidateAccessTokenWithClaims(ctx, token)
+    registered, custom, err := mgr.ValidateAccessTokenWithClaims(ctx, token)
     if err != nil {
         log.Fatal(err)
     }
@@ -333,7 +333,7 @@ func main() {
 | `Logger` | `logging.Logger` | No | `nil` | Optional structured logger |
 | `Metrics` | `metrics.Metrics` | No | `nil` | Optional metrics collector |
 
-### ServiceConfig
+### ManagerConfig
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
@@ -386,7 +386,7 @@ config := keymanager.ManagerConfig{
 
 ## Error Reference
 
-All `TokenService` errors are exported sentinels compatible with `errors.Is()`. Middleware and API handlers should switch on these to return specific responses.
+All `TokenManager` errors are exported sentinels compatible with `errors.Is()`. Middleware and API handlers should switch on these to return specific responses.
 
 | Error | Trigger | Client-side action |
 |-------|---------|-------------------|
@@ -399,11 +399,11 @@ All `TokenService` errors are exported sentinels compatible with `errors.Is()`. 
 | `tokens.ErrInvalidRefreshToken` | Refresh token not found in store | Force re-login |
 | `tokens.ErrRefreshTokenExpired` | Refresh token past its TTL | Force re-login |
 | `tokens.ErrInvalidUserID` | Empty or whitespace-only `userID` passed to issuance method | Fix caller — input validation error |
-| `tokens.ErrServiceNotRunning` | Token operation called before `Start()` or after `Shutdown()` | Fix caller — lifecycle management error |
+| `tokens.ErrManagerNotRunning` | Token operation called before `Start()` or after `Shutdown()` | Fix caller — lifecycle management error |
 
 ```go
 // Example: mapping errors to HTTP responses in middleware
-claims, err := svc.ValidateAccessToken(r.Context(), token)
+claims, err := mgr.ValidateAccessToken(r.Context(), token)
 switch {
 case errors.Is(err, tokens.ErrTokenExpired):
     writeJSON(w, 401, `{"error":"token_expired"}`)
@@ -451,7 +451,7 @@ func (m *MyZapAdapter) Info(msg string, args ...interface{}) {
 
 ### Correlation ID
 
-Correlation IDs let you filter all log lines from a single request across every internal component — KeyManager, RefreshStore, and TokenService — with a single `jq` query.
+Correlation IDs let you filter all log lines from a single request across every internal component — KeyManager, RefreshStore, and TokenManager — with a single `jq` query.
 
 **Quick start**:
 
@@ -473,7 +473,7 @@ func correlationMiddleware(next http.Handler) http.Handler {
 }
 
 // 3. Pass ctx through — all internal logs automatically carry correlation_id
-accessToken, refreshToken, err := svc.IssueTokenPair(ctx, userID)
+accessToken, refreshToken, err := mgr.IssueTokenPair(ctx, userID)
 ```
 
 **Before** (hard to correlate):
@@ -535,7 +535,7 @@ http.Handle("/metrics", pm.Handler())
 ks, _ := keymanager.NewDiskKeyStore("./keys", 2048, logger, pm)
 km, _ := keymanager.NewManager(keymanager.ManagerConfig{KeyStore: ks, Metrics: pm})
 store := storage.NewMemoryRefreshStore(logger, pm)
-svc, _ := tokens.NewService(tokens.ServiceConfig{
+mgr, _ := tokens.NewManager(tokens.ManagerConfig{
     KeyManager:   km,
     RefreshStore: store,
     Metrics:      pm,
@@ -592,7 +592,7 @@ jwtauth_key_active_versions_count
 **Alerting guidance**:
 - `jwtauth_key_active_versions_count == 0` → critical — no signing key available, all token issuance will fail
 - `rate(jwtauth_key_rotations_total{status!="success"}[1h]) > 0` → warning — key rotation is failing
-- `jwtauth_service_running == 0` → critical — TokenService has stopped
+- `jwtauth_service_running == 0` → critical — TokenManager has stopped
 
 For the full operator reference including Grafana dashboard guidance and label cardinality analysis, see [doc/METRICS.md](doc/METRICS.md).
 
@@ -628,10 +628,10 @@ github.com/aetomala/jwtauth/
 │   │   ├── disk_test.go          # 9-phase DiskKeyStore tests (38 specs)
 │   │   └── redis_test.go         # 9-phase RedisKeyStore tests (35 specs, miniredis)
 │   ├── tokens/                   # JWT operations (Beta) 🟡
-│   │   ├── service.go            # TokenService implementation
+│   │   ├── manager.go            # TokenManager implementation
 │   │   ├── claims.go             # Claims management
-│   │   ├── service_test.go       # Token operations tests
-│   │   ├── service_lifecycle_test.go  # Lifecycle management tests
+│   │   ├── manager_test.go       # Token operations tests
+│   │   ├── manager_lifecycle_test.go  # Lifecycle management tests
 │   │   └── integration/          # Integration tests
 │   │       └── integration_test.go
 │   └── storage/                  # Refresh token storage ✅
@@ -666,7 +666,7 @@ github.com/aetomala/jwtauth/
 
 ### Test Coverage
 
-**Current**: 605 comprehensive tests across KeyManager, TokenService, RefreshStore, Metrics, Logging, and Tracing, all passing with race detection (KeyManager ~90%, TokenService ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%)
+**Current**: 605 comprehensive tests across KeyManager, TokenManager, RefreshStore, Metrics, Logging, and Tracing, all passing with race detection (KeyManager ~90%, TokenManager ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%)
 
 **KeyManager** (3 test suites — 125 total specs):
 - **9-phase Manager tests** (52 specs, MockKeyStore — no I/O):
@@ -686,7 +686,7 @@ github.com/aetomala/jwtauth/
   - Error handling: corrupt metadata, missing metadata entry, Redis unavailability via SetError
   - Concurrency, metrics recording (storage_backend: "redis")
 
-**TokenService** (7 test suites, 153 total tests):
+**TokenManager** (7 test suites, 153 total tests):
 - **Lifecycle Management Tests** (20 tests):
   - Start: idempotency, logging, background cleanup, failure handling, context cancellation
   - Shutdown: logging, cleanup termination, goroutine coordination, timeout respect, idempotency
@@ -720,7 +720,7 @@ github.com/aetomala/jwtauth/
 - **Test Suite Architecture**: Single parameterized suite eliminates 800+ lines of duplication, ensures both implementations have identical semantics
 
 **Test Organization**:
-- Separate test files for logical concerns (`service_test.go`, `service_lifecycle_test.go`)
+- Separate test files for logical concerns (`manager_test.go`, `manager_lifecycle_test.go`)
 - Ginkgo/Gomega BDD-style test organization
 - gomock for dependency injection testing
 - Shared test utilities and fixtures
@@ -764,7 +764,7 @@ Tests follow **progressive phase-based development**:
 
 3. **Zero-downtime key rotation** — `KeyManager` keeps the previous key valid for an overlap period (default 1 hour) while signing all new tokens with the rotated key. Tokens issued before rotation continue to validate. No service restart or forced re-login is required.
 
-4. **Clock skew tolerance without inflating TTLs** — the `ClockSkew` field on `ServiceConfig` applies `jwt.WithLeeway()` to `exp` and `nbf` validation. Distributed deployments with NTP drift work correctly without extending access token lifetimes.
+4. **Clock skew tolerance without inflating TTLs** — the `ClockSkew` field on `ManagerConfig` applies `jwt.WithLeeway()` to `exp` and `nbf` validation. Distributed deployments with NTP drift work correctly without extending access token lifetimes.
 
 5. **10 granular sentinel errors, all `errors.Is()`-compatible** — callers can distinguish `ErrTokenExpired` from `ErrTokenRevoked` from `ErrInvalidAudience` without string matching. Middleware can return specific JSON error codes (`token_expired`, `token_revoked`, `invalid_audience`) that clients can act on.
 
@@ -802,14 +802,14 @@ Tests follow **progressive phase-based development**:
 - ✅ Architecture documentation
 
 ### v0.2.0 ✅ Complete
-- ✅ TokenService: JWT creation with RS256 signing
-- ✅ TokenService: Lifecycle management (Start/Shutdown/IsRunning)
-- ✅ TokenService: Claims management with custom claims support and reserved claim protection
-- ✅ TokenService: Access token validation with issuer/audience enforcement (ValidateAccessToken)
-- ✅ TokenService: Refresh token rotation with expiration and revocation checks (RefreshAccessToken)
-- ✅ TokenService: Token revocation — single and bulk (RevokeRefreshToken, RevokeAllUserTokens)
-- ✅ TokenService: Token introspection per RFC 7662 (IntrospectToken)
-- ✅ TokenService: Manual cleanup sweep (CleanupExpiredTokens)
+- ✅ TokenManager: JWT creation with RS256 signing
+- ✅ TokenManager: Lifecycle management (Start/Shutdown/IsRunning)
+- ✅ TokenManager: Claims management with custom claims support and reserved claim protection
+- ✅ TokenManager: Access token validation with issuer/audience enforcement (ValidateAccessToken)
+- ✅ TokenManager: Refresh token rotation with expiration and revocation checks (RefreshAccessToken)
+- ✅ TokenManager: Token revocation — single and bulk (RevokeRefreshToken, RevokeAllUserTokens)
+- ✅ TokenManager: Token introspection per RFC 7662 (IntrospectToken)
+- ✅ TokenManager: Manual cleanup sweep (CleanupExpiredTokens)
 - ✅ RefreshStore: Shared test suite pattern (eliminates duplication, runs against all implementations)
 - ✅ RefreshStore: MemoryRefreshStore with defensive copying and concurrent safety
 - ✅ RefreshStore: RedisRefreshStore for distributed deployments with go-redis/v9
@@ -817,9 +817,9 @@ Tests follow **progressive phase-based development**:
 - ✅ KeyStore interface extracted from KeyManager — `DiskKeyStore` for single-instance, `RedisKeyStore` for distributed deployments
 
 ### v0.3.0 (Current — Beta)
-- ✅ TokenService: Clock skew tolerance (`ClockSkew` field, `jwt.WithLeeway()` integration)
-- ✅ TokenService: `ValidateAccessTokenWithClaims` — registered and custom claims returned after validation
-- ✅ Wire metrics into all components — KeyStore, Manager, TokenService, RefreshStore with `error_type` label and context propagation
+- ✅ TokenManager: Clock skew tolerance (`ClockSkew` field, `jwt.WithLeeway()` integration)
+- ✅ TokenManager: `ValidateAccessTokenWithClaims` — registered and custom claims returned after validation
+- ✅ Wire metrics into all components — KeyStore, Manager, TokenManager, RefreshStore with `error_type` label and context propagation
 - ✅ Example middleware returns specific JSON error codes (`token_expired`, `token_revoked`, etc.) via sentinel error mapping
 - ✅ `KeyManager` interface extended with context on all read methods (`GetCurrentSigningKey`, `GetPublicKey`, `GetJWKS`)
 - ✅ Correlation ID logging — `CorrelationIDHandler`, `WithCorrelationID`/`GetCorrelationID` helpers, `NewCorrelationJSONLogger`/`NewCorrelationTextLogger`, context-aware `SlogAdapter`
@@ -831,7 +831,7 @@ Tests follow **progressive phase-based development**:
 - ✅ `pkg/tracing` interfaces scaffolded — `Tracer`, `Span`, `SpanOption`, `StatusCode`, `SpanKind`
 - ✅ `NoOpTracer` / `NoOpSpan` implementations (36 tests, race-detection clean)
 - ✅ `MockTracer` / `MockSpan` generated for dependency injection in component tests
-- 🚧 Wire tracing into KeyManager, TokenService, and RefreshStore
+- 🚧 Wire tracing into KeyManager, TokenManager, and RefreshStore
 - 🚧 OpenTelemetry adapter (`pkg/tracing/otel`) bridging `pkg/tracing.Tracer` to `go.opentelemetry.io/otel`
 
 ### v1.0.0 (Stable)
@@ -922,7 +922,7 @@ MIT License - see [LICENSE](LICENSE) for details
 
 ## Background
 
-Built by a Senior Platform Engineer with 28 years of experience in distributed systems. This library represents production-grade patterns learned from building authentication systems at scale, with a focus on operational excellence, observability, and maintainability.
+Built by a Senior Platform Engineer with 28 years of experience in distributed systems. This library represents production-grade patterns learned from building authorization token systems at scale, with a focus on operational excellence, observability, and maintainability.
 
 **Design Philosophy**: Software should be observable, testable, and maintainable. Good architecture makes these properties natural, not afterthoughts.
 
@@ -930,6 +930,6 @@ Built by a Senior Platform Engineer with 28 years of experience in distributed s
 
 **Status**: Beta (Active Development)
 **Version**: 0.3.0-beta
-**Components**: KeyManager ✅ | TokenService (Beta) 🟡 | RefreshStore (Memory + Redis) ✅ | Metrics (Prometheus) ✅ | Logging (Correlation ID) ✅ | Tracing (scaffold) 🚧
-**Test Coverage**: 605 tests (KeyManager ~90%, TokenService ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%), all passing, race-detection enabled
+**Components**: KeyManager ✅ | TokenManager (Beta) 🟡 | RefreshStore (Memory + Redis) ✅ | Metrics (Prometheus) ✅ | Logging (Correlation ID) ✅ | Tracing (scaffold) 🚧
+**Test Coverage**: 605 tests (KeyManager ~90%, TokenManager ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%), all passing, race-detection enabled
 **Last Updated**: April 14, 2026

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -1,6 +1,6 @@
-# JWT Authentication System - Architecture
+# jwtauth — JWT Authorization Token Engine
 
-This document explains the design decisions, patterns, and principles used in the JWT authentication system.
+This document explains the design decisions, patterns, and principles used in the JWT authorization token engine.
 
 ## Table of Contents
 
@@ -17,7 +17,7 @@ This document explains the design decisions, patterns, and principles used in th
 
 ## Overview
 
-The JWT authentication system is designed as a **production-ready, highly observable, and testable** authentication solution for Go applications.
+jwtauth is designed as a **production-ready, highly observable, and testable** JWT authorization token engine for Go applications. It manages the stateful machinery that production token systems require — cryptographic key generation and zero-downtime rotation, access token issuance and validation, and refresh token lifecycle with revocation support. Identity verification is intentionally out of scope.
 
 ### Key Features
 
@@ -112,10 +112,10 @@ github.com/aetomala/jwtauth/
 │   │   ├── disk_test.go           # 9-phase DiskKeyStore tests (38 specs)
 │   │   └── redis_test.go          # 9-phase RedisKeyStore tests (35 specs, miniredis)
 │   ├── tokens/                    # JWT token operations (Beta)
-│   │   ├── service.go             # TokenService implementation
+│   │   ├── manager.go             # TokenManager implementation
 │   │   ├── claims.go              # Claims management
-│   │   ├── service_test.go        # Token operations tests
-│   │   ├── service_lifecycle_test.go  # Lifecycle management tests
+│   │   ├── manager_test.go        # Token operations tests
+│   │   ├── manager_lifecycle_test.go  # Lifecycle management tests
 │   │   └── integration/           # Integration tests
 │   │       └── integration_test.go
 │   └── storage/                   # Refresh token storage ✅
@@ -505,7 +505,7 @@ Keys carry no TTL — Manager owns the lifecycle and calls `Delete` explicitly v
 
 `SetGauge(jwtauth_keystore_keys_count)` is recorded only by `LoadAll` — set to the count of valid non-expired keys returned. This is sufficient because `GetCurrentSigningKey` never calls the store after startup and `GetPublicKey` only calls `LoadKey` on rare cache misses, so KeyStore operations are not on the hot path.
 
-### TokenService (Beta)
+### TokenManager (Beta)
 
 **Responsibilities**:
 - Issue access tokens (short-lived, e.g., 15 minutes) with optional custom claims
@@ -530,7 +530,7 @@ Created → Start() → Running → Shutdown() → Stopped
 - **Synchronization**: `atomic.Bool` for running state; cleanup uses channel signaling and `sync.WaitGroup` for graceful shutdown
 
 **Key Design Decisions**:
-- Rate limiting is intentionally **not** in TokenService — it belongs at the infrastructure layer (API Gateway, Ingress, Load Balancer) where per-route and per-IP policies apply globally
+- Rate limiting is intentionally **not** in TokenManager — it belongs at the infrastructure layer (API Gateway, Ingress, Load Balancer) where per-route and per-IP policies apply globally
 - All storage operations accept `context.Context` for cancellation propagation
 - Reserved JWT claims (`sub`, `iss`, `aud`, `exp`, `iat`, `jti`) cannot be overridden by custom claims
 
@@ -874,9 +874,9 @@ Catches:
 - ✅ Prometheus implementation (`PrometheusMetrics`) with 22 pre-registered metrics, 100% test coverage
 - ✅ NoOp implementation
 - ✅ gomock `MockMetrics` for dependency injection in tests
-- ✅ Wired into KeyManager, TokenService, and RefreshStore — all components fully instrumented
+- ✅ Wired into KeyManager, TokenManager, and RefreshStore — all components fully instrumented
 
-### Phase 3: TokenService ✅ (Beta)
+### Phase 3: TokenManager ✅ (Beta)
 - ✅ JWT creation with RS256 signing and custom claims
 - ✅ Access token validation (signature, expiration, issuer, audience)
 - ✅ Refresh token rotation with revocation checks
@@ -884,7 +884,7 @@ Catches:
 - ✅ Token introspection per RFC 7662
 - ✅ Lifecycle management (Start/Shutdown/IsRunning)
 - ✅ Background cleanup goroutine with configurable interval
-- ✅ Clock skew tolerance (`ClockSkew time.Duration` in `ServiceConfig` — `jwt.WithLeeway()` integration)
+- ✅ Clock skew tolerance (`ClockSkew time.Duration` in `ManagerConfig` — `jwt.WithLeeway()` integration)
 - ✅ `ValidateAccessTokenWithClaims` — returns registered claims and custom claims map after validation
 - ✅ Comprehensive test coverage (153 tests, ~87% coverage, race-detection clean)
 - ✅ RefreshStore interface with context propagation
@@ -917,10 +917,10 @@ Catches:
   - `Manager` unit tests are now filesystem-free (use `MockKeyStore`)
   - 44 Manager specs + 38 DiskKeyStore specs (9 phases), all race-clean
   - `MockKeyStore` generated via gomock
-- ✅ Wire `PrometheusMetrics` into TokenService — deferred closure pattern with `error_type` label, context propagation
+- ✅ Wire `PrometheusMetrics` into TokenManager — deferred closure pattern with `error_type` label, context propagation
 - ✅ `RedisKeyStore` implementation — `ks:pem:<id>` / `ks:meta:<id>` Redis layout, atomic Pipeline writes, SCAN-based `LoadAll`, full metrics with `storage_backend: "redis"`
 - ✅ Correlation ID logging — `CorrelationIDHandler` wraps any `slog.Handler`; `WithCorrelationID`/`GetCorrelationID` context helpers; `SlogAdapter` context-aware routing; `NewCorrelationJSONLogger`/`NewCorrelationTextLogger` convenience constructors
-- ✅ All component logging call sites forward `ctx` — correlation ID propagates through KeyManager, TokenService, and RefreshStore without Logger interface changes
+- ✅ All component logging call sites forward `ctx` — correlation ID propagates through KeyManager, TokenManager, and RefreshStore without Logger interface changes
 - ✅ `KeyManager` interface extended with context on all read methods (`GetCurrentSigningKey`, `GetPublicKey`, `GetJWKS`)
 - ✅ Context cancellation guards in `GetJWKS` and `cleanupExpiredKeys` with warning log on early return
 - ✅ Redis integration tests via miniredis (`pkg/tokens/integration`) covering distributed token operations end-to-end
@@ -929,7 +929,7 @@ Catches:
 - ✅ `pkg/tracing` — `Tracer` and `Span` interfaces defined; `SpanOption` functional options; `StatusCode` and `SpanKind` enumerations
 - ✅ `NoOpTracer` / `NoOpSpan` — zero-allocation implementations; 36 tests, race-detection clean
 - ✅ `MockTracer` / `MockSpan` generated via gomock for dependency injection in component tests
-- ⏳ Wire tracing into KeyManager, TokenService, and RefreshStore
+- ⏳ Wire tracing into KeyManager, TokenManager, and RefreshStore
 - ⏳ OpenTelemetry adapter (`pkg/tracing/otel`) bridging `pkg/tracing.Tracer` to `go.opentelemetry.io/otel`
 
 ---

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -142,7 +142,8 @@ github.com/aetomala/jwtauth/
 ├── examples/                      # Framework usage examples
 │   ├── gin-example/               # Gin HTTP framework
 │   ├── echo-example/              # Echo HTTP framework
-│   └── chi-example/               # Chi HTTP router
+│   ├── chi-example/               # Chi HTTP router
+│   └── correlation-example/       # End-to-end correlation ID with stdlib net/http
 └── jwtauth_suite_test.go          # Root Ginkgo suite bootstrap
 ```
 
@@ -254,6 +255,39 @@ KeyManager → logging.Logger interface → SlogAdapter → os.Stdout → K8s lo
 - ✅ Testable (MockLogger)
 - ✅ Debug level disableable in production (disable at handler, not in code)
 
+**Correlation ID**:
+
+All jwtauth components accept `context.Context` on every operation and pass it as the first element of `keysAndValues` when logging. `SlogAdapter` detects this and routes the call through `slog.*Context()`, which lets `CorrelationIDHandler` extract a correlation ID from the context and append it to every record automatically.
+
+```go
+// Internal component logging — ctx as the first kwarg:
+m.config.Logger.Info("key rotation successful",
+    ctx,
+    "keyID", newKeyID,
+    "duration", time.Since(start))
+
+// SlogAdapter calls InfoContext(ctx, ...), CorrelationIDHandler injects the field:
+// → {"msg":"key rotation successful","keyID":"abc","correlation_id":"req-001"}
+```
+
+Wire it at application startup:
+
+```go
+// NewCorrelationJSONLogger wraps slog.NewJSONHandler with CorrelationIDHandler.
+logger := logging.NewCorrelationJSONLogger(slog.LevelInfo)
+
+mgr, _ := tokens.NewManager(tokens.ManagerConfig{Logger: logger, ...})
+```
+
+Inject the ID once at the HTTP request boundary — it propagates to all jwtauth calls for that request:
+
+```go
+ctx := logging.WithCorrelationID(r.Context(), r.Header.Get("X-Correlation-ID"))
+accessToken, _, err := mgr.IssueTokenPair(ctx, userID)
+```
+
+See `examples/correlation-example/` for a complete working demonstration.
+
 ### Metrics
 
 **Interface**: `pkg/metrics/Metrics`
@@ -329,9 +363,11 @@ func (m *Manager) RotateKeys(ctx context.Context) error {
     
     // Rotate logic...
     
-    // Optional logging
+    // Optional logging — ctx is the first kwarg so SlogAdapter routes through
+    // InfoContext, which lets CorrelationIDHandler inject correlation_id.
     if m.config.Logger != nil {
         m.config.Logger.Info("key rotation successful",
+            ctx,
             "keyID", newKeyID,
             "duration", time.Since(start))
     }

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -31,14 +31,14 @@ store := storage.NewRedisRefreshStore(redisClient, logger, pm)
 
 ### Service Start Order
 
-Always start `KeyManager` before `TokenService` — `TokenService.Start()` does not call `KeyManager.Start()`:
+Always start `KeyManager` before `TokenManager` — `TokenManager.Start()` does not call `KeyManager.Start()`:
 ```go
 // Correct order
 if err := km.Start(ctx); err != nil {
     log.Fatal("KeyManager failed to start:", err)
 }
-if err := svc.Start(ctx); err != nil {
-    log.Fatal("TokenService failed to start:", err)
+if err := mgr.Start(ctx); err != nil {
+    log.Fatal("TokenManager failed to start:", err)
 }
 ```
 
@@ -49,10 +49,10 @@ if err := svc.Start(ctx); err != nil {
 Expose a health endpoint that reflects actual service state — not just HTTP liveness.
 
 ```go
-// Health check handler — checks both service and key availability
-func healthHandler(svc *tokens.Service, km keymanager.KeyManager) http.HandlerFunc {
+// Health check handler — checks both manager and key availability
+func healthHandler(mgr *tokens.Manager, km keymanager.KeyManager) http.HandlerFunc {
     return func(w http.ResponseWriter, r *http.Request) {
-        if !svc.IsRunning() {
+        if !mgr.IsRunning() {
             w.WriteHeader(http.StatusServiceUnavailable)
             json.NewEncoder(w).Encode(map[string]string{
                 "status": "unhealthy",
@@ -107,7 +107,7 @@ pm := metrics.NewPrometheusMetrics(metrics.PrometheusConfig{
 ks, _   := keymanager.NewDiskKeyStore("./keys", 2048, logger, pm)
 km, _   := keymanager.NewManager(keymanager.ManagerConfig{KeyStore: ks, Metrics: pm})
 store   := storage.NewMemoryRefreshStore(logger, pm)
-svc, _  := tokens.NewService(tokens.ServiceConfig{
+mgr, _  := tokens.NewManager(tokens.ManagerConfig{
     KeyManager:   km,
     RefreshStore: store,
     Metrics:      pm,
@@ -147,12 +147,12 @@ groups:
         annotations:
           summary: "Key rotation errors detected"
 
-      - alert: TokenServiceStopped
+      - alert: TokenManagerStopped
         expr: jwtauth_service_running == 0
         for: 1m
         severity: critical
         annotations:
-          summary: "TokenService is not running"
+          summary: "TokenManager is not running"
 ```
 
 For the complete metric reference — all 22 metrics with label values and PromQL cookbook — see [METRICS.md](METRICS.md).
@@ -161,7 +161,7 @@ For the complete metric reference — all 22 metrics with label values and PromQ
 
 ## Graceful Shutdown
 
-Shut down in reverse start order — `TokenService` first, then `KeyManager`. Always use a deadline:
+Shut down in reverse start order — `TokenManager` first, then `KeyManager`. Always use a deadline:
 
 ```go
 srv := &http.Server{Addr: ":8080", Handler: r}
@@ -180,9 +180,9 @@ if err := srv.Shutdown(shutdownCtx); err != nil {
     log.Println("HTTP server shutdown error:", err)
 }
 
-// 2. Shut down TokenService (drains in-flight operations)
-if err := svc.Shutdown(shutdownCtx); err != nil {
-    log.Println("TokenService shutdown error:", err)
+// 2. Shut down TokenManager (drains in-flight operations)
+if err := mgr.Shutdown(shutdownCtx); err != nil {
+    log.Println("TokenManager shutdown error:", err)
 }
 
 // 3. Shut down KeyManager
@@ -230,7 +230,7 @@ store := storage.NewRedisRefreshStore(redisClient, logger, pm)
 In distributed deployments, servers may have slight clock drift. `ClockSkew` adds leeway to `exp` and `nbf` validation without inflating token lifetimes:
 
 ```go
-svc, _ := tokens.NewService(tokens.ServiceConfig{
+mgr, _ := tokens.NewManager(tokens.ManagerConfig{
     // ...
     ClockSkew: 30 * time.Second,  // Accept tokens up to 30s past expiry
 })

--- a/doc/METRICS.md
+++ b/doc/METRICS.md
@@ -43,7 +43,7 @@ Identifies which RefreshStore or KeyStore implementation is recording the metric
 
 ---
 
-## TokenService Metrics
+## TokenManager Metrics
 
 ### `jwtauth_tokens_issued_total`
 - **Type**: Counter
@@ -79,7 +79,7 @@ Identifies which RefreshStore or KeyStore implementation is recording the metric
 - **Type**: Histogram
 - **Labels**: `operation`
 - **Buckets**: 1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2.5s, 5s, 10s
-- **Description**: End-to-end latency for TokenService operations. `operation` matches the method name (e.g. `"issue_token_pair"`, `"validate_access_token"`).
+- **Description**: End-to-end latency for TokenManager operations. `operation` matches the method name (e.g. `"issue_token_pair"`, `"validate_access_token"`).
 
 ### `jwtauth_active_tokens`
 - **Type**: Gauge
@@ -89,7 +89,7 @@ Identifies which RefreshStore or KeyStore implementation is recording the metric
 ### `jwtauth_service_running`
 - **Type**: Gauge
 - **Labels**: none
-- **Description**: `1` when the TokenService is running (after `Start()`), `0` when stopped. Alert on `== 0`.
+- **Description**: `1` when the TokenManager is running (after `Start()`), `0` when stopped. Alert on `== 0`.
 
 ---
 
@@ -242,12 +242,12 @@ groups:
           severity: critical
           summary: "No active signing key — all token issuance will fail until rotation succeeds"
 
-      - alert: TokenServiceStopped
+      - alert: TokenManagerStopped
         expr: jwtauth_service_running == 0
         for: 1m
         annotations:
           severity: critical
-          summary: "TokenService is not running"
+          summary: "TokenManager is not running"
 
   - name: jwtauth.warning
     rules:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
-# jwtauth Framework Examples
+# jwtauth — Integration Examples
 
-This directory contains complete, runnable examples of using `jwtauth` with different HTTP frameworks. Each example demonstrates:
+This directory contains complete, runnable examples showing how to integrate the `jwtauth` authorization token engine with different HTTP frameworks. Each example demonstrates:
 
 - Setting up a `KeyManager` for zero-downtime key rotation
 - Creating a `TokenManager` for token operations
@@ -64,9 +64,27 @@ cd echo-example
 go run main.go
 ```
 
+### [Correlation ID Example](correlation-example/)
+
+End-to-end correlation ID tracing using only the standard library (`net/http`). Best for:
+- Understanding how `correlation_id` flows through all jwtauth internal logs
+- Adding per-request log tracing to any framework (the pattern is framework-agnostic)
+
+**Features**:
+- `NewCorrelationJSONLogger` with `CorrelationIDHandler` pre-wired
+- `X-Correlation-ID` header extraction with auto-generation when absent
+- `correlation_id` appears on every jwtauth log line for the request automatically
+- No external framework dependencies — pure stdlib
+
+**Run**:
+```bash
+cd correlation-example
+go run main.go
+```
+
 ## Common Pattern Across Examples
 
-All examples follow the same pattern:
+All examples follow the same pattern. The `correlation-example` extends this pattern with per-request log tracing — see it for a complete demonstration of wiring `CorrelationIDHandler` and `logging.WithCorrelationID` into the request lifecycle.
 
 ### 1. Setup Service Dependencies
 
@@ -183,7 +201,7 @@ claims := map[string]interface{}{
     "tenant": "org-123",
 }
 
-token, err := svc.IssueAccessTokenWithClaims(ctx, userID, claims)
+token, err := mgr.IssueAccessTokenWithClaims(ctx, userID, claims)
 ```
 
 ### Add Database Integration
@@ -282,16 +300,17 @@ The examples show how simple it is to write middleware for any framework that ca
 
 ## Framework Comparison
 
-| Feature | Gin | Chi | Echo |
-|---------|-----|-----|------|
-| **Speed** | Very fast | Fast | Very fast |
-| **Middleware** | `gin.HandlerFunc` | `func(Handler)Handler` | `MiddlewareFunc` |
-| **Complexity** | Simple | Minimal | Rich features |
-| **Learning curve** | Easy | Very easy | Medium |
-| **Ecosystem** | Large | Small | Large |
-| **Best for** | Microservices | Simplicity | Feature-rich apps |
+| Feature | Gin | Chi | Echo | Correlation |
+|---------|-----|-----|------|-------------|
+| **Framework** | Gin | Chi | Echo | stdlib |
+| **Middleware** | `gin.HandlerFunc` | `func(Handler)Handler` | `MiddlewareFunc` | `func(HandlerFunc)HandlerFunc` |
+| **Complexity** | Simple | Minimal | Rich features | Minimal |
+| **Learning curve** | Easy | Very easy | Medium | Very easy |
+| **Ecosystem** | Large | Small | Large | None (stdlib only) |
+| **Best for** | Microservices | Simplicity | Feature-rich apps | Log tracing demo |
+| **Correlation ID** | Not shown | Not shown | Not shown | Full demo |
 
-All examples achieve the same authentication goals — choose based on your framework preference!
+All examples achieve the same token lifecycle goals. The correlation-example additionally demonstrates per-request log tracing — the pattern applies equally to Gin, Chi, and Echo.
 
 ## Next Steps
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,8 +3,8 @@
 This directory contains complete, runnable examples of using `jwtauth` with different HTTP frameworks. Each example demonstrates:
 
 - Setting up a `KeyManager` for zero-downtime key rotation
-- Creating a `TokenService` for token operations
-- Writing framework-specific authentication middleware
+- Creating a `TokenManager` for token operations
+- Writing framework-specific bearer token middleware
 - Implementing login, refresh, logout flows
 - Protecting endpoints with token validation
 
@@ -78,24 +78,24 @@ km.Start(ctx)
 // Create RefreshStore for token persistence
 store := storage.NewMemoryRefreshStore(logger)
 
-// Create TokenService for token operations
-svc, _ := tokens.NewService(config)
-svc.Start(ctx)
+// Create TokenManager for token operations
+mgr, _ := tokens.NewManager(config)
+mgr.Start(ctx)
 ```
 
 ### 2. Write Framework Middleware
 
 Each framework has a different middleware pattern, but they all:
 - Extract token from `Authorization: Bearer <token>` header
-- Validate with `svc.ValidateAccessToken(ctx, token)`
+- Validate with `mgr.ValidateAccessToken(ctx, token)`
 - Attach user ID and claims to request context
 - Proceed to the route handler
 
 **Gin**:
 ```go
-func AuthMiddleware(svc *tokens.Service) gin.HandlerFunc {
+func BearerMiddleware(mgr *tokens.Manager) gin.HandlerFunc {
     return func(c *gin.Context) {
-        claims, err := svc.ValidateAccessToken(c, token)
+        claims, err := mgr.ValidateAccessToken(c, token)
         c.Set("userID", claims.Subject)
         c.Next()
     }
@@ -104,10 +104,10 @@ func AuthMiddleware(svc *tokens.Service) gin.HandlerFunc {
 
 **Chi**:
 ```go
-func AuthMiddleware(svc *tokens.Service) func(http.Handler) http.Handler {
+func BearerMiddleware(mgr *tokens.Manager) func(http.Handler) http.Handler {
     return func(next http.Handler) http.Handler {
         return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-            claims, err := svc.ValidateAccessToken(r.Context(), token)
+            claims, err := mgr.ValidateAccessToken(r.Context(), token)
             ctx := context.WithValue(r.Context(), "userID", claims.Subject)
             next.ServeHTTP(w, r.WithContext(ctx))
         })
@@ -117,10 +117,10 @@ func AuthMiddleware(svc *tokens.Service) func(http.Handler) http.Handler {
 
 **Echo**:
 ```go
-func AuthMiddleware(svc *tokens.Service) echo.MiddlewareFunc {
+func BearerMiddleware(mgr *tokens.Manager) echo.MiddlewareFunc {
     return func(next echo.HandlerFunc) echo.HandlerFunc {
         return func(c echo.Context) error {
-            claims, err := svc.ValidateAccessToken(c.Request().Context(), token)
+            claims, err := mgr.ValidateAccessToken(c.Request().Context(), token)
             c.Set("userID", claims.Subject)
             return next(c)
         }
@@ -131,7 +131,7 @@ func AuthMiddleware(svc *tokens.Service) echo.MiddlewareFunc {
 ### 3. Define Endpoints
 
 Each example includes:
-- `POST /login` - Issue access + refresh token pair
+- `POST /login` - Issue access + refresh token pair (calls `issueTokensHandler`)
 - `POST /refresh` - Issue new access token
 - `GET /api/profile` - Protected endpoint
 - `POST /api/logout` - Revoke all user tokens
@@ -200,9 +200,9 @@ func (s *PostgresRefreshStore) Store(ctx context.Context, tokenID, userID string
     // Store in database
 }
 
-// Use it in the service
+// Use it in the manager
 store := &PostgresRefreshStore{db: db}
-svc, _ := tokens.NewService(tokens.ServiceConfig{
+mgr, _ := tokens.NewManager(tokens.ManagerConfig{
     RefreshStore: store,
 })
 ```
@@ -213,7 +213,7 @@ Check custom claims in middleware:
 
 ```go
 // Use ValidateAccessTokenWithClaims to get both registered and custom claims:
-registered, custom, err := svc.ValidateAccessTokenWithClaims(ctx, token)
+registered, custom, err := mgr.ValidateAccessTokenWithClaims(ctx, token)
 // registered.Subject == userID
 // custom["role"] == "admin"  (application-defined fields only)
 
@@ -248,7 +248,7 @@ The `jwtauth` library itself is **framework-agnostic** — it only provides core
 ✅ **Easy to integrate with your chosen framework**
 ✅ **Small library size and focused API**
 
-The examples show how simple it is to write middleware for any framework that can use your `TokenService`.
+The examples show how simple it is to write middleware for any framework that can use your `TokenManager`.
 
 ## Key Concepts
 

--- a/examples/chi-example/README.md
+++ b/examples/chi-example/README.md
@@ -153,7 +153,7 @@ Response:
 Chi middleware uses the standard `func(http.Handler) http.Handler` pattern. The custom middleware in `auth/middleware.go`:
 
 1. **Extracts** the token from the `Authorization: Bearer <token>` header
-2. **Validates** the token using `svc.ValidateAccessToken()`
+2. **Validates** the token using `mgr.ValidateAccessToken()`
 3. **Attaches** the claims to the request context with `context.WithValue()`
 4. **Proceeds** to the next handler or **writes** 401 if validation fails
 
@@ -165,7 +165,7 @@ Chi allows organizing routes hierarchically:
 
 ```go
 r.Route("/api", func(r chi.Router) {
-    r.Use(auth.AuthMiddleware(svc))  // Only applied to /api routes
+    r.Use(auth.BearerMiddleware(mgr))  // Only applied to /api routes
     r.Get("/profile", profileHandler)
     r.Post("/logout", logoutHandler)
 })
@@ -178,16 +178,16 @@ The example demonstrates proper `jwtauth` lifecycle management:
 ```go
 // Start
 km.Start(ctx)
-svc.Start(ctx)
+mgr.Start(ctx)
 
 // Use
-svc.IssueTokenPair(ctx, userID)
-svc.ValidateAccessToken(ctx, token)
-svc.RefreshAccessToken(ctx, refreshToken)
-svc.RevokeAllUserTokens(ctx, userID)
+mgr.IssueTokenPair(ctx, userID)
+mgr.ValidateAccessToken(ctx, token)
+mgr.RefreshAccessToken(ctx, refreshToken)
+mgr.RevokeAllUserTokens(ctx, userID)
 
 // Shutdown
-svc.Shutdown(shutdownCtx)
+mgr.Shutdown(shutdownCtx)
 km.Shutdown(shutdownCtx)
 ```
 
@@ -218,7 +218,7 @@ claims := map[string]interface{}{
     "tenant": "org-123",
 }
 
-token, err := svc.IssueAccessTokenWithClaims(ctx, userID, claims)
+token, err := mgr.IssueAccessTokenWithClaims(ctx, userID, claims)
 ```
 
 ### Add Authorization Middleware
@@ -227,7 +227,7 @@ Use `ValidateAccessTokenWithClaims` in your middleware to surface custom claims,
 
 ```go
 // In auth middleware — replace ValidateAccessToken with ValidateAccessTokenWithClaims
-registered, custom, err := svc.ValidateAccessTokenWithClaims(r.Context(), token)
+registered, custom, err := mgr.ValidateAccessTokenWithClaims(r.Context(), token)
 if err != nil {
     writeJSONError(w, tokenErrorCode(err), http.StatusUnauthorized)
     return
@@ -265,7 +265,7 @@ Replace the in-memory `RefreshStore` with your own implementation:
 // Create custom store
 store := database.NewPostgresRefreshStore(db, logger)
 
-svc, _ := tokens.NewService(tokens.ServiceConfig{
+mgr, _ := tokens.NewManager(tokens.ManagerConfig{
     RefreshStore: store,
     // ... other config
 })
@@ -284,7 +284,7 @@ km, _ := keymanager.NewManager(keymanager.ManagerConfig{
     Logger:   logger,
 })
 
-svc, _ := tokens.NewService(tokens.ServiceConfig{
+mgr, _ := tokens.NewManager(tokens.ManagerConfig{
     Logger: logger,
 })
 ```

--- a/examples/chi-example/auth/middleware.go
+++ b/examples/chi-example/auth/middleware.go
@@ -10,9 +10,9 @@ import (
 	"github.com/aetomala/jwtauth/pkg/tokens"
 )
 
-// AuthMiddleware validates JWT tokens in the Authorization header
+// BearerMiddleware validates JWT tokens in the Authorization header
 // and attaches claims to the request context.
-func AuthMiddleware(svc *tokens.Service) func(http.Handler) http.Handler {
+func BearerMiddleware(mgr *tokens.Manager) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Extract token from Authorization header
@@ -30,7 +30,7 @@ func AuthMiddleware(svc *tokens.Service) func(http.Handler) http.Handler {
 			}
 
 			// Validate token using jwtauth
-			claims, err := svc.ValidateAccessToken(r.Context(), token)
+			claims, err := mgr.ValidateAccessToken(r.Context(), token)
 			if err != nil {
 				writeJSONError(w, tokenErrorCode(err), http.StatusUnauthorized)
 				return

--- a/examples/chi-example/main.go
+++ b/examples/chi-example/main.go
@@ -56,7 +56,7 @@ func main() {
 	store := storage.NewMemoryRefreshStore(logger, pm)
 
 	// Create TokenService
-	svc, err := tokens.NewService(tokens.ServiceConfig{
+	mgr, err := tokens.NewManager(tokens.ManagerConfig{
 		KeyManager:           km,
 		RefreshStore:         store,
 		AccessTokenDuration:  15 * time.Minute,
@@ -71,13 +71,13 @@ func main() {
 		log.Fatal("Failed to create TokenService:", err)
 	}
 
-	if err := svc.Start(ctx); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		log.Fatal("Failed to start TokenService:", err)
 	}
 	defer func() {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_ = svc.Shutdown(shutdownCtx)
+		_ = mgr.Shutdown(shutdownCtx)
 	}()
 
 	// Setup Chi router
@@ -92,17 +92,17 @@ func main() {
 	r.Get("/metrics", pm.Handler().ServeHTTP)
 
 	// Public endpoints
-	r.Post("/login", loginHandler(svc))
-	r.Post("/refresh", refreshHandler(svc))
+	r.Post("/login", issueTokensHandler(mgr))
+	r.Post("/refresh", refreshHandler(mgr))
 
 	// Health check
 	r.Get("/health", healthHandler)
 
 	// Protected routes
 	r.Route("/api", func(r chi.Router) {
-		r.Use(auth.AuthMiddleware(svc))
+		r.Use(auth.BearerMiddleware(mgr))
 		r.Get("/profile", profileHandler)
-		r.Post("/logout", logoutHandler(svc))
+		r.Post("/logout", logoutHandler(mgr))
 	})
 
 	log.Println("Starting server on :8080")
@@ -123,8 +123,8 @@ type TokenResponse struct {
 	ExpiresIn    int    `json:"expires_in"`
 }
 
-// loginHandler issues a new token pair
-func loginHandler(svc *tokens.Service) http.HandlerFunc {
+// issueTokensHandler issues a new token pair
+func issueTokensHandler(mgr *tokens.Manager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req LoginRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -140,7 +140,7 @@ func loginHandler(svc *tokens.Service) http.HandlerFunc {
 		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 		defer cancel()
 
-		accessToken, refreshToken, err := svc.IssueTokenPair(ctx, req.UserID)
+		accessToken, refreshToken, err := mgr.IssueTokenPair(ctx, req.UserID)
 		if err != nil {
 			http.Error(w, "failed to issue tokens", http.StatusInternalServerError)
 			return
@@ -161,7 +161,7 @@ type RefreshRequest struct {
 }
 
 // refreshHandler refreshes an access token
-func refreshHandler(svc *tokens.Service) http.HandlerFunc {
+func refreshHandler(mgr *tokens.Manager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req RefreshRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -177,7 +177,7 @@ func refreshHandler(svc *tokens.Service) http.HandlerFunc {
 		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 		defer cancel()
 
-		accessToken, err := svc.RefreshAccessToken(ctx, req.RefreshToken)
+		accessToken, err := mgr.RefreshAccessToken(ctx, req.RefreshToken)
 		if err != nil {
 			http.Error(w, "failed to refresh token", http.StatusUnauthorized)
 			return
@@ -207,7 +207,7 @@ func profileHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // logoutHandler revokes the user's tokens
-func logoutHandler(svc *tokens.Service) http.HandlerFunc {
+func logoutHandler(mgr *tokens.Manager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		userID := r.Context().Value("userID")
 		if userID == nil {
@@ -218,7 +218,7 @@ func logoutHandler(svc *tokens.Service) http.HandlerFunc {
 		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 		defer cancel()
 
-		if err := svc.RevokeAllUserTokens(ctx, userID.(string)); err != nil {
+		if err := mgr.RevokeAllUserTokens(ctx, userID.(string)); err != nil {
 			http.Error(w, "failed to revoke tokens", http.StatusInternalServerError)
 			return
 		}

--- a/examples/correlation-example/README.md
+++ b/examples/correlation-example/README.md
@@ -1,0 +1,210 @@
+# Correlation ID Example
+
+This example demonstrates end-to-end correlation ID tracing using only the Go standard library (`net/http`). Every log line produced by jwtauth during a request carries the same `correlation_id`, making production log filtering trivial.
+
+## Overview
+
+The example shows:
+- Wiring `NewCorrelationJSONLogger` so all jwtauth internal logs carry `correlation_id`
+- An `X-Correlation-ID` HTTP middleware that injects or generates the ID per request
+- How passing the enriched context to jwtauth operations propagates the ID automatically
+- Filtering the resulting logs by `correlation_id` in a log aggregator
+
+## Project Structure
+
+```
+correlation-example/
+├── main.go     # Server setup, middleware, and route handlers
+└── README.md   # This file
+```
+
+## Setup
+
+### Prerequisites
+
+- Go 1.21+
+- The parent `jwtauth` library (from the parent directory)
+
+### Install Dependencies
+
+```bash
+go mod tidy
+```
+
+## Running the Example
+
+```bash
+go run main.go
+```
+
+You'll see output like:
+
+```
+{"time":"2026-04-14T10:30:00Z","level":"INFO","msg":"correlation-example server starting","addr":":8080"}
+{"time":"2026-04-14T10:30:00Z","level":"INFO","msg":"key manager started","active_keys":1,"current_key_id":"20260414_103000"}
+{"time":"2026-04-14T10:30:00Z","level":"INFO","msg":"token manager started","issuer":"correlation-example"}
+```
+
+## Testing the API
+
+### 1. Login — supply a correlation ID
+
+```bash
+curl -s -X POST http://localhost:8080/login \
+  -H "Content-Type: application/json" \
+  -H "X-Correlation-ID: req-001" \
+  -d '{"user_id": "alice"}'
+```
+
+Response:
+```json
+{
+  "access_token": "eyJhbGci...",
+  "refresh_token": "eyJhbGci..."
+}
+```
+
+Every log line the server emits while handling this request includes `"correlation_id":"req-001"`:
+
+```json
+{"time":"...","level":"INFO","msg":"token pair issued","userID":"alice","correlation_id":"req-001"}
+{"time":"...","level":"DEBUG","msg":"refresh token stored","tokenID":"tok-xyz","correlation_id":"req-001"}
+```
+
+### 2. Login — no correlation ID supplied
+
+```bash
+curl -s -X POST http://localhost:8080/login \
+  -H "Content-Type: application/json" \
+  -d '{"user_id": "bob"}'
+```
+
+The server generates an ID automatically and echoes it back in the `X-Correlation-ID` response header:
+
+```
+X-Correlation-ID: 3f2a1b0c-4d5e
+```
+
+### 3. Refresh Token
+
+```bash
+curl -s -X POST http://localhost:8080/refresh \
+  -H "Content-Type: application/json" \
+  -H "X-Correlation-ID: req-002" \
+  -d '{"refresh_token": "YOUR_REFRESH_TOKEN"}'
+```
+
+Response:
+```json
+{
+  "access_token": "eyJhbGci..."
+}
+```
+
+### 4. Validate Token
+
+```bash
+curl -s -X GET http://localhost:8080/validate \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -H "X-Correlation-ID: req-003"
+```
+
+Response:
+```json
+{
+  "subject": "alice",
+  "issuer": "correlation-example"
+}
+```
+
+### 5. Filter Logs by Correlation ID
+
+With JSON logging, every line is filterable. To isolate all log lines for a single request:
+
+```bash
+go run main.go 2>&1 | jq 'select(.correlation_id=="req-001")'
+```
+
+## Key Implementation Details
+
+### Logger: `NewCorrelationJSONLogger`
+
+The example uses `logging.NewCorrelationJSONLogger` instead of `logging.NewJSONLogger`:
+
+```go
+logger := logging.NewCorrelationJSONLogger(slog.LevelDebug)
+```
+
+`NewCorrelationJSONLogger` wraps `slog.NewJSONHandler` with `CorrelationIDHandler`. When any jwtauth component logs a line, `CorrelationIDHandler` extracts the correlation ID from the context and appends it to the record. Switching back to `NewJSONLogger` would produce identical logs minus the `correlation_id` field.
+
+### The `withCorrelation` Middleware
+
+```go
+withCorrelation := func(next http.HandlerFunc) http.HandlerFunc {
+    return func(w http.ResponseWriter, r *http.Request) {
+        id := r.Header.Get("X-Correlation-ID")
+        if id == "" {
+            id = newCorrelationID() // auto-generate if absent
+        }
+        ctx := logging.WithCorrelationID(r.Context(), id)
+        w.Header().Set("X-Correlation-ID", id)
+        next(w, r.WithContext(ctx))
+    }
+}
+```
+
+This is the only place the correlation ID enters the system. The enriched context is then passed to every jwtauth call (`IssueTokenPair`, `RefreshAccessToken`, `ValidateAccessToken`), and jwtauth threads it through all internal operations.
+
+### The Context-as-First-Kwarg Convention
+
+jwtauth components pass `ctx` as the first element of key-value pairs when calling the logger:
+
+```go
+logger.Info("token pair issued", ctx, "userID", userID)
+```
+
+`SlogAdapter` detects this and routes the call through `slog.InfoContext(ctx, ...)`. The `CorrelationIDHandler` then sees the context in its `Handle(ctx, r)` method and appends `correlation_id` automatically. No changes to the `Logger` interface or to component call sites are needed.
+
+### Auto-Generated IDs
+
+For requests that arrive without `X-Correlation-ID`, the middleware generates a short pseudo-random hex ID:
+
+```go
+func newCorrelationID() string {
+    return fmt.Sprintf("%08x-%04x", rand.Uint32(), rand.Uint32()&0xffff)
+}
+```
+
+For production use, replace this with a UUID library (e.g. `github.com/google/uuid`) to guarantee global uniqueness.
+
+## Adding Correlation ID to Gin, Chi, or Echo
+
+The pattern is framework-agnostic. For Gin:
+
+```go
+// 1. Swap the logger
+logger := logging.NewCorrelationJSONLogger(slog.LevelInfo)
+
+// 2. Add a correlation ID middleware
+r.Use(func(c *gin.Context) {
+    id := c.GetHeader("X-Correlation-ID")
+    if id == "" {
+        id = uuid.New().String()
+    }
+    ctx := logging.WithCorrelationID(c.Request.Context(), id)
+    c.Request = c.Request.WithContext(ctx)
+    c.Header("X-Correlation-ID", id)
+    c.Next()
+})
+
+// 3. Handlers already pass c.Request.Context() to jwtauth — no other changes needed.
+```
+
+Chi and Echo follow the same two-step pattern: swap the logger constructor, add one middleware.
+
+## Next Steps
+
+- Read [pkg/logging/README.md](../../pkg/logging/README.md) for the full correlation ID API reference
+- Read [ARCHITECTURE.md](../../doc/ARCHITECTURE.md) for how the context-as-first-kwarg convention works internally
+- Explore the [Gin](../gin-example/), [Chi](../chi-example/), and [Echo](../echo-example/) examples for framework-specific patterns
+- Implement a Redis `RefreshStore` for distributed deployments

--- a/examples/correlation-example/main.go
+++ b/examples/correlation-example/main.go
@@ -44,9 +44,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	// ===== TokenService =====
+	// ===== TokenManager =====
 	store := storage.NewMemoryRefreshStore(logger, nil)
-	svc, err := tokens.NewService(tokens.ServiceConfig{
+	mgr, err := tokens.NewManager(tokens.ManagerConfig{
 		KeyManager:           km,
 		RefreshStore:         store,
 		AccessTokenDuration:  15 * time.Minute,
@@ -62,14 +62,14 @@ func main() {
 	}
 
 	startCtx := context.Background()
-	if err := svc.Start(startCtx); err != nil {
+	if err := mgr.Start(startCtx); err != nil {
 		slog.Error("failed to start token service", "error", err)
 		os.Exit(1)
 	}
 	defer func() {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_ = svc.Shutdown(shutdownCtx)
+		_ = mgr.Shutdown(shutdownCtx)
 	}()
 
 	// ===== HTTP Handlers =====
@@ -103,7 +103,7 @@ func main() {
 			return
 		}
 
-		accessToken, refreshToken, err := svc.IssueTokenPair(ctx, req.UserID)
+		accessToken, refreshToken, err := mgr.IssueTokenPair(ctx, req.UserID)
 		if err != nil {
 			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
 			return
@@ -128,7 +128,7 @@ func main() {
 			return
 		}
 
-		newAccessToken, err := svc.RefreshAccessToken(ctx, req.RefreshToken)
+		newAccessToken, err := mgr.RefreshAccessToken(ctx, req.RefreshToken)
 		if err != nil {
 			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusUnauthorized)
 			return
@@ -150,7 +150,7 @@ func main() {
 			return
 		}
 
-		claims, err := svc.ValidateAccessToken(ctx, bearer[7:])
+		claims, err := mgr.ValidateAccessToken(ctx, bearer[7:])
 		if err != nil {
 			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusUnauthorized)
 			return

--- a/examples/echo-example/README.md
+++ b/examples/echo-example/README.md
@@ -155,7 +155,7 @@ Response:
 Echo middleware follows the `func(HandlerFunc) HandlerFunc` pattern. The custom middleware in `middleware/auth.go`:
 
 1. **Extracts** the token from the `Authorization: Bearer <token>` header
-2. **Validates** the token using `svc.ValidateAccessToken()`
+2. **Validates** the token using `mgr.ValidateAccessToken()`
 3. **Attaches** the claims to the Echo context with `c.Set()`
 4. **Proceeds** to the next handler or **aborts** with 401 if validation fails
 
@@ -167,7 +167,7 @@ Echo allows organizing routes hierarchically with groups:
 
 ```go
 protected := e.Group("/api")
-protected.Use(middleware.AuthMiddleware(svc))
+protected.Use(middleware.BearerMiddleware(mgr))
 protected.GET("/profile", profileHandler)
 protected.POST("/logout", logoutHandler)
 ```
@@ -179,16 +179,16 @@ The example demonstrates proper `jwtauth` lifecycle management:
 ```go
 // Start
 km.Start(ctx)
-svc.Start(ctx)
+mgr.Start(ctx)
 
 // Use
-svc.IssueTokenPair(ctx, userID)
-svc.ValidateAccessToken(ctx, token)
-svc.RefreshAccessToken(ctx, refreshToken)
-svc.RevokeAllUserTokens(ctx, userID)
+mgr.IssueTokenPair(ctx, userID)
+mgr.ValidateAccessToken(ctx, token)
+mgr.RefreshAccessToken(ctx, refreshToken)
+mgr.RevokeAllUserTokens(ctx, userID)
 
 // Shutdown
-svc.Shutdown(shutdownCtx)
+mgr.Shutdown(shutdownCtx)
 km.Shutdown(shutdownCtx)
 ```
 
@@ -219,7 +219,7 @@ claims := map[string]interface{}{
     "tenant": "org-123",
 }
 
-token, err := svc.IssueAccessTokenWithClaims(ctx, userID, claims)
+token, err := mgr.IssueAccessTokenWithClaims(ctx, userID, claims)
 ```
 
 ### Add Authorization Middleware
@@ -228,7 +228,7 @@ Use `ValidateAccessTokenWithClaims` in your middleware to surface custom claims,
 
 ```go
 // In auth middleware — replace ValidateAccessToken with ValidateAccessTokenWithClaims
-registered, custom, err := svc.ValidateAccessTokenWithClaims(c.Request().Context(), token)
+registered, custom, err := mgr.ValidateAccessTokenWithClaims(c.Request().Context(), token)
 if err != nil {
     return c.JSON(http.StatusUnauthorized, map[string]string{"error": tokenErrorCode(err)})
 }
@@ -265,7 +265,7 @@ Replace the in-memory `RefreshStore` with your own implementation:
 // Create custom store
 store := database.NewPostgresRefreshStore(db, logger)
 
-svc, _ := tokens.NewService(tokens.ServiceConfig{
+mgr, _ := tokens.NewManager(tokens.ManagerConfig{
     RefreshStore: store,
     // ... other config
 })
@@ -284,7 +284,7 @@ km, _ := keymanager.NewManager(keymanager.ManagerConfig{
     Logger:   logger,
 })
 
-svc, _ := tokens.NewService(tokens.ServiceConfig{
+mgr, _ := tokens.NewManager(tokens.ManagerConfig{
     Logger: logger,
 })
 ```

--- a/examples/echo-example/main.go
+++ b/examples/echo-example/main.go
@@ -54,7 +54,7 @@ func main() {
 	store := storage.NewMemoryRefreshStore(logger, pm)
 
 	// Create TokenService
-	svc, err := tokens.NewService(tokens.ServiceConfig{
+	mgr, err := tokens.NewManager(tokens.ManagerConfig{
 		KeyManager:           km,
 		RefreshStore:         store,
 		AccessTokenDuration:  15 * time.Minute,
@@ -69,13 +69,13 @@ func main() {
 		log.Fatal("Failed to create TokenService:", err)
 	}
 
-	if err := svc.Start(ctx); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		log.Fatal("Failed to start TokenService:", err)
 	}
 	defer func() {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_ = svc.Shutdown(shutdownCtx)
+		_ = mgr.Shutdown(shutdownCtx)
 	}()
 
 	// Setup Echo router
@@ -84,7 +84,7 @@ func main() {
 	// Middleware
 	e.Use(echo.MiddlewareFunc(func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			c.Set("tokenService", svc)
+			c.Set("tokenService", mgr)
 			return next(c)
 		}
 	}))
@@ -96,17 +96,17 @@ func main() {
 	})
 
 	// Public endpoints
-	e.POST("/login", loginHandler(svc))
-	e.POST("/refresh", refreshHandler(svc))
+	e.POST("/login", issueTokensHandler(mgr))
+	e.POST("/refresh", refreshHandler(mgr))
 
 	// Health check
 	e.GET("/health", healthHandler)
 
 	// Protected endpoints
 	protected := e.Group("/api")
-	protected.Use(middleware.AuthMiddleware(svc))
+	protected.Use(middleware.BearerMiddleware(mgr))
 	protected.GET("/profile", profileHandler)
-	protected.POST("/logout", logoutHandler(svc))
+	protected.POST("/logout", logoutHandler(mgr))
 
 	log.Println("Starting server on :8080")
 	if err := e.Start(":8080"); err != nil && err != http.ErrServerClosed {
@@ -126,8 +126,8 @@ type TokenResponse struct {
 	ExpiresIn    int    `json:"expires_in"`
 }
 
-// loginHandler issues a new token pair
-func loginHandler(svc *tokens.Service) echo.HandlerFunc {
+// issueTokensHandler issues a new token pair
+func issueTokensHandler(mgr *tokens.Manager) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		var req LoginRequest
 		if err := c.Bind(&req); err != nil {
@@ -145,7 +145,7 @@ func loginHandler(svc *tokens.Service) echo.HandlerFunc {
 		ctx, cancel := context.WithTimeout(c.Request().Context(), 5*time.Second)
 		defer cancel()
 
-		accessToken, refreshToken, err := svc.IssueTokenPair(ctx, req.UserID)
+		accessToken, refreshToken, err := mgr.IssueTokenPair(ctx, req.UserID)
 		if err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]string{
 				"error": "failed to issue tokens",
@@ -166,7 +166,7 @@ type RefreshRequest struct {
 }
 
 // refreshHandler refreshes an access token
-func refreshHandler(svc *tokens.Service) echo.HandlerFunc {
+func refreshHandler(mgr *tokens.Manager) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		var req RefreshRequest
 		if err := c.Bind(&req); err != nil {
@@ -184,7 +184,7 @@ func refreshHandler(svc *tokens.Service) echo.HandlerFunc {
 		ctx, cancel := context.WithTimeout(c.Request().Context(), 5*time.Second)
 		defer cancel()
 
-		accessToken, err := svc.RefreshAccessToken(ctx, req.RefreshToken)
+		accessToken, err := mgr.RefreshAccessToken(ctx, req.RefreshToken)
 		if err != nil {
 			return c.JSON(http.StatusUnauthorized, map[string]string{
 				"error": "failed to refresh token",
@@ -214,7 +214,7 @@ func profileHandler(c echo.Context) error {
 }
 
 // logoutHandler revokes the user's tokens
-func logoutHandler(svc *tokens.Service) echo.HandlerFunc {
+func logoutHandler(mgr *tokens.Manager) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		userID := c.Get("userID")
 		if userID == nil {
@@ -226,7 +226,7 @@ func logoutHandler(svc *tokens.Service) echo.HandlerFunc {
 		ctx, cancel := context.WithTimeout(c.Request().Context(), 5*time.Second)
 		defer cancel()
 
-		if err := svc.RevokeAllUserTokens(ctx, userID.(string)); err != nil {
+		if err := mgr.RevokeAllUserTokens(ctx, userID.(string)); err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]string{
 				"error": "failed to revoke tokens",
 			})

--- a/examples/echo-example/middleware/auth.go
+++ b/examples/echo-example/middleware/auth.go
@@ -10,9 +10,9 @@ import (
 	"github.com/aetomala/jwtauth/pkg/tokens"
 )
 
-// AuthMiddleware validates JWT tokens in the Authorization header
+// BearerMiddleware validates JWT tokens in the Authorization header
 // and attaches claims to the Echo context.
-func AuthMiddleware(svc *tokens.Service) echo.MiddlewareFunc {
+func BearerMiddleware(mgr *tokens.Manager) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			// Extract token from Authorization header
@@ -32,7 +32,7 @@ func AuthMiddleware(svc *tokens.Service) echo.MiddlewareFunc {
 			}
 
 			// Validate token using jwtauth
-			claims, err := svc.ValidateAccessToken(c.Request().Context(), token)
+			claims, err := mgr.ValidateAccessToken(c.Request().Context(), token)
 			if err != nil {
 				return c.JSON(http.StatusUnauthorized, map[string]string{
 					"error": tokenErrorCode(err),

--- a/examples/gin-example/README.md
+++ b/examples/gin-example/README.md
@@ -154,7 +154,7 @@ Response:
 The custom middleware in `middleware/auth.go`:
 
 1. **Extracts** the token from the `Authorization: Bearer <token>` header
-2. **Validates** the token using `svc.ValidateAccessToken()`
+2. **Validates** the token using `mgr.ValidateAccessToken()`
 3. **Attaches** the claims to the Gin context with `c.Set()`
 4. **Proceeds** to the next handler or **aborts** with 401 if validation fails
 
@@ -167,16 +167,16 @@ The example demonstrates proper `jwtauth` lifecycle management:
 ```go
 // Start
 km.Start(ctx)
-svc.Start(ctx)
+mgr.Start(ctx)
 
 // Use
-svc.IssueTokenPair(ctx, userID)
-svc.ValidateAccessToken(ctx, token)
-svc.RefreshAccessToken(ctx, refreshToken)
-svc.RevokeAllUserTokens(ctx, userID)
+mgr.IssueTokenPair(ctx, userID)
+mgr.ValidateAccessToken(ctx, token)
+mgr.RefreshAccessToken(ctx, refreshToken)
+mgr.RevokeAllUserTokens(ctx, userID)
 
 // Shutdown
-svc.Shutdown(shutdownCtx)
+mgr.Shutdown(shutdownCtx)
 km.Shutdown(shutdownCtx)
 ```
 
@@ -207,7 +207,7 @@ claims := map[string]interface{}{
     "tenant": "org-123",
 }
 
-token, err := svc.IssueAccessTokenWithClaims(ctx, userID, claims)
+token, err := mgr.IssueAccessTokenWithClaims(ctx, userID, claims)
 ```
 
 ### Add Custom Middleware
@@ -216,7 +216,7 @@ Use `ValidateAccessTokenWithClaims` in your middleware to surface custom claims,
 
 ```go
 // In auth middleware — replace ValidateAccessToken with ValidateAccessTokenWithClaims
-registered, custom, err := svc.ValidateAccessTokenWithClaims(c.Request.Context(), token)
+registered, custom, err := mgr.ValidateAccessTokenWithClaims(c.Request.Context(), token)
 if err != nil {
     c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": tokenErrorCode(err)})
     return
@@ -252,7 +252,7 @@ Replace the in-memory `RefreshStore` with your own implementation:
 // Create custom store
 store := database.NewPostgresRefreshStore(db, logger)
 
-svc, _ := tokens.NewService(tokens.ServiceConfig{
+mgr, _ := tokens.NewManager(tokens.ManagerConfig{
     RefreshStore: store,
     // ... other config
 })
@@ -271,7 +271,7 @@ km, _ := keymanager.NewManager(keymanager.ManagerConfig{
     Logger:   logger,
 })
 
-svc, _ := tokens.NewService(tokens.ServiceConfig{
+mgr, _ := tokens.NewManager(tokens.ManagerConfig{
     Logger: logger,
 })
 ```

--- a/examples/gin-example/main.go
+++ b/examples/gin-example/main.go
@@ -54,7 +54,7 @@ func main() {
 	store := storage.NewMemoryRefreshStore(logger, pm)
 
 	// Create TokenService
-	svc, err := tokens.NewService(tokens.ServiceConfig{
+	mgr, err := tokens.NewManager(tokens.ManagerConfig{
 		KeyManager:           km,
 		RefreshStore:         store,
 		AccessTokenDuration:  15 * time.Minute,
@@ -69,13 +69,13 @@ func main() {
 		log.Fatal("Failed to create TokenService:", err)
 	}
 
-	if err := svc.Start(ctx); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		log.Fatal("Failed to start TokenService:", err)
 	}
 	defer func() {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_ = svc.Shutdown(shutdownCtx)
+		_ = mgr.Shutdown(shutdownCtx)
 	}()
 
 	// Setup Gin router
@@ -85,14 +85,14 @@ func main() {
 	r.GET("/metrics", gin.WrapH(pm.Handler()))
 
 	// Public endpoints
-	r.POST("/login", loginHandler(svc))
-	r.POST("/refresh", refreshHandler(svc))
+	r.POST("/login", issueTokensHandler(mgr))
+	r.POST("/refresh", refreshHandler(mgr))
 
 	// Protected endpoints
 	protected := r.Group("/api")
-	protected.Use(middleware.AuthMiddleware(svc))
+	protected.Use(middleware.BearerMiddleware(mgr))
 	protected.GET("/profile", profileHandler)
-	protected.POST("/logout", logoutHandler(svc))
+	protected.POST("/logout", logoutHandler(mgr))
 
 	// Health check
 	r.GET("/health", func(c *gin.Context) {
@@ -117,8 +117,8 @@ type TokenResponse struct {
 	ExpiresIn    int    `json:"expires_in"`
 }
 
-// loginHandler issues a new token pair
-func loginHandler(svc *tokens.Service) gin.HandlerFunc {
+// issueTokensHandler issues a new token pair
+func issueTokensHandler(mgr *tokens.Manager) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req LoginRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -134,7 +134,7 @@ func loginHandler(svc *tokens.Service) gin.HandlerFunc {
 		ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
 		defer cancel()
 
-		accessToken, refreshToken, err := svc.IssueTokenPair(ctx, req.UserID)
+		accessToken, refreshToken, err := mgr.IssueTokenPair(ctx, req.UserID)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to issue tokens"})
 			return
@@ -154,7 +154,7 @@ type RefreshRequest struct {
 }
 
 // refreshHandler refreshes an access token
-func refreshHandler(svc *tokens.Service) gin.HandlerFunc {
+func refreshHandler(mgr *tokens.Manager) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req RefreshRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -165,7 +165,7 @@ func refreshHandler(svc *tokens.Service) gin.HandlerFunc {
 		ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
 		defer cancel()
 
-		accessToken, err := svc.RefreshAccessToken(ctx, req.RefreshToken)
+		accessToken, err := mgr.RefreshAccessToken(ctx, req.RefreshToken)
 		if err != nil {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "failed to refresh token"})
 			return
@@ -193,7 +193,7 @@ func profileHandler(c *gin.Context) {
 }
 
 // logoutHandler revokes the user's tokens
-func logoutHandler(svc *tokens.Service) gin.HandlerFunc {
+func logoutHandler(mgr *tokens.Manager) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, exists := c.Get("userID")
 		if !exists {
@@ -204,7 +204,7 @@ func logoutHandler(svc *tokens.Service) gin.HandlerFunc {
 		ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
 		defer cancel()
 
-		if err := svc.RevokeAllUserTokens(ctx, userID.(string)); err != nil {
+		if err := mgr.RevokeAllUserTokens(ctx, userID.(string)); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to revoke tokens"})
 			return
 		}

--- a/examples/gin-example/middleware/auth.go
+++ b/examples/gin-example/middleware/auth.go
@@ -10,9 +10,9 @@ import (
 	"github.com/aetomala/jwtauth/pkg/tokens"
 )
 
-// AuthMiddleware validates JWT tokens in the Authorization header
+// BearerMiddleware validates JWT tokens in the Authorization header
 // and attaches claims to the Gin context.
-func AuthMiddleware(svc *tokens.Service) gin.HandlerFunc {
+func BearerMiddleware(mgr *tokens.Manager) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Extract token from Authorization header
 		authHeader := c.GetHeader("Authorization")
@@ -33,7 +33,7 @@ func AuthMiddleware(svc *tokens.Service) gin.HandlerFunc {
 		}
 
 		// Validate token using jwtauth
-		claims, err := svc.ValidateAccessToken(c.Request.Context(), token)
+		claims, err := mgr.ValidateAccessToken(c.Request.Context(), token)
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
 				"error": tokenErrorCode(err),

--- a/internal/testutil/README.md
+++ b/internal/testutil/README.md
@@ -40,10 +40,10 @@ mockKM.EXPECT().Start(gomock.Any()).Return(nil).AnyTimes()
 mockLog := testutil.NewMockLogger()
 
 // Pass to the component under test
-svc := myapp.NewService(myapp.Config{Logger: mockLog})
+mgr := myapp.NewManager(myapp.Config{Logger: mockLog})
 
 // Assert on captured output
-Expect(mockLog.HasLog("info", "service started")).To(BeTrue())
+Expect(mockLog.HasLog("info", "manager started")).To(BeTrue())
 Expect(mockLog.HasLogWithField("warn", "token expired", "tokenID")).To(BeTrue())
 Expect(mockLog.CountLogs("error")).To(Equal(0))
 

--- a/pkg/logging/README.md
+++ b/pkg/logging/README.md
@@ -1,6 +1,6 @@
 # Logging Package
 
-Shared logging interface for the JWT authentication system.
+Shared logging interface for the JWT authorization token engine.
 
 ## Overview
 

--- a/pkg/logging/README.md
+++ b/pkg/logging/README.md
@@ -8,42 +8,42 @@ The `logging` package provides a simple, structured logging interface that all c
 
 ## Design Principles
 
-- **Simple**: Only 3 log levels (Info, Warn, Error)
+- **Simple**: Only 4 log levels (Debug, Info, Warn, Error)
 - **Structured**: Key-value pairs for machine-readable logs
 - **Flexible**: Works with any logging library via adapters
 - **Optional**: Components work without a logger (nil-safe)
 
 ## Quick Start
 
-### Production (JSON for Kubernetes)
+### Production (JSON for Kubernetes, with correlation ID)
 
 ```go
 import (
     "log/slog"
-    "os"
     "github.com/aetomala/jwtauth/pkg/logging"
     "github.com/aetomala/jwtauth/pkg/keymanager"
 )
 
 func main() {
-    // Create JSON logger for production
-    handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-        Level: slog.LevelInfo,
-    })
-    logger := logging.NewSlogAdapter(slog.New(handler))
-    
-    // Or use helper:
+    // Recommended: JSON logger with CorrelationIDHandler pre-wired.
+    // When a request context carries a correlation ID, every jwtauth log
+    // line for that request will include "correlation_id" automatically.
+    logger := logging.NewCorrelationJSONLogger(slog.LevelInfo)
+
+    // Without correlation ID support (simpler, no X-Correlation-ID tracing):
     // logger := logging.NewJSONLogger(slog.LevelInfo)
-    
+
     // Use with KeyManager
     ks, _ := keymanager.NewDiskKeyStore("/keys", 2048, logger, nil)
     manager, _ := keymanager.NewManager(keymanager.ManagerConfig{
         KeyStore: ks,
         Logger:   logger,
     })
-    
+
     manager.Start(context.Background())
     // Logs: {"time":"2025-01-07T10:30:00Z","level":"INFO","msg":"key manager started"}
+    // With a correlation ID in ctx:
+    // {"time":"...","level":"INFO","msg":"token pair issued","correlation_id":"req-001","userID":"alice"}
 }
 ```
 
@@ -117,6 +117,21 @@ logger.Error("key rotation failed",
     "error", err,
     "keyID", keyID,
     "attempt", 3)
+```
+
+### Debug
+
+Use for development and troubleshooting. Suppressed at Info level and above — safe to leave in production code and enable only when needed:
+
+- Internal state, cache hits/misses
+- Entry points on high-frequency read paths
+- Intermediate steps inside loops
+- No-op outcomes ("nothing to do")
+
+```go
+logger.Debug("public key cache hit", "keyID", keyID)
+logger.Debug("revoking token for user", "tokenID", tokenID, "userID", userID)
+logger.Debug("no expired keys found during cleanup")
 ```
 
 ## Structured Logging
@@ -217,6 +232,10 @@ func NewZapAdapter(logger *zap.SugaredLogger) *ZapAdapter {
     return &ZapAdapter{logger: logger}
 }
 
+func (z *ZapAdapter) Debug(msg string, keysAndValues ...interface{}) {
+    z.logger.Debugw(msg, keysAndValues...)
+}
+
 func (z *ZapAdapter) Info(msg string, keysAndValues ...interface{}) {
     z.logger.Infow(msg, keysAndValues...)
 }
@@ -252,6 +271,12 @@ func NewZerologAdapter(logger zerolog.Logger) *ZerologAdapter {
     return &ZerologAdapter{logger: logger}
 }
 
+func (z *ZerologAdapter) Debug(msg string, keysAndValues ...interface{}) {
+    event := z.logger.Debug()
+    z.addFields(event, keysAndValues)
+    event.Msg(msg)
+}
+
 func (z *ZerologAdapter) Info(msg string, keysAndValues ...interface{}) {
     event := z.logger.Info()
     z.addFields(event, keysAndValues)
@@ -280,6 +305,89 @@ func (z *ZerologAdapter) addFields(event *zerolog.Event, keysAndValues []interfa
     }
 }
 ```
+
+## Correlation ID
+
+Every jwtauth component passes `context.Context` through all operations. When you wire `CorrelationIDHandler` into your logger and inject a correlation ID at the request boundary, **every internal log line for that request automatically carries `correlation_id`** — from token validation to refresh store lookups — with no changes to component code.
+
+### How It Works
+
+`SlogAdapter` checks whether the first element of `keysAndValues` is a `context.Context`. If it is, the adapter routes the call through `slog.*Context()` instead of `slog.*()`, which lets `CorrelationIDHandler` extract the ID and append it to every record:
+
+```go
+// This is how jwtauth components log internally — ctx as the first kwarg:
+logger.Info("token pair issued", ctx, "userID", userID)
+
+// SlogAdapter detects ctx and calls:
+s.logger.InfoContext(ctx, "token pair issued", "userID", userID)
+
+// CorrelationIDHandler.Handle extracts and injects the field:
+// → {"msg":"token pair issued","userID":"alice","correlation_id":"req-001"}
+```
+
+### Setup
+
+```go
+// Recommended for production — CorrelationIDHandler pre-wired:
+logger := logging.NewCorrelationJSONLogger(slog.LevelInfo)
+
+// For local development:
+// logger := logging.NewCorrelationTextLogger(slog.LevelDebug)
+
+mgr, _ := tokens.NewManager(tokens.ManagerConfig{
+    Logger: logger,
+    // ...
+})
+```
+
+### HTTP Middleware
+
+Inject a correlation ID once at the request boundary — jwtauth propagates it from there:
+
+```go
+func withCorrelation(next http.HandlerFunc) http.HandlerFunc {
+    return func(w http.ResponseWriter, r *http.Request) {
+        id := r.Header.Get("X-Correlation-ID")
+        if id == "" {
+            id = uuid.New().String() // generate if client did not supply one
+        }
+        ctx := logging.WithCorrelationID(r.Context(), id)
+        w.Header().Set("X-Correlation-ID", id) // echo back to client
+        next(w, r.WithContext(ctx))
+    }
+}
+
+// Handler — pass r.Context() (which now carries the ID) to all jwtauth calls:
+func loginHandler(w http.ResponseWriter, r *http.Request) {
+    accessToken, refreshToken, err := mgr.IssueTokenPair(r.Context(), userID)
+    // All jwtauth log lines for this call will include correlation_id automatically.
+}
+```
+
+### Output
+
+```json
+{"time":"2026-04-14T10:30:00Z","level":"INFO","msg":"token pair issued","userID":"alice","correlation_id":"req-001"}
+{"time":"2026-04-14T10:30:00Z","level":"DEBUG","msg":"refresh token stored","tokenID":"tok-xyz","correlation_id":"req-001"}
+```
+
+Every line for the same request carries the same `correlation_id`. Filter in any log aggregator:
+
+```bash
+jq 'select(.correlation_id=="req-001")' app.log
+```
+
+### API Reference
+
+| Symbol | Description |
+|--------|-------------|
+| `WithCorrelationID(ctx, id)` | Returns a copy of ctx with the correlation ID attached |
+| `GetCorrelationID(ctx)` | Extracts the correlation ID from ctx; returns `""` if not set |
+| `NewCorrelationIDHandler(h)` | Wraps any `slog.Handler` to inject `correlation_id` on every record |
+| `NewCorrelationJSONLogger(level)` | JSON logger with `CorrelationIDHandler` pre-wired — recommended for production |
+| `NewCorrelationTextLogger(level)` | Text logger with `CorrelationIDHandler` pre-wired — recommended for development |
+
+See [examples/correlation-example/](../../examples/correlation-example/) for a complete runnable demonstration.
 
 ## Testing
 
@@ -334,5 +442,5 @@ The Logger interface is designed to be compatible with OpenTelemetry for unified
 ## See Also
 
 - [Metrics Package](../metrics/README.md) - For metrics/monitoring
-- [Architecture Docs](../../docs/ARCHITECTURE.md) - Overall design decisions
+- [Architecture Docs](../../doc/ARCHITECTURE.md) - Overall design decisions
 - [KeyManager Example](../../examples/keymanager/) - Complete usage examples

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -1,7 +1,7 @@
 package logging
 
-// Logger is the standard logging interface for the JWT authentication system.
-// All components (KeyManager, TokenService, RefreshTokenStore, etc.)
+// Logger is the standard logging interface for the JWT authorization token engine.
+// All components (KeyManager, TokenManager, RefreshTokenStore, etc.)
 // use this interface for structured logging.
 //
 // Implementations must support structured logging with key-value pairs where

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -71,7 +71,7 @@ func NewPrometheusMetrics(config PrometheusConfig) *PrometheusMetrics {
 // registerAllMetrics registers every metric this package exposes, grouped by
 // the component that owns each metric.
 func (pm *PrometheusMetrics) registerAllMetrics(namespace string) {
-	// ===== TokenService Metrics =====
+	// ===== TokenManager Metrics =====
 
 	pm.registerCounter(namespace, "tokens_issued_total",
 		"Total number of tokens issued",

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -176,7 +176,7 @@ var _ = Describe("Prometheus", func() {
 				Expect(descCh).NotTo(BeEmpty())
 			})
 
-			It("should register TokenService counters", func() {
+			It("should register TokenManager counters", func() {
 				descCh := make(chan *prometheus.Desc, 100)
 				registry.Describe(descCh)
 				close(descCh)

--- a/pkg/tokens/integration/disk_memory_test.go
+++ b/pkg/tokens/integration/disk_memory_test.go
@@ -14,13 +14,13 @@ import (
 )
 
 func init() {
-	RunTokenServiceIntegrationTests(
-		"TokenService Integration — DiskKeyStore + MemoryRefreshStore",
+	RunTokenManagerIntegrationTests(
+		"TokenManager Integration — DiskKeyStore + MemoryRefreshStore",
 		diskMemoryFactory,
 	)
 }
 
-func diskMemoryFactory(cfg tokens.ServiceConfig) (*tokens.Service, *keymanager.Manager, func()) {
+func diskMemoryFactory(cfg tokens.ManagerConfig) (*tokens.Manager, *keymanager.Manager, func()) {
 	tmpDir, err := os.MkdirTemp("", "integration-disk-*")
 	Expect(err).NotTo(HaveOccurred())
 
@@ -37,12 +37,12 @@ func diskMemoryFactory(cfg tokens.ServiceConfig) (*tokens.Service, *keymanager.M
 	cfg.KeyManager = km
 	cfg.RefreshStore = storage.NewMemoryRefreshStore(nil, nil)
 
-	svc, err := tokens.NewService(cfg)
+	mgr, err := tokens.NewManager(cfg)
 	Expect(err).NotTo(HaveOccurred())
 
 	cleanup := func() {
 		os.RemoveAll(tmpDir)
 	}
 
-	return svc, km, cleanup
+	return mgr, km, cleanup
 }

--- a/pkg/tokens/integration/integration_suite_test.go
+++ b/pkg/tokens/integration/integration_suite_test.go
@@ -19,18 +19,18 @@ func TestIntegration(t *testing.T) {
 	RunSpecs(t, "Integration Suite")
 }
 
-// ServiceFactory creates a configured but not-yet-started TokenService along with its
+// ManagerFactory creates a configured but not-yet-started TokenManager along with its
 // KeyManager and a cleanup function. The caller is responsible for calling Start and
-// Shutdown on the returned service, and calling cleanup after Shutdown.
-type ServiceFactory func(cfg tokens.ServiceConfig) (svc *tokens.Service, km *keymanager.Manager, cleanup func())
+// Shutdown on the returned manager, and calling cleanup after Shutdown.
+type ManagerFactory func(cfg tokens.ManagerConfig) (mgr *tokens.Manager, km *keymanager.Manager, cleanup func())
 
-// RunTokenServiceIntegrationTests runs the full TokenService behavioral contract suite
+// RunTokenManagerIntegrationTests runs the full TokenManager behavioral contract suite
 // against the storage backend provided by factory. It is called once per backend
 // (DiskKeyStore+Memory, RedisKeyStore+Redis) and produces 10 specs each.
-func RunTokenServiceIntegrationTests(description string, factory ServiceFactory) {
+func RunTokenManagerIntegrationTests(description string, factory ManagerFactory) {
 	Describe(description, func() {
 		var (
-			svc    *tokens.Service
+			mgr    *tokens.Manager
 			km     *keymanager.Manager
 			ctx    context.Context
 			cancel context.CancelFunc
@@ -40,20 +40,20 @@ func RunTokenServiceIntegrationTests(description string, factory ServiceFactory)
 			ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
 
 			var cleanup func()
-			svc, km, cleanup = factory(tokens.ServiceConfig{
+			mgr, km, cleanup = factory(tokens.ManagerConfig{
 				AccessTokenDuration:  5 * time.Minute,
 				RefreshTokenDuration: 1 * time.Hour,
 				CleanupInterval:      5 * time.Minute,
 				Issuer:               "integration-test",
 				Audience:             []string{"integration-test"},
 			})
-			Expect(svc.Start(ctx)).To(Succeed())
+			Expect(mgr.Start(ctx)).To(Succeed())
 
 			DeferCleanup(func() {
-				if svc != nil && svc.IsRunning() {
+				if mgr != nil && mgr.IsRunning() {
 					shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 					defer shutdownCancel()
-					_ = svc.Shutdown(shutdownCtx)
+					_ = mgr.Shutdown(shutdownCtx)
 				}
 				cancel()
 				if cleanup != nil {
@@ -65,22 +65,22 @@ func RunTokenServiceIntegrationTests(description string, factory ServiceFactory)
 		It("should issue, validate, and refresh tokens", func() {
 			userID := "test-user"
 
-			accessToken, refreshToken, err := svc.IssueTokenPair(ctx, userID)
+			accessToken, refreshToken, err := mgr.IssueTokenPair(ctx, userID)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(accessToken).NotTo(BeEmpty())
 			Expect(refreshToken).NotTo(BeEmpty())
 
-			claims, err := svc.ValidateAccessToken(ctx, accessToken)
+			claims, err := mgr.ValidateAccessToken(ctx, accessToken)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(claims.Subject).To(Equal(userID))
 			Expect(claims.Issuer).To(Equal("integration-test"))
 			Expect(claims.Audience).To(ContainElement("integration-test"))
 
-			newAccessToken, err := svc.RefreshAccessToken(ctx, refreshToken)
+			newAccessToken, err := mgr.RefreshAccessToken(ctx, refreshToken)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(newAccessToken).NotTo(BeEmpty())
 
-			newClaims, err := svc.ValidateAccessToken(ctx, newAccessToken)
+			newClaims, err := mgr.ValidateAccessToken(ctx, newAccessToken)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(newClaims.Subject).To(Equal(userID))
 
@@ -90,82 +90,82 @@ func RunTokenServiceIntegrationTests(description string, factory ServiceFactory)
 		It("should prevent refresh after token is revoked", func() {
 			userID := "revoke-test-user"
 
-			refreshToken, err := svc.IssueRefreshToken(ctx, userID)
+			refreshToken, err := mgr.IssueRefreshToken(ctx, userID)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = svc.RevokeAllUserTokens(ctx, userID)
+			err = mgr.RevokeAllUserTokens(ctx, userID)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = svc.RefreshAccessToken(ctx, refreshToken)
+			_, err = mgr.RefreshAccessToken(ctx, refreshToken)
 			Expect(err).To(Equal(tokens.ErrTokenRevoked))
 		})
 
 		It("should invalidate all refresh tokens for a user", func() {
 			userID := "multi-token-user"
 
-			token1, err := svc.IssueRefreshToken(ctx, userID)
+			token1, err := mgr.IssueRefreshToken(ctx, userID)
 			Expect(err).NotTo(HaveOccurred())
 
-			token2, err := svc.IssueRefreshToken(ctx, userID)
+			token2, err := mgr.IssueRefreshToken(ctx, userID)
 			Expect(err).NotTo(HaveOccurred())
 
-			token3, err := svc.IssueRefreshToken(ctx, userID)
+			token3, err := mgr.IssueRefreshToken(ctx, userID)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = svc.RefreshAccessToken(ctx, token1)
+			_, err = mgr.RefreshAccessToken(ctx, token1)
 			Expect(err).NotTo(HaveOccurred())
-			_, err = svc.RefreshAccessToken(ctx, token2)
+			_, err = mgr.RefreshAccessToken(ctx, token2)
 			Expect(err).NotTo(HaveOccurred())
-			_, err = svc.RefreshAccessToken(ctx, token3)
-			Expect(err).NotTo(HaveOccurred())
-
-			err = svc.RevokeAllUserTokens(ctx, userID)
+			_, err = mgr.RefreshAccessToken(ctx, token3)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = svc.RefreshAccessToken(ctx, token1)
+			err = mgr.RevokeAllUserTokens(ctx, userID)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = mgr.RefreshAccessToken(ctx, token1)
 			Expect(err).To(Equal(tokens.ErrTokenRevoked))
 
-			_, err = svc.RefreshAccessToken(ctx, token2)
+			_, err = mgr.RefreshAccessToken(ctx, token2)
 			Expect(err).To(Equal(tokens.ErrTokenRevoked))
 
-			_, err = svc.RefreshAccessToken(ctx, token3)
+			_, err = mgr.RefreshAccessToken(ctx, token3)
 			Expect(err).To(Equal(tokens.ErrTokenRevoked))
 		})
 
 		It("should introspect active and revoked tokens", func() {
 			userID := "introspect-user"
 
-			refreshToken1, err := svc.IssueRefreshToken(ctx, userID)
+			refreshToken1, err := mgr.IssueRefreshToken(ctx, userID)
 			Expect(err).NotTo(HaveOccurred())
 
-			metadata, err := svc.IntrospectToken(ctx, refreshToken1)
+			metadata, err := mgr.IntrospectToken(ctx, refreshToken1)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(metadata.Active).To(BeTrue())
 			Expect(metadata.Subject).To(Equal(userID))
 
-			_, err = svc.IssueRefreshToken(ctx, userID)
+			_, err = mgr.IssueRefreshToken(ctx, userID)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = svc.RevokeAllUserTokens(ctx, userID)
+			err = mgr.RevokeAllUserTokens(ctx, userID)
 			Expect(err).NotTo(HaveOccurred())
 
-			revokedMetadata, err := svc.IntrospectToken(ctx, refreshToken1)
+			revokedMetadata, err := mgr.IntrospectToken(ctx, refreshToken1)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(revokedMetadata.Active).To(BeFalse())
 		})
 
 		It("should reject operations when service is not running", func() {
-			svc2, _, cleanup2 := factory(tokens.ServiceConfig{
+			mgr2, _, cleanup2 := factory(tokens.ManagerConfig{
 				AccessTokenDuration:  5 * time.Minute,
 				RefreshTokenDuration: 1 * time.Hour,
 				Issuer:               "integration-test",
 				Audience:             []string{"integration-test"},
 			})
 			DeferCleanup(cleanup2)
-			// Note: NOT calling svc2.Start(ctx)
+			// Note: NOT calling mgr2.Start(ctx)
 
-			_, err := svc2.IssueAccessToken(ctx, "user-id")
-			Expect(err).To(Equal(tokens.ErrServiceNotRunning))
+			_, err := mgr2.IssueAccessToken(ctx, "user-id")
+			Expect(err).To(Equal(tokens.ErrManagerNotRunning))
 		})
 
 		It("should issue tokens concurrently without data races", func() {
@@ -175,7 +175,7 @@ func RunTokenServiceIntegrationTests(description string, factory ServiceFactory)
 			results := make(chan string, numGoroutines*2)
 			for i := 0; i < numGoroutines; i++ {
 				go func() {
-					accessToken, refreshToken, err := svc.IssueTokenPair(ctx, userID)
+					accessToken, refreshToken, err := mgr.IssueTokenPair(ctx, userID)
 					Expect(err).NotTo(HaveOccurred())
 					results <- accessToken
 					results <- refreshToken
@@ -200,23 +200,23 @@ func RunTokenServiceIntegrationTests(description string, factory ServiceFactory)
 		It("should validate tokens signed before a key rotation", func() {
 			userID := "rotation-user"
 
-			oldAccessToken, err := svc.IssueAccessToken(ctx, userID)
+			oldAccessToken, err := mgr.IssueAccessToken(ctx, userID)
 			Expect(err).NotTo(HaveOccurred())
 
-			claims, err := svc.ValidateAccessToken(ctx, oldAccessToken)
+			claims, err := mgr.ValidateAccessToken(ctx, oldAccessToken)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(claims.Subject).To(Equal(userID))
 
 			err = km.RotateKeys(ctx)
 			Expect(err).NotTo(HaveOccurred())
 
-			claims, err = svc.ValidateAccessToken(ctx, oldAccessToken)
+			claims, err = mgr.ValidateAccessToken(ctx, oldAccessToken)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(claims.Subject).To(Equal(userID))
 
-			newAccessToken, err := svc.IssueAccessToken(ctx, userID)
+			newAccessToken, err := mgr.IssueAccessToken(ctx, userID)
 			Expect(err).NotTo(HaveOccurred())
-			claims, err = svc.ValidateAccessToken(ctx, newAccessToken)
+			claims, err = mgr.ValidateAccessToken(ctx, newAccessToken)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(claims.Subject).To(Equal(userID))
 		})
@@ -224,42 +224,42 @@ func RunTokenServiceIntegrationTests(description string, factory ServiceFactory)
 		It("should clean up expired tokens", func() {
 			userID := "cleanup-user"
 
-			svc2, _, cleanup2 := factory(tokens.ServiceConfig{
+			mgr2, _, cleanup2 := factory(tokens.ManagerConfig{
 				AccessTokenDuration:  5 * time.Minute,
 				RefreshTokenDuration: 100 * time.Millisecond,
 				CleanupInterval:      10 * time.Second,
 				Issuer:               "integration-test",
 				Audience:             []string{"integration-test"},
 			})
-			Expect(svc2.Start(ctx)).To(Succeed())
+			Expect(mgr2.Start(ctx)).To(Succeed())
 			DeferCleanup(func() {
 				shutdownCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
 				defer c()
-				_ = svc2.Shutdown(shutdownCtx)
+				_ = mgr2.Shutdown(shutdownCtx)
 				cleanup2()
 			})
 
-			token1, err := svc2.IssueRefreshToken(ctx, userID)
+			token1, err := mgr2.IssueRefreshToken(ctx, userID)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = svc2.IssueRefreshToken(ctx, userID)
+			_, err = mgr2.IssueRefreshToken(ctx, userID)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = svc2.IssueRefreshToken(ctx, userID)
+			_, err = mgr2.IssueRefreshToken(ctx, userID)
 			Expect(err).NotTo(HaveOccurred())
 
 			time.Sleep(150 * time.Millisecond)
 
-			count, err := svc2.CleanupExpiredTokens(ctx)
+			count, err := mgr2.CleanupExpiredTokens(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(count).To(BeNumerically(">=", 3))
 
-			_, err = svc2.RefreshAccessToken(ctx, token1)
+			_, err = mgr2.RefreshAccessToken(ctx, token1)
 			Expect(err).To(HaveOccurred())
 
-			freshToken, err := svc2.IssueRefreshToken(ctx, userID)
+			freshToken, err := mgr2.IssueRefreshToken(ctx, userID)
 			Expect(err).NotTo(HaveOccurred())
-			newAccessToken, err := svc2.RefreshAccessToken(ctx, freshToken)
+			newAccessToken, err := mgr2.RefreshAccessToken(ctx, freshToken)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(newAccessToken).NotTo(BeEmpty())
 		})
@@ -279,14 +279,14 @@ func RunTokenServiceIntegrationTests(description string, factory ServiceFactory)
 					"device_id":   deviceID,
 					"ip_address":  "192.168.1.100",
 				}
-				token, err := svc.IssueRefreshTokenWithMetadata(ctx, userID, metadata)
+				token, err := mgr.IssueRefreshTokenWithMetadata(ctx, userID, metadata)
 				Expect(err).NotTo(HaveOccurred())
 				deviceRefreshTokens[deviceName] = token
 			}
 
 			accessTokens := make(map[string]string)
 			for deviceName, refreshToken := range deviceRefreshTokens {
-				accessToken, err := svc.RefreshAccessToken(ctx, refreshToken)
+				accessToken, err := mgr.RefreshAccessToken(ctx, refreshToken)
 				Expect(err).NotTo(HaveOccurred())
 				accessTokens[deviceName] = accessToken
 			}
@@ -297,17 +297,17 @@ func RunTokenServiceIntegrationTests(description string, factory ServiceFactory)
 			}
 
 			for deviceName, accessToken := range accessTokens {
-				claims, err := svc.ValidateAccessToken(ctx, accessToken)
+				claims, err := mgr.ValidateAccessToken(ctx, accessToken)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(claims.Subject).To(Equal(userID))
 				_ = deviceName
 			}
 
-			err := svc.RevokeAllUserTokens(ctx, userID)
+			err := mgr.RevokeAllUserTokens(ctx, userID)
 			Expect(err).NotTo(HaveOccurred())
 
 			for _, refreshToken := range deviceRefreshTokens {
-				_, err = svc.RefreshAccessToken(ctx, refreshToken)
+				_, err = mgr.RefreshAccessToken(ctx, refreshToken)
 				Expect(err).To(Equal(tokens.ErrTokenRevoked))
 			}
 		})
@@ -315,48 +315,48 @@ func RunTokenServiceIntegrationTests(description string, factory ServiceFactory)
 		It("should reject invalid, expired, and revoked refresh tokens", func() {
 			validUserID := "valid-user"
 
-			validToken, err := svc.IssueRefreshToken(ctx, validUserID)
+			validToken, err := mgr.IssueRefreshToken(ctx, validUserID)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = svc.RefreshAccessToken(ctx, "not-a-valid-token")
+			_, err = mgr.RefreshAccessToken(ctx, "not-a-valid-token")
 			Expect(err).To(HaveOccurred())
 
-			svc2, _, cleanup2 := factory(tokens.ServiceConfig{
+			mgr2, _, cleanup2 := factory(tokens.ManagerConfig{
 				AccessTokenDuration:  5 * time.Minute,
 				RefreshTokenDuration: 50 * time.Millisecond,
 				Issuer:               "integration-test",
 				Audience:             []string{"integration-test"},
 			})
-			Expect(svc2.Start(ctx)).To(Succeed())
+			Expect(mgr2.Start(ctx)).To(Succeed())
 			DeferCleanup(func() {
 				shutdownCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
 				defer c()
-				_ = svc2.Shutdown(shutdownCtx)
+				_ = mgr2.Shutdown(shutdownCtx)
 				cleanup2()
 			})
 
-			expiredToken, err := svc2.IssueRefreshToken(ctx, "expired-user")
+			expiredToken, err := mgr2.IssueRefreshToken(ctx, "expired-user")
 			Expect(err).NotTo(HaveOccurred())
 			time.Sleep(100 * time.Millisecond)
-			_, err = svc2.RefreshAccessToken(ctx, expiredToken)
+			_, err = mgr2.RefreshAccessToken(ctx, expiredToken)
 			Expect(err).To(HaveOccurred())
 
 			revokeUserID := "revoke-user"
-			revokedToken, err := svc.IssueRefreshToken(ctx, revokeUserID)
+			revokedToken, err := mgr.IssueRefreshToken(ctx, revokeUserID)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = svc.RefreshAccessToken(ctx, revokedToken)
+			_, err = mgr.RefreshAccessToken(ctx, revokedToken)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = svc.RevokeAllUserTokens(ctx, revokeUserID)
+			err = mgr.RevokeAllUserTokens(ctx, revokeUserID)
 			Expect(err).NotTo(HaveOccurred())
-			_, err = svc.RefreshAccessToken(ctx, revokedToken)
+			_, err = mgr.RefreshAccessToken(ctx, revokedToken)
 			Expect(err).To(Equal(tokens.ErrTokenRevoked))
 
-			_, err = svc.RefreshAccessToken(ctx, "token-never-issued")
+			_, err = mgr.RefreshAccessToken(ctx, "token-never-issued")
 			Expect(err).To(HaveOccurred())
 
-			newAccessToken, err := svc.RefreshAccessToken(ctx, validToken)
+			newAccessToken, err := mgr.RefreshAccessToken(ctx, validToken)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(newAccessToken).NotTo(BeEmpty())
 		})

--- a/pkg/tokens/integration/redis_test.go
+++ b/pkg/tokens/integration/redis_test.go
@@ -17,12 +17,12 @@ import (
 )
 
 func init() {
-	RunTokenServiceIntegrationTests(
-		"TokenService Integration — RedisKeyStore + RedisRefreshStore",
+	RunTokenManagerIntegrationTests(
+		"TokenManager Integration — RedisKeyStore + RedisRefreshStore",
 		redisFactory,
 	)
 
-	Describe("TokenService Integration — distributed Redis behavior", func() {
+	Describe("TokenManager Integration — distributed Redis behavior", func() {
 		var (
 			mr     *miniredis.Miniredis
 			client *redis.Client
@@ -52,9 +52,9 @@ func init() {
 			// key store and refresh store — this is the distributed deployment model.
 			// Each Manager starts independently, loading shared keys from Redis.
 			// Instance A issues and revokes; instance B must observe the revocation immediately
-			// because both TokenServices read from the same Redis refresh store.
+			// because both TokenManagers read from the same Redis refresh store.
 
-			// Instance A — own KeyManager, own TokenService, shared Redis backend
+			// Instance A — own KeyManager, own TokenManager, shared Redis backend
 			ksA, err := keymanager.NewRedisKeyStore(client, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -66,7 +66,7 @@ func init() {
 			Expect(err).NotTo(HaveOccurred())
 
 			storeA := storage.NewRedisRefreshStore(client, nil, nil)
-			svcA, err := tokens.NewService(tokens.ServiceConfig{
+			mgrA, err := tokens.NewManager(tokens.ManagerConfig{
 				KeyManager:           kmA,
 				RefreshStore:         storeA,
 				AccessTokenDuration:  5 * time.Minute,
@@ -75,14 +75,14 @@ func init() {
 				Audience:             []string{"integration-test"},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(svcA.Start(ctx)).To(Succeed())
+			Expect(mgrA.Start(ctx)).To(Succeed())
 			DeferCleanup(func() {
 				shutdownCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
 				defer c()
-				_ = svcA.Shutdown(shutdownCtx)
+				_ = mgrA.Shutdown(shutdownCtx)
 			})
 
-			// Instance B — own KeyManager (loads A's keys from Redis), own TokenService, shared refresh store
+			// Instance B — own KeyManager (loads A's keys from Redis), own TokenManager, shared refresh store
 			ksB, err := keymanager.NewRedisKeyStore(client, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -94,7 +94,7 @@ func init() {
 			Expect(err).NotTo(HaveOccurred())
 
 			storeB := storage.NewRedisRefreshStore(client, nil, nil)
-			svcB, err := tokens.NewService(tokens.ServiceConfig{
+			mgrB, err := tokens.NewManager(tokens.ManagerConfig{
 				KeyManager:           kmB,
 				RefreshStore:         storeB,
 				AccessTokenDuration:  5 * time.Minute,
@@ -103,33 +103,33 @@ func init() {
 				Audience:             []string{"integration-test"},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(svcB.Start(ctx)).To(Succeed())
+			Expect(mgrB.Start(ctx)).To(Succeed())
 			DeferCleanup(func() {
 				shutdownCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
 				defer c()
-				_ = svcB.Shutdown(shutdownCtx)
+				_ = mgrB.Shutdown(shutdownCtx)
 			})
 
 			userID := "distributed-user"
 
 			// Instance A issues tokens
-			_, refreshToken, err := svcA.IssueTokenPair(ctx, userID)
+			_, refreshToken, err := mgrA.IssueTokenPair(ctx, userID)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Instance B can use the refresh token (shared store)
-			newAccessToken, err := svcB.RefreshAccessToken(ctx, refreshToken)
+			newAccessToken, err := mgrB.RefreshAccessToken(ctx, refreshToken)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(newAccessToken).NotTo(BeEmpty())
 
 			// Issue a fresh refresh token (the previous one was consumed by RefreshAccessToken)
-			_, freshRefresh, err := svcA.IssueTokenPair(ctx, userID)
+			_, freshRefresh, err := mgrA.IssueTokenPair(ctx, userID)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Instance A revokes all tokens for the user
-			Expect(svcA.RevokeAllUserTokens(ctx, userID)).To(Succeed())
+			Expect(mgrA.RevokeAllUserTokens(ctx, userID)).To(Succeed())
 
 			// Instance B must immediately observe the revocation — no cache, reads Redis directly
-			_, err = svcB.RefreshAccessToken(ctx, freshRefresh)
+			_, err = mgrB.RefreshAccessToken(ctx, freshRefresh)
 			Expect(err).To(Equal(tokens.ErrTokenRevoked))
 		})
 
@@ -149,7 +149,7 @@ func init() {
 			Expect(err).NotTo(HaveOccurred())
 
 			storeA := storage.NewRedisRefreshStore(client, nil, nil)
-			svcA, err := tokens.NewService(tokens.ServiceConfig{
+			mgrA, err := tokens.NewManager(tokens.ManagerConfig{
 				KeyManager:           kmA,
 				RefreshStore:         storeA,
 				AccessTokenDuration:  5 * time.Minute,
@@ -158,24 +158,24 @@ func init() {
 				Audience:             []string{"integration-test"},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(svcA.Start(ctx)).To(Succeed())
+			Expect(mgrA.Start(ctx)).To(Succeed())
 			DeferCleanup(func() {
 				shutdownCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
 				defer c()
-				_ = svcA.Shutdown(shutdownCtx)
+				_ = mgrA.Shutdown(shutdownCtx)
 			})
 
 			userID := "rotation-distributed-user"
 
 			// Instance A issues a token with the initial key
-			preRotationToken, err := svcA.IssueAccessToken(ctx, userID)
+			preRotationToken, err := mgrA.IssueAccessToken(ctx, userID)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Instance A rotates keys — new key saved to Redis
 			Expect(kmA.RotateKeys(ctx)).To(Succeed())
 
 			// Instance A issues a token with the new key
-			postRotationToken, err := svcA.IssueAccessToken(ctx, userID)
+			postRotationToken, err := mgrA.IssueAccessToken(ctx, userID)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Instance B starts with the same Redis key store — loads all keys on Start
@@ -190,7 +190,7 @@ func init() {
 			Expect(err).NotTo(HaveOccurred())
 
 			storeB := storage.NewRedisRefreshStore(client, nil, nil)
-			svcB, err := tokens.NewService(tokens.ServiceConfig{
+			mgrB, err := tokens.NewManager(tokens.ManagerConfig{
 				KeyManager:           kmB,
 				RefreshStore:         storeB,
 				AccessTokenDuration:  5 * time.Minute,
@@ -199,28 +199,28 @@ func init() {
 				Audience:             []string{"integration-test"},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(svcB.Start(ctx)).To(Succeed())
+			Expect(mgrB.Start(ctx)).To(Succeed())
 			DeferCleanup(func() {
 				shutdownCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
 				defer c()
-				_ = svcB.Shutdown(shutdownCtx)
+				_ = mgrB.Shutdown(shutdownCtx)
 			})
 
 			// Instance B validates both tokens signed by instance A's keys
-			claims, err := svcB.ValidateAccessToken(ctx, preRotationToken)
+			claims, err := mgrB.ValidateAccessToken(ctx, preRotationToken)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(claims.Subject).To(Equal(userID))
 
-			claims, err = svcB.ValidateAccessToken(ctx, postRotationToken)
+			claims, err = mgrB.ValidateAccessToken(ctx, postRotationToken)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(claims.Subject).To(Equal(userID))
 		})
 	})
 }
 
-// redisFactory creates a TokenService backed by RedisKeyStore + RedisRefreshStore
+// redisFactory creates a TokenManager backed by RedisKeyStore + RedisRefreshStore
 // using an isolated miniredis instance. Each call produces a fully independent backend.
-func redisFactory(cfg tokens.ServiceConfig) (*tokens.Service, *keymanager.Manager, func()) {
+func redisFactory(cfg tokens.ManagerConfig) (*tokens.Manager, *keymanager.Manager, func()) {
 	mr, err := miniredis.Run()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -239,7 +239,7 @@ func redisFactory(cfg tokens.ServiceConfig) (*tokens.Service, *keymanager.Manage
 	cfg.KeyManager = km
 	cfg.RefreshStore = storage.NewRedisRefreshStore(client, nil, nil)
 
-	svc, err := tokens.NewService(cfg)
+	mgr, err := tokens.NewManager(cfg)
 	Expect(err).NotTo(HaveOccurred())
 
 	cleanup := func() {
@@ -247,5 +247,5 @@ func redisFactory(cfg tokens.ServiceConfig) (*tokens.Service, *keymanager.Manage
 		mr.Close()
 	}
 
-	return svc, km, cleanup
+	return mgr, km, cleanup
 }

--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -18,11 +18,11 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
-// ServiceConfig holds the configuration for a Service.
+// ManagerConfig holds the configuration for a Manager.
 //
 // KeyManager and RefreshStore are required. All duration fields
-// default to production-safe values via ConfigDefault if left at zero.
-type ServiceConfig struct {
+// default to production-safe values via DefaultManagerConfig if left at zero.
+type ManagerConfig struct {
 	// Required dependencies
 	KeyManager   keymanager.KeyManager // Signs and validates tokens
 	RefreshStore storage.RefreshStore  // Persists refresh tokens
@@ -31,7 +31,7 @@ type ServiceConfig struct {
 	Logger  logging.Logger  // Structured logger; nil disables logging
 	Metrics metrics.Metrics // Optional; nil disables metrics.
 
-	// Token lifetimes — defaults applied by NewService if zero
+	// Token lifetimes — defaults applied by NewManager if zero
 	AccessTokenDuration  time.Duration // Default: 15 minutes
 	RefreshTokenDuration time.Duration // Default: 30 days
 	CleanupInterval      time.Duration // How often expired tokens are purged; default: 1 hour
@@ -44,12 +44,12 @@ type ServiceConfig struct {
 	Audience []string // Values for the "aud" claim
 }
 
-// Service issues, validates, and revokes JWT access tokens and opaque refresh
-// tokens. It must be started with Start before use and stopped with Shutdown
+// Manager issues, validates, and revokes JWT access tokens and opaque refresh
+// tokenm. It must be started with Start before use and stopped with Shutdown
 // for clean termination.
 //
 // All public methods are safe for concurrent use.
-type Service struct {
+type Manager struct {
 	// ===== Dependencies (Interfaces) =====
 	keyManager   keymanager.KeyManager // Crypto operations
 	refreshStore storage.RefreshStore  // Token storage
@@ -70,10 +70,10 @@ type Service struct {
 	wg           sync.WaitGroup // Waits for goroutines to finish on shutdown
 }
 
-// Sentinel errors returned by Service methods.
+// Sentinel errors returned by Manager methodm.
 var (
 	ErrInvalidUserID       = errors.New("invalid user ID")
-	ErrServiceNotRunning   = errors.New("service is not running")
+	ErrManagerNotRunning   = errors.New("manager is not running")
 	ErrInvalidToken        = errors.New("invalid token")
 	ErrInvalidRefreshToken = errors.New("invalid refresh token")
 	ErrRefreshTokenExpired = errors.New("token has expired")
@@ -81,41 +81,41 @@ var (
 )
 
 // ErrInvalidConfig returns a configuration error with the given message.
-// Returned by NewService when required fields are missing or values are invalid.
+// Returned by NewManager when required fields are missing or values are invalid.
 func ErrInvalidConfig(msg string) error {
 	return errors.New(msg)
 }
 
-// ConfigDefault returns a ServiceConfig populated with production-safe defaults.
-// NewService applies these automatically for any zero-value duration fields.
-func ConfigDefault() ServiceConfig {
-	return ServiceConfig{
+// DefaultManagerConfig returns a ManagerConfig populated with production-safe defaultm.
+// NewManager applies these automatically for any zero-value duration fieldm.
+func DefaultManagerConfig() ManagerConfig {
+	return ManagerConfig{
 		AccessTokenDuration:  15 * time.Minute,
 		RefreshTokenDuration: 30 * 24 * time.Hour,
 		CleanupInterval:      1 * time.Hour,
 	}
 }
 
-// IsRunning reports whether the service has been started and not yet shut down.
+// IsRunning reports whether the manager has been started and not yet shut down.
 // Safe to call concurrently.
-func (s *Service) IsRunning() bool {
-	return s.isRunning.Load()
+func (m *Manager) IsRunning() bool {
+	return m.isRunning.Load()
 }
 
-// NewService constructs a Service from the given config. Zero-value duration
-// fields are filled with defaults from ConfigDefault. Returns an error if any
+// NewManager constructs a Manager from the given config. Zero-value duration
+// fields are filled with defaults from DefaultManagerConfig. Returns an error if any
 // required dependency is nil or a duration is negative.
-func NewService(config ServiceConfig) (*Service, error) {
+func NewManager(config ManagerConfig) (*Manager, error) {
 	if config.AccessTokenDuration == 0 {
-		config.AccessTokenDuration = ConfigDefault().AccessTokenDuration
+		config.AccessTokenDuration = DefaultManagerConfig().AccessTokenDuration
 	}
 
 	if config.RefreshTokenDuration == 0 {
-		config.RefreshTokenDuration = ConfigDefault().RefreshTokenDuration
+		config.RefreshTokenDuration = DefaultManagerConfig().RefreshTokenDuration
 	}
 
 	if config.CleanupInterval == 0 {
-		config.CleanupInterval = ConfigDefault().CleanupInterval
+		config.CleanupInterval = DefaultManagerConfig().CleanupInterval
 	}
 
 	if config.KeyManager == nil {
@@ -142,7 +142,7 @@ func NewService(config ServiceConfig) (*Service, error) {
 		return nil, ErrInvalidConfig("ClockSkew must be non-negative")
 	}
 
-	s := &Service{
+	m := &Manager{
 		keyManager:           config.KeyManager,
 		refreshStore:         config.RefreshStore,
 		logger:               config.Logger,
@@ -156,89 +156,89 @@ func NewService(config ServiceConfig) (*Service, error) {
 		shutdownChan:         make(chan struct{}),
 	}
 
-	return s, nil
+	return m, nil
 }
 
-// Start initializes the service and begins background operations. It starts
+// Start initializes the service and begins background operationm. It starts
 // the KeyManager and launches the cleanup goroutine that periodically purges
-// expired refresh tokens.
+// expired refresh tokenm.
 //
 // Start is idempotent — calling it on an already-running service is a no-op.
 // Returns an error if the KeyManager fails to start or the context is cancelled.
-func (s *Service) Start(ctx context.Context) error {
+func (m *Manager)Start(ctx context.Context) error {
 	// ===== STEP 1: Check If Already Running (Idempotent) =====
-	if !s.isRunning.CompareAndSwap(false, true) {
+	if !m.isRunning.CompareAndSwap(false, true) {
 		// Already running — idempotent no-op, no metric recorded
-		if s.logger != nil {
-			s.logger.Warn("start called but service already running", ctx)
+		if m.logger != nil {
+			m.logger.Warn("start called but service already running", ctx)
 		}
 		return nil // Already running, not an error
 	}
 
 	// ===== STEP 2: Log Startup =====
-	if s.logger != nil {
-		s.logger.Info("starting token service", ctx)
+	if m.logger != nil {
+		m.logger.Info("starting token service", ctx)
 	}
 
 	// ===== STEP 3: Start KeyManager =====
-	if err := s.keyManager.Start(ctx); err != nil {
-		s.isRunning.Store(false) // Revert state
+	if err := m.keyManager.Start(ctx); err != nil {
+		m.isRunning.Store(false) // Revert state
 
-		if s.logger != nil {
-			s.logger.Error("failed to start token service", ctx,
+		if m.logger != nil {
+			m.logger.Error("failed to start token service", ctx,
 				"error", err)
 		}
 		return fmt.Errorf("failed to start keymanager: %w", err)
 	}
 
 	// ===== STEP 4: Start Background Cleanup Goroutine =====
-	s.wg.Add(1)
-	go s.cleanupLoop(ctx)
+	m.wg.Add(1)
+	go m.cleanupLoop(ctx)
 
 	// ===== STEP 5: Record Metric and Log Success =====
-	if s.metrics != nil {
-		s.metrics.SetGauge(metricServiceRunning, 1.0, map[string]string{})
+	if m.metrics != nil {
+		m.metrics.SetGauge(metricServiceRunning, 1.0, map[string]string{})
 	}
-	if s.logger != nil {
-		s.logger.Info("token service started", ctx)
+	if m.logger != nil {
+		m.logger.Info("token service started", ctx)
 	}
 
 	return nil
 }
 
-func (s *Service) cleanupLoop(ctx context.Context) {
-	defer s.wg.Done()
+func (m *Manager)cleanupLoop(ctx context.Context) {
+	defer m.wg.Done()
 
 	// Cleanup at configured interval
-	ticker := time.NewTicker(s.cleanupInterval)
+	ticker := time.NewTicker(m.cleanupInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ticker.C:
-			if s.logger != nil {
-				s.logger.Debug("cleanup loop tick started", ctx)
+			if m.logger != nil {
+				m.logger.Debug("cleanup loop tick started", ctx)
 			}
 			// Cleanup expired refresh tokens
-			if s.logger != nil {
-				s.logger.Debug("cleanup ticker fired", ctx)
+			if m.logger != nil {
+				m.logger.Debug("cleanup ticker fired", ctx)
 			}
-			if count, err := s.refreshStore.Cleanup(ctx); err != nil {
-				if s.logger != nil {
-					s.logger.Error("refresh token cleanup failed", ctx,
+			if count, err := m.refreshStore.Cleanup(ctx); err != nil {
+				if m.logger != nil {
+					m.logger.Error("refresh token cleanup failed", ctx,
 						"error", err)
 				}
 			} else {
 
-				if s.logger != nil {
-					s.logger.Info("refresh token cleanup completed", ctx,
+				if m.logger != nil {
+					m.logger.Info("refresh token cleanup completed", ctx,
 						"tokens", count)
 				}
 			}
 
-		case <-s.shutdownChan:
-			if s.logger != nil {
-				s.logger.Info("cleanup loop stopping", ctx)
+		case <-m.shutdownChan:
+			if m.logger != nil {
+				m.logger.Info("cleanup loop stopping", ctx)
 			}
 			return
 		}
@@ -251,27 +251,27 @@ func (s *Service) cleanupLoop(ctx context.Context) {
 // Shutdown is idempotent — calling it on a stopped service is a no-op.
 // Returns context.DeadlineExceeded if the goroutines do not finish within
 // the deadline, or any error returned by the KeyManager's Shutdown.
-func (s *Service) Shutdown(ctx context.Context) error {
+func (m *Manager)Shutdown(ctx context.Context) error {
 	// ===== STEP 1: Check If Running (Idempotent) =====
-	if !s.isRunning.CompareAndSwap(true, false) {
-		if s.logger != nil {
-			s.logger.Warn("shutdown called but service not running", ctx)
+	if !m.isRunning.CompareAndSwap(true, false) {
+		if m.logger != nil {
+			m.logger.Warn("shutdown called but service not running", ctx)
 		}
 		return nil // Already stopped, not an error
 	}
 
 	// ===== STEP 2: Log Shutdown =====
-	if s.logger != nil {
-		s.logger.Info("shutting down token service", ctx)
+	if m.logger != nil {
+		m.logger.Info("shutting down token service", ctx)
 	}
 
 	// ===== STEP 3: Signal Background Goroutines =====
-	close(s.shutdownChan)
+	close(m.shutdownChan)
 
 	// ===== STEP 4: Wait For Goroutines With Timeout =====
 	done := make(chan struct{})
 	go func() {
-		s.wg.Wait()
+		m.wg.Wait()
 		close(done)
 	}()
 
@@ -280,28 +280,28 @@ func (s *Service) Shutdown(ctx context.Context) error {
 		// Goroutines completed
 	case <-ctx.Done():
 		// Timeout
-		if s.logger != nil {
-			s.logger.Warn("shutdown timeout waiting for goroutines", ctx,
+		if m.logger != nil {
+			m.logger.Warn("shutdown timeout waiting for goroutines", ctx,
 				"error", ctx.Err())
 		}
 		return ctx.Err()
 	}
 
 	// ===== STEP 5: Shutdown KeyManager =====
-	if err := s.keyManager.Shutdown(ctx); err != nil {
-		if s.logger != nil {
-			s.logger.Error("failed to shutdown keymanager", ctx,
+	if err := m.keyManager.Shutdown(ctx); err != nil {
+		if m.logger != nil {
+			m.logger.Error("failed to shutdown keymanager", ctx,
 				"error", err)
 		}
 		return fmt.Errorf("failed to shutdown keymanager: %w", err)
 	}
 
 	// ===== STEP 6: Record Metric and Log Success =====
-	if s.metrics != nil {
-		s.metrics.SetGauge(metricServiceRunning, 0.0, map[string]string{})
+	if m.metrics != nil {
+		m.metrics.SetGauge(metricServiceRunning, 0.0, map[string]string{})
 	}
-	if s.logger != nil {
-		s.logger.Info("token service stopped", ctx)
+	if m.logger != nil {
+		m.logger.Info("token service stopped", ctx)
 	}
 
 	return nil
@@ -311,19 +311,19 @@ func (s *Service) Shutdown(ctx context.Context) error {
 // user. The token carries standard registered claims (sub, iss, aud, exp, iat,
 // nbf, jti) and is signed with the current key from the KeyManager.
 //
-// Returns ErrInvalidUserID for empty/whitespace-only user IDs, ErrServiceNotRunning
+// Returns ErrInvalidUserID for empty/whitespace-only user IDs, ErrManagerNotRunning
 // if the service is stopped, or the context error if the context is already cancelled.
-func (s *Service) IssueAccessToken(ctx context.Context, userID string) (string, error) {
+func (m *Manager)IssueAccessToken(ctx context.Context, userID string) (string, error) {
 	start := time.Now()
 	status := "error"
 	errorType := "error"
 	defer func() {
-		if s.metrics != nil {
-			s.metrics.IncrementCounter(metricTokensIssuedTotal, map[string]string{
+		if m.metrics != nil {
+			m.metrics.IncrementCounter(metricTokensIssuedTotal, map[string]string{
 				"status":     status,
 				"error_type": errorType,
 			})
-			s.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
+			m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 				"operation": "issue_access_token",
 			})
 		}
@@ -333,20 +333,20 @@ func (s *Service) IssueAccessToken(ctx context.Context, userID string) (string, 
 	if len(strings.TrimSpace(userID)) == 0 {
 		status = "invalid_input"
 		errorType = "invalid_input"
-		if s.logger != nil {
-			s.logger.Warn("attempted to get token with empty userID", ctx)
+		if m.logger != nil {
+			m.logger.Warn("attempted to get token with empty userID", ctx)
 		}
 		return "", ErrInvalidUserID
 	}
 
 	// ===== STEP 2: Service State Check =====
-	if !s.IsRunning() {
+	if !m.IsRunning() {
 		status = "not_running"
 		errorType = "not_running"
-		if s.logger != nil {
-			s.logger.Warn("service not running", ctx)
+		if m.logger != nil {
+			m.logger.Warn("service not running", ctx)
 		}
-		return "", ErrServiceNotRunning
+		return "", ErrManagerNotRunning
 	}
 	// ===== STEP 3: Context Check =====
 	// Check if context is already cancelled/expired
@@ -354,8 +354,8 @@ func (s *Service) IssueAccessToken(ctx context.Context, userID string) (string, 
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
 		errorType = "cancelled"
-		if s.logger != nil {
-			s.logger.Warn("context cancelled during token issuance", ctx,
+		if m.logger != nil {
+			m.logger.Warn("context cancelled during token issuance", ctx,
 				"userID", userID,
 				"error", err)
 		}
@@ -365,29 +365,29 @@ func (s *Service) IssueAccessToken(ctx context.Context, userID string) (string, 
 	// ===== STEP 4: Get Signing Key =====
 	// Retrieve current private key and its ID from KeyManager
 	// The key ID will be included in the JWT header for verification
-	privateKey, keyID, err := s.keyManager.GetCurrentSigningKey(ctx)
+	privateKey, keyID, err := m.keyManager.GetCurrentSigningKey(ctx)
 	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("failed to get signing key", ctx,
+		if m.logger != nil {
+			m.logger.Error("failed to get signing key", ctx,
 				"userID", userID,
 				"error", err)
 		}
 		return "", fmt.Errorf("failed to get signing key: %w", err)
 	}
-	if s.logger != nil {
-		s.logger.Debug("signing key retrieved", ctx,
+	if m.logger != nil {
+		m.logger.Debug("signing key retrieved", ctx,
 			"userID", userID,
 			"keyID", keyID)
 	}
 
 	// ===== STEP 5: Create JWT Claims =====
 	now := time.Now()
-	expiresAt := now.Add(s.accessTokenDuration)
+	expiresAt := now.Add(m.accessTokenDuration)
 	// Generate unique token ID (jti claim)
 	tokenID, err := generateTokenID()
 	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("failed to generate token ID", ctx,
+		if m.logger != nil {
+			m.logger.Error("failed to generate token ID", ctx,
 				"userID", userID,
 				"error", err)
 		}
@@ -397,15 +397,15 @@ func (s *Service) IssueAccessToken(ctx context.Context, userID string) (string, 
 	// Create standard JWT claims
 	claims := jwt.RegisteredClaims{
 		Subject:   userID,                        // "sub" - who the token is for
-		Issuer:    s.issuer,                      // "iss" - who issued the token
-		Audience:  s.audience,                    // "aud" - who can use the token
+		Issuer:    m.issuer,                      // "iss" - who issued the token
+		Audience:  m.audience,                    // "aud" - who can use the token
 		ExpiresAt: jwt.NewNumericDate(expiresAt), // "exp" - when it expires
 		IssuedAt:  jwt.NewNumericDate(now),       // "iat" - when it was issued
 		NotBefore: jwt.NewNumericDate(now),       // "nbf" - valid from when
 		ID:        tokenID,                       // "jti" - unique token identifier
 	}
-	if s.logger != nil {
-		s.logger.Debug("access token claims created", ctx,
+	if m.logger != nil {
+		m.logger.Debug("access token claims created", ctx,
 			"userID", userID,
 			"tokenID", tokenID,
 			"expiresAt", expiresAt)
@@ -423,16 +423,16 @@ func (s *Service) IssueAccessToken(ctx context.Context, userID string) (string, 
 	signedToken, err := token.SignedString(privateKey)
 
 	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("failed to sign token", ctx,
+		if m.logger != nil {
+			m.logger.Error("failed to sign token", ctx,
 				"userID", userID,
 				"keyID", keyID,
 				"error", err)
 		}
 		return "", fmt.Errorf("failed to sign token: %w", err)
 	}
-	if s.logger != nil {
-		s.logger.Debug("access token signed", ctx,
+	if m.logger != nil {
+		m.logger.Debug("access token signed", ctx,
 			"userID", userID,
 			"tokenID", tokenID)
 	}
@@ -440,8 +440,8 @@ func (s *Service) IssueAccessToken(ctx context.Context, userID string) (string, 
 	// ===== STEP 8: Record Success and Log =====
 	status = "success"
 	errorType = ""
-	if s.logger != nil {
-		s.logger.Info("access token issued", ctx,
+	if m.logger != nil {
+		m.logger.Info("access token issued", ctx,
 			"userID", userID,
 			"tokenID", tokenID,
 			"keyID", keyID,
@@ -457,17 +457,17 @@ func (s *Service) IssueAccessToken(ctx context.Context, userID string) (string, 
 // and logged as a warning.
 //
 // Returns the same errors as IssueAccessToken.
-func (s *Service) IssueAccessTokenWithClaims(ctx context.Context, userID string, customClaims map[string]interface{}) (string, error) {
+func (m *Manager)IssueAccessTokenWithClaims(ctx context.Context, userID string, customClaims map[string]interface{}) (string, error) {
 	start := time.Now()
 	status := "error"
 	errorType := "error"
 	defer func() {
-		if s.metrics != nil {
-			s.metrics.IncrementCounter(metricTokensIssuedTotal, map[string]string{
+		if m.metrics != nil {
+			m.metrics.IncrementCounter(metricTokensIssuedTotal, map[string]string{
 				"status":     status,
 				"error_type": errorType,
 			})
-			s.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
+			m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 				"operation": "issue_access_token",
 			})
 		}
@@ -477,28 +477,28 @@ func (s *Service) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 	if len(strings.TrimSpace(userID)) == 0 {
 		status = "invalid_input"
 		errorType = "invalid_input"
-		if s.logger != nil {
-			s.logger.Warn("attempted to get token with empty userID", ctx)
+		if m.logger != nil {
+			m.logger.Warn("attempted to get token with empty userID", ctx)
 		}
 		return "", ErrInvalidUserID
 	}
 
 	// ===== STEP 2: Service State Check =====
-	if !s.IsRunning() {
+	if !m.IsRunning() {
 		status = "not_running"
 		errorType = "not_running"
-		if s.logger != nil {
-			s.logger.Warn("service not running", ctx)
+		if m.logger != nil {
+			m.logger.Warn("service not running", ctx)
 		}
-		return "", ErrServiceNotRunning
+		return "", ErrManagerNotRunning
 	}
 
 	// ===== STEP 3: Context Check =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
 		errorType = "cancelled"
-		if s.logger != nil {
-			s.logger.Warn("context cancelled during token issuance", ctx,
+		if m.logger != nil {
+			m.logger.Warn("context cancelled during token issuance", ctx,
 				"userID", userID,
 				"error", err)
 		}
@@ -506,27 +506,27 @@ func (s *Service) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 	}
 
 	// ===== STEP 4: Get Signing Key =====
-	privateKey, keyID, err := s.keyManager.GetCurrentSigningKey(ctx)
+	privateKey, keyID, err := m.keyManager.GetCurrentSigningKey(ctx)
 	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("failed to get signing key", ctx,
+		if m.logger != nil {
+			m.logger.Error("failed to get signing key", ctx,
 				"userID", userID,
 				"error", err)
 		}
 		return "", fmt.Errorf("failed to get signing key: %w", err)
 	}
-	if s.logger != nil {
-		s.logger.Debug("signing key retrieved", ctx,
+	if m.logger != nil {
+		m.logger.Debug("signing key retrieved", ctx,
 			"userID", userID,
 			"keyID", keyID)
 	}
 
 	now := time.Now()
-	expiresAt := now.Add(s.accessTokenDuration)
+	expiresAt := now.Add(m.accessTokenDuration)
 	tokenID, err := generateTokenID()
 	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("failed to generate token ID", ctx,
+		if m.logger != nil {
+			m.logger.Error("failed to generate token ID", ctx,
 				"userID", userID,
 				"error", err)
 		}
@@ -536,8 +536,8 @@ func (s *Service) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 	// Create map claims to support both standard and custom claims
 	claims := jwt.MapClaims{
 		"sub": userID,
-		"iss": s.issuer,
-		"aud": s.audience,
+		"iss": m.issuer,
+		"aud": m.audience,
 		"exp": expiresAt.Unix(),
 		"iat": now.Unix(),
 		"nbf": now.Unix(),
@@ -557,15 +557,15 @@ func (s *Service) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 			claims[key] = value
 			customClaimsCount++
 		} else {
-			if s.logger != nil {
-				s.logger.Warn("attempted to override reserved claim", ctx,
+			if m.logger != nil {
+				m.logger.Warn("attempted to override reserved claim", ctx,
 					"userID", userID,
 					"claim", key)
 			}
 		}
 	}
-	if s.logger != nil {
-		s.logger.Debug("access token claims created with custom claims", ctx,
+	if m.logger != nil {
+		m.logger.Debug("access token claims created with custom claims", ctx,
 			"userID", userID,
 			"tokenID", tokenID,
 			"customClaimsCount", customClaimsCount,
@@ -578,24 +578,24 @@ func (s *Service) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 
 	signedToken, err := token.SignedString(privateKey)
 	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("failed to sign token with custom claims", ctx,
+		if m.logger != nil {
+			m.logger.Error("failed to sign token with custom claims", ctx,
 				"userID", userID,
 				"keyID", keyID,
 				"error", err)
 		}
 		return "", fmt.Errorf("failed to sign token: %w", err)
 	}
-	if s.logger != nil {
-		s.logger.Debug("access token with custom claims signed", ctx,
+	if m.logger != nil {
+		m.logger.Debug("access token with custom claims signed", ctx,
 			"userID", userID,
 			"tokenID", tokenID)
 	}
 	// ===== STEP 8: Record Success and Log =====
 	status = "success"
 	errorType = ""
-	if s.logger != nil {
-		s.logger.Info("access token with custom claims issued", ctx,
+	if m.logger != nil {
+		m.logger.Info("access token with custom claims issued", ctx,
 			"userID", userID,
 			"tokenID", tokenID,
 			"keyID", keyID,
@@ -611,17 +611,17 @@ func (s *Service) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 // not JWTs — they are 256-bit random values stored in the RefreshStore.
 //
 // Returns the same errors as IssueAccessToken.
-func (s *Service) IssueRefreshToken(ctx context.Context, userID string) (string, error) {
+func (m *Manager)IssueRefreshToken(ctx context.Context, userID string) (string, error) {
 	start := time.Now()
 	status := "error"
 	errorType := "error"
 	defer func() {
-		if s.metrics != nil {
-			s.metrics.IncrementCounter(metricTokensIssuedTotal, map[string]string{
+		if m.metrics != nil {
+			m.metrics.IncrementCounter(metricTokensIssuedTotal, map[string]string{
 				"status":     status,
 				"error_type": errorType,
 			})
-			s.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
+			m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 				"operation": "issue_refresh_token",
 			})
 		}
@@ -631,21 +631,21 @@ func (s *Service) IssueRefreshToken(ctx context.Context, userID string) (string,
 	if len(strings.TrimSpace(userID)) == 0 {
 		status = "invalid_input"
 		errorType = "invalid_input"
-		if s.logger != nil {
-			s.logger.Warn("attempted to get token with empty userID", ctx)
+		if m.logger != nil {
+			m.logger.Warn("attempted to get token with empty userID", ctx)
 		}
 		return "", ErrInvalidUserID
 	}
 
 	// ===== STEP 2: Service State Check =====
 
-	if !s.IsRunning() {
+	if !m.IsRunning() {
 		status = "not_running"
 		errorType = "not_running"
-		if s.logger != nil {
-			s.logger.Warn("service not running", ctx)
+		if m.logger != nil {
+			m.logger.Warn("service not running", ctx)
 		}
-		return "", ErrServiceNotRunning
+		return "", ErrManagerNotRunning
 	}
 
 	// ===== STEP 3: Context Check =====
@@ -654,16 +654,16 @@ func (s *Service) IssueRefreshToken(ctx context.Context, userID string) (string,
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
 		errorType = "cancelled"
-		if s.logger != nil {
-			s.logger.Warn("context cancelled during token issuance", ctx,
+		if m.logger != nil {
+			m.logger.Warn("context cancelled during token issuance", ctx,
 				"userID", userID,
 				"error", err)
 		}
 		return "", err
 	}
 
-	if s.logger != nil {
-		s.logger.Debug("issuing refresh token", ctx, "userID", userID)
+	if m.logger != nil {
+		m.logger.Debug("issuing refresh token", ctx, "userID", userID)
 	}
 
 	// ===== STEP 4: Generate Refresh Token =====
@@ -671,21 +671,21 @@ func (s *Service) IssueRefreshToken(ctx context.Context, userID string) (string,
 	// this is an OPAQUE token (not a JWT)
 	refreshToken, err := generateRefreshToken()
 	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("failed to generate refresh token", ctx,
+		if m.logger != nil {
+			m.logger.Error("failed to generate refresh token", ctx,
 				"userID", userID,
 				"error", err)
 		}
 		return "", fmt.Errorf("failed to generate refresh token: %w", err)
 	}
-	if s.logger != nil {
-		s.logger.Debug("refresh token generated", ctx,
+	if m.logger != nil {
+		m.logger.Debug("refresh token generated", ctx,
 			"userID", userID)
 	}
 
 	// ===== STEP 5: Calculate Expiration =====
 	now := time.Now()
-	expiresAt := now.Add(s.refreshTokenDuration)
+	expiresAt := now.Add(m.refreshTokenDuration)
 
 	// ===== STEP 6: Store Token =====
 	// Store token with metadata in RefreshStore
@@ -694,7 +694,7 @@ func (s *Service) IssueRefreshToken(ctx context.Context, userID string) (string,
 	//   - Token revocation
 	//   - User session tracking
 	//   - Audit trails
-	err = s.refreshStore.Store(
+	err = m.refreshStore.Store(
 		ctx,          // Context for cancellation
 		refreshToken, // Token ID (the token itself is the ID)
 		userID,       // Who owns the token
@@ -702,15 +702,15 @@ func (s *Service) IssueRefreshToken(ctx context.Context, userID string) (string,
 		nil,          // No metadata (use IssueRefreshTokenWithMetadata for metadata)
 	)
 	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("failed to store refresh token", ctx,
+		if m.logger != nil {
+			m.logger.Error("failed to store refresh token", ctx,
 				"userID", userID,
 				"error", err)
 		}
 		return "", fmt.Errorf("failed to store refresh token: %w", err)
 	}
-	if s.logger != nil {
-		s.logger.Debug("refresh token stored", ctx,
+	if m.logger != nil {
+		m.logger.Debug("refresh token stored", ctx,
 			"userID", userID,
 			"expiresAt", expiresAt)
 	}
@@ -718,8 +718,8 @@ func (s *Service) IssueRefreshToken(ctx context.Context, userID string) (string,
 	// ===== STEP 7: Record Success and Log =====
 	status = "success"
 	errorType = ""
-	if s.logger != nil {
-		s.logger.Info("refresh token issued", ctx,
+	if m.logger != nil {
+		m.logger.Info("refresh token issued", ctx,
 			"userID", userID,
 			"tokenID", refreshToken,
 			"expiresAt", expiresAt)
@@ -733,17 +733,17 @@ func (s *Service) IssueRefreshToken(ctx context.Context, userID string) (string,
 // tags). The metadata is retrievable via IntrospectToken.
 //
 // Returns the same errors as IssueAccessToken.
-func (s *Service) IssueRefreshTokenWithMetadata(ctx context.Context, userID string, metadata map[string]interface{}) (string, error) {
+func (m *Manager)IssueRefreshTokenWithMetadata(ctx context.Context, userID string, metadata map[string]interface{}) (string, error) {
 	start := time.Now()
 	status := "error"
 	errorType := "error"
 	defer func() {
-		if s.metrics != nil {
-			s.metrics.IncrementCounter(metricTokensIssuedTotal, map[string]string{
+		if m.metrics != nil {
+			m.metrics.IncrementCounter(metricTokensIssuedTotal, map[string]string{
 				"status":     status,
 				"error_type": errorType,
 			})
-			s.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
+			m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 				"operation": "issue_refresh_token",
 			})
 		}
@@ -753,20 +753,20 @@ func (s *Service) IssueRefreshTokenWithMetadata(ctx context.Context, userID stri
 	if len(strings.TrimSpace(userID)) == 0 {
 		status = "invalid_input"
 		errorType = "invalid_input"
-		if s.logger != nil {
-			s.logger.Warn("attempted to get token with empty userID", ctx)
+		if m.logger != nil {
+			m.logger.Warn("attempted to get token with empty userID", ctx)
 		}
 		return "", ErrInvalidUserID
 	}
 
 	// ===== STEP 2: Service State Check =====
-	if !s.IsRunning() {
+	if !m.IsRunning() {
 		status = "not_running"
 		errorType = "not_running"
-		if s.logger != nil {
-			s.logger.Warn("service not running", ctx)
+		if m.logger != nil {
+			m.logger.Warn("service not running", ctx)
 		}
-		return "", ErrServiceNotRunning
+		return "", ErrManagerNotRunning
 	}
 
 	// ===== STEP 3: Context Check =====
@@ -775,16 +775,16 @@ func (s *Service) IssueRefreshTokenWithMetadata(ctx context.Context, userID stri
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
 		errorType = "cancelled"
-		if s.logger != nil {
-			s.logger.Warn("context cancelled during token issuance", ctx,
+		if m.logger != nil {
+			m.logger.Warn("context cancelled during token issuance", ctx,
 				"userID", userID,
 				"error", err)
 		}
 		return "", err
 	}
 
-	if s.logger != nil {
-		s.logger.Debug("issuing refresh token with metadata", ctx, "userID", userID)
+	if m.logger != nil {
+		m.logger.Debug("issuing refresh token with metadata", ctx, "userID", userID)
 	}
 
 	// ===== STEP 4: Generate Refresh Token =====
@@ -792,21 +792,21 @@ func (s *Service) IssueRefreshTokenWithMetadata(ctx context.Context, userID stri
 	// this is an OPAQUE token (not a JWT)
 	refreshToken, err := generateRefreshToken()
 	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("failed to generate refresh token", ctx,
+		if m.logger != nil {
+			m.logger.Error("failed to generate refresh token", ctx,
 				"userID", userID,
 				"error", err)
 		}
 		return "", fmt.Errorf("failed to generate refresh token: %w", err)
 	}
-	if s.logger != nil {
-		s.logger.Debug("refresh token generated", ctx,
+	if m.logger != nil {
+		m.logger.Debug("refresh token generated", ctx,
 			"userID", userID)
 	}
 
 	// ===== STEP 5: Calculate Expiration =====
 	now := time.Now()
-	expiresAt := now.Add(s.refreshTokenDuration)
+	expiresAt := now.Add(m.refreshTokenDuration)
 
 	// ===== STEP 6: Store Token =====
 	// Store token with metadata in RefreshStore
@@ -815,7 +815,7 @@ func (s *Service) IssueRefreshTokenWithMetadata(ctx context.Context, userID stri
 	//   - Token revocation
 	//   - User session tracking
 	//   - Audit trails
-	err = s.refreshStore.Store(
+	err = m.refreshStore.Store(
 		ctx,          // Context for cancellation
 		refreshToken, // Token ID (the token itself is the ID)
 		userID,       // Who owns the token
@@ -823,15 +823,15 @@ func (s *Service) IssueRefreshTokenWithMetadata(ctx context.Context, userID stri
 		metadata,     // Custom metadata
 	)
 	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("failed to store refresh token with metadata", ctx,
+		if m.logger != nil {
+			m.logger.Error("failed to store refresh token with metadata", ctx,
 				"userID", userID,
 				"error", err)
 		}
 		return "", fmt.Errorf("failed to store refresh token with metadata: %w", err)
 	}
-	if s.logger != nil {
-		s.logger.Debug("refresh token with metadata stored", ctx,
+	if m.logger != nil {
+		m.logger.Debug("refresh token with metadata stored", ctx,
 			"userID", userID,
 			"metadataKeys", len(metadata),
 			"expiresAt", expiresAt)
@@ -840,8 +840,8 @@ func (s *Service) IssueRefreshTokenWithMetadata(ctx context.Context, userID stri
 	// ===== STEP 7: Record Success and Log =====
 	status = "success"
 	errorType = ""
-	if s.logger != nil {
-		s.logger.Info("refresh token with metadata issued", ctx,
+	if m.logger != nil {
+		m.logger.Info("refresh token with metadata issued", ctx,
 			"userID", userID,
 			"tokenID", refreshToken,
 			"expiresAt", expiresAt,
@@ -856,17 +856,17 @@ func (s *Service) IssueRefreshTokenWithMetadata(ctx context.Context, userID stri
 //
 // Returns (accessToken, refreshToken, error). Returns the same errors as
 // IssueAccessToken.
-func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, string, error) {
+func (m *Manager)IssueTokenPair(ctx context.Context, userID string) (string, string, error) {
 	start := time.Now()
 	status := "error"
 	errorType := "error"
 	defer func() {
-		if s.metrics != nil {
-			s.metrics.IncrementCounter(metricTokensIssuedTotal, map[string]string{
+		if m.metrics != nil {
+			m.metrics.IncrementCounter(metricTokensIssuedTotal, map[string]string{
 				"status":     status,
 				"error_type": errorType,
 			})
-			s.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
+			m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 				"operation": "issue_token_pair",
 			})
 		}
@@ -876,20 +876,20 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 	if len(strings.TrimSpace(userID)) == 0 {
 		status = "invalid_input"
 		errorType = "invalid_input"
-		if s.logger != nil {
-			s.logger.Warn("attempted to get token with empty userID", ctx)
+		if m.logger != nil {
+			m.logger.Warn("attempted to get token with empty userID", ctx)
 		}
 		return "", "", ErrInvalidUserID
 	}
 
 	// ===== STEP 2: Service State Check =====
-	if !s.IsRunning() {
+	if !m.IsRunning() {
 		status = "not_running"
 		errorType = "not_running"
-		if s.logger != nil {
-			s.logger.Warn("service not running", ctx)
+		if m.logger != nil {
+			m.logger.Warn("service not running", ctx)
 		}
-		return "", "", ErrServiceNotRunning
+		return "", "", ErrManagerNotRunning
 	}
 
 	// ===== STEP 3: Context Check =====
@@ -898,23 +898,23 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
 		errorType = "cancelled"
-		if s.logger != nil {
-			s.logger.Warn("context cancelled during token issuance", ctx,
+		if m.logger != nil {
+			m.logger.Warn("context cancelled during token issuance", ctx,
 				"userID", userID,
 				"error", err)
 		}
 		return "", "", err
 	}
 
-	if s.logger != nil {
-		s.logger.Debug("issuing token pair", ctx, "userID", userID)
+	if m.logger != nil {
+		m.logger.Debug("issuing token pair", ctx, "userID", userID)
 	}
 
 	// ===== STEP 4: Get Signing Key =====
-	privateKey, keyID, err := s.keyManager.GetCurrentSigningKey(ctx)
+	privateKey, keyID, err := m.keyManager.GetCurrentSigningKey(ctx)
 	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("failed to get signing key", ctx,
+		if m.logger != nil {
+			m.logger.Error("failed to get signing key", ctx,
 				"userID", userID,
 				"error", err)
 		}
@@ -923,12 +923,12 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 
 	// ===== STEP 5: Create JWT Claims =====
 	now := time.Now()
-	expiresAt := now.Add(s.accessTokenDuration)
+	expiresAt := now.Add(m.accessTokenDuration)
 	// Generate unique token ID (jti claim)
 	tokenID, err := generateTokenID()
 	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("failed to generate token ID", ctx,
+		if m.logger != nil {
+			m.logger.Error("failed to generate token ID", ctx,
 				"userID", userID,
 				"error", err)
 		}
@@ -938,8 +938,8 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 	// Create standard JWT claims
 	claims := jwt.RegisteredClaims{
 		Subject:   userID,                        // "sub" - who the token is for
-		Issuer:    s.issuer,                      // "iss" - who issued the token
-		Audience:  s.audience,                    // "aud" - who can use the token
+		Issuer:    m.issuer,                      // "iss" - who issued the token
+		Audience:  m.audience,                    // "aud" - who can use the token
 		ExpiresAt: jwt.NewNumericDate(expiresAt), // "exp" - when it expires
 		IssuedAt:  jwt.NewNumericDate(now),       // "iat" - when it was issued
 		NotBefore: jwt.NewNumericDate(now),       // "nbf" - valid from when
@@ -958,8 +958,8 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 	signedToken, err := token.SignedString(privateKey)
 
 	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("failed to sign token", ctx,
+		if m.logger != nil {
+			m.logger.Error("failed to sign token", ctx,
 				"userID", userID,
 				"keyID", keyID,
 				"error", err)
@@ -970,8 +970,8 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 	// ===== STEP 8: Generate Refresh Token =====
 	refreshToken, err := generateRefreshToken()
 	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("failed to generate refresh token", ctx,
+		if m.logger != nil {
+			m.logger.Error("failed to generate refresh token", ctx,
 				"userID", userID,
 				"error", err)
 		}
@@ -980,7 +980,7 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 
 	// ===== STEP 9: Calculate Refresh Token Expiration =====
 	now = time.Now()
-	expiresAt = now.Add(s.refreshTokenDuration)
+	expiresAt = now.Add(m.refreshTokenDuration)
 
 	// ===== STEP 10: Store Refresh Token =====
 	// Store token with metadata in RefreshStore
@@ -989,7 +989,7 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 	//   - Token revocation
 	//   - User session tracking
 	//   - Audit trails
-	err = s.refreshStore.Store(
+	err = m.refreshStore.Store(
 		ctx,          // Context for cancellation
 		refreshToken, // Token ID (the token itself is the ID)
 		userID,       // Who owns the token
@@ -997,8 +997,8 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 		nil,          // No metadata (use IssueRefreshTokenWithMetadata for metadata)
 	)
 	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("failed to store refresh token", ctx,
+		if m.logger != nil {
+			m.logger.Error("failed to store refresh token", ctx,
 				"userID", userID,
 				"error", err)
 		}
@@ -1008,8 +1008,8 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 	// ===== STEP 11: Record Success and Log =====
 	status = "success"
 	errorType = ""
-	if s.logger != nil {
-		s.logger.Info("token pair issued", ctx,
+	if m.logger != nil {
+		m.logger.Info("token pair issued", ctx,
 			"userID", userID,
 			"tokenID", refreshToken,
 			"expiresAt", expiresAt)
@@ -1021,55 +1021,55 @@ func (s *Service) IssueTokenPair(ctx context.Context, userID string) (string, st
 // It verifies the RS256 signature using the public key identified by the token's
 // "kid" header, then checks expiration, issuer, and audience claims.
 //
-/// Returns the parsed RegisteredClaims on success, or one of: ErrServiceNotRunning,
+/// Returns the parsed RegisteredClaims on success, or one of: ErrManagerNotRunning,
 // ErrTokenExpired, ErrTokenNotYetValid, ErrInvalidIssuer, ErrInvalidAudience,
 // ErrInvalidToken (covers malformed tokens, wrong signing method, and unknown key IDs),
 // or the context error.
-func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (*jwt.RegisteredClaims, error) {
+func (m *Manager)ValidateAccessToken(ctx context.Context, tokenString string) (*jwt.RegisteredClaims, error) {
 	start := time.Now()
 	status := "error"
 	errorType := "error"
 	defer func() {
-		if s.metrics != nil {
-			s.metrics.IncrementCounter(metricTokensValidatedTotal, map[string]string{
+		if m.metrics != nil {
+			m.metrics.IncrementCounter(metricTokensValidatedTotal, map[string]string{
 				"status":     status,
 				"error_type": errorType,
 			})
-			s.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
+			m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 				"operation": "validate_access_token",
 			})
 		}
 	}()
 
 	// ===== STEP 1: Service State Check =====
-	if !s.IsRunning() {
+	if !m.IsRunning() {
 		status = "not_running"
 		errorType = "not_running"
-		if s.logger != nil {
-			s.logger.Warn("attempted token validation while service stopped", ctx)
+		if m.logger != nil {
+			m.logger.Warn("attempted token validation while service stopped", ctx)
 		}
-		return nil, ErrServiceNotRunning
+		return nil, ErrManagerNotRunning
 	}
 
 	// ===== STEP 2: Context Check =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
 		errorType = "cancelled"
-		if s.logger != nil {
-			s.logger.Info("context cancelled during token validation", ctx,
+		if m.logger != nil {
+			m.logger.Info("context cancelled during token validation", ctx,
 				"error", err)
 		}
 		return nil, err
 	}
 
-	if s.logger != nil {
-		s.logger.Debug("validating access token", ctx)
+	if m.logger != nil {
+		m.logger.Debug("validating access token", ctx)
 	}
 
 	// ===== STEP 3: Parse JWT Token =====
 	parseOpts := []jwt.ParserOption{}
-	if s.clockSkew > 0 {
-		parseOpts = append(parseOpts, jwt.WithLeeway(s.clockSkew))
+	if m.clockSkew > 0 {
+		parseOpts = append(parseOpts, jwt.WithLeeway(m.clockSkew))
 	}
 
 	token, err := jwt.ParseWithClaims(
@@ -1078,8 +1078,8 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 		func(token *jwt.Token) (interface{}, error) {
 			// ===== STEP 4a: Verify Signing Method =====
 			if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
-				if s.logger != nil {
-					s.logger.Warn("token uses unexpected signing method", ctx,
+				if m.logger != nil {
+					m.logger.Warn("token uses unexpected signing method", ctx,
 						"method", token.Header["alg"])
 				}
 				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
@@ -1088,28 +1088,28 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 			// ===== STEP 4b: Extract Key ID =====
 			kid, ok := token.Header["kid"].(string)
 			if !ok {
-				if s.logger != nil {
-					s.logger.Warn("token missing kid in header", ctx)
+				if m.logger != nil {
+					m.logger.Warn("token missing kid in header", ctx)
 				}
 				return nil, errors.New("missing kid in token header")
 			}
-			if s.logger != nil {
-				s.logger.Debug("token kid extracted from header", ctx,
+			if m.logger != nil {
+				m.logger.Debug("token kid extracted from header", ctx,
 					"kid", kid)
 			}
 
 			// ===== STEP 4c: Get Public Key =====
-			publicKey, err := s.keyManager.GetPublicKey(ctx, kid)
+			publicKey, err := m.keyManager.GetPublicKey(ctx, kid)
 			if err != nil {
-				if s.logger != nil {
-					s.logger.Error("failed to get public key", ctx,
+				if m.logger != nil {
+					m.logger.Error("failed to get public key", ctx,
 						"kid", kid,
 						"error", err)
 				}
 				return nil, fmt.Errorf("failed to get public key: %w", err)
 			}
-			if s.logger != nil {
-				s.logger.Debug("public key retrieved for token validation", ctx,
+			if m.logger != nil {
+				m.logger.Debug("public key retrieved for token validation", ctx,
 					"kid", kid)
 			}
 
@@ -1120,8 +1120,8 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 
 	// ===== STEP 5: Check Parsing Errors =====
 	if err != nil {
-		if s.logger != nil {
-			s.logger.Warn("token parsing failed", ctx,
+		if m.logger != nil {
+			m.logger.Warn("token parsing failed", ctx,
 				"error", err)
 		}
 
@@ -1129,8 +1129,8 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 		if errors.Is(err, jwt.ErrTokenExpired) {
 			status = "expired"
 			errorType = "expired"
-			if s.logger != nil {
-				s.logger.Warn("token expired", ctx)
+			if m.logger != nil {
+				m.logger.Warn("token expired", ctx)
 			}
 			return nil, ErrTokenExpired
 		}
@@ -1142,8 +1142,8 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 		if errors.Is(err, keymanager.ErrKeyNotFound) {
 			status = "error"
 			errorType = "key_not_found"
-			if s.logger != nil {
-				s.logger.Warn("token references unknown key ID", ctx)
+			if m.logger != nil {
+				m.logger.Warn("token references unknown key ID", ctx)
 			}
 			return nil, ErrInvalidToken
 		}
@@ -1153,47 +1153,47 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 
 	// ===== STEP 6: Verify Token is Valid =====
 	if !token.Valid {
-		if s.logger != nil {
-			s.logger.Warn("token marked as invalid", ctx)
+		if m.logger != nil {
+			m.logger.Warn("token marked as invalid", ctx)
 		}
 		return nil, ErrInvalidToken
 	}
-	if s.logger != nil {
-		s.logger.Debug("token signature and structure validated", ctx)
+	if m.logger != nil {
+		m.logger.Debug("token signature and structure validated", ctx)
 	}
 
 	// ===== STEP 7: Extract Claims =====
 	claims, ok := token.Claims.(*jwt.RegisteredClaims)
 	if !ok {
-		if s.logger != nil {
-			s.logger.Error("failed to extract claims from token", ctx)
+		if m.logger != nil {
+			m.logger.Error("failed to extract claims from token", ctx)
 		}
 		return nil, ErrInvalidToken
 	}
-	if s.logger != nil {
-		s.logger.Debug("claims extracted from token", ctx,
+	if m.logger != nil {
+		m.logger.Debug("claims extracted from token", ctx,
 			"tokenID", claims.ID,
 			"userID", claims.Subject)
 	}
 
 	// ===== STEP 8: Validate Issuer =====
-	if s.issuer != "" && claims.Issuer != s.issuer {
-		if s.logger != nil {
-			s.logger.Warn("token issuer mismatch", ctx,
-				"expected", s.issuer,
+	if m.issuer != "" && claims.Issuer != m.issuer {
+		if m.logger != nil {
+			m.logger.Warn("token issuer mismatch", ctx,
+				"expected", m.issuer,
 				"actual", claims.Issuer)
 		}
 		return nil, ErrInvalidIssuer
 	}
-	if s.logger != nil {
-		s.logger.Debug("token issuer validated", ctx,
+	if m.logger != nil {
+		m.logger.Debug("token issuer validated", ctx,
 			"issuer", claims.Issuer)
 	}
 
 	// ===== STEP 9: Validate Audience =====
-	if len(s.audience) > 0 {
+	if len(m.audience) > 0 {
 		validAudience := false
-		for _, aud := range s.audience {
+		for _, aud := range m.audience {
 			for _, tokenAud := range claims.Audience {
 				if aud == tokenAud {
 					validAudience = true
@@ -1206,15 +1206,15 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 		}
 
 		if !validAudience {
-			if s.logger != nil {
-				s.logger.Warn("token audience mismatch", ctx,
-					"expected", s.audience,
+			if m.logger != nil {
+				m.logger.Warn("token audience mismatch", ctx,
+					"expected", m.audience,
 					"actual", claims.Audience)
 			}
 			return nil, ErrInvalidAudience
 		}
-		if s.logger != nil {
-			s.logger.Debug("token audience validated", ctx,
+		if m.logger != nil {
+			m.logger.Debug("token audience validated", ctx,
 				"audience", claims.Audience)
 		}
 	}
@@ -1222,8 +1222,8 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 	// ===== STEP 10: Record Success and Log =====
 	status = "success"
 	errorType = ""
-	if s.logger != nil {
-		s.logger.Info("access token validated", ctx,
+	if m.logger != nil {
+		m.logger.Info("access token validated", ctx,
 			"userID", claims.Subject,
 			"tokenID", claims.ID)
 	}
@@ -1232,21 +1232,21 @@ func (s *Service) ValidateAccessToken(ctx context.Context, tokenString string) (
 }
 
 // ValidateAccessTokenWithClaims validates the token and returns both the registered
-// claims and any custom claims embedded at issuance via IssueAccessTokenWithClaims.
+// claims and any custom claims embedded at issuance via IssueAccessTokenWithClaimm.
 // Reserved claim keys (sub, exp, nbf, iat, jti, iss, aud) are excluded from the
-// custom claims map so callers receive only the application-defined fields.
+// custom claims map so callers receive only the application-defined fieldm.
 // Returns an empty map when no custom claims were embedded.
 //
-// Returns ErrServiceNotRunning if the service has not been started, ErrTokenExpired
+// Returns ErrManagerNotRunning if the service has not been started, ErrTokenExpired
 // if the token has expired beyond the configured ClockSkew, ErrTokenNotYetValid if
 // the nbf claim has not been reached, ErrInvalidIssuer or ErrInvalidAudience if
 // configured values do not match, ErrInvalidToken for malformed tokens or unknown
 // key IDs, or the context error if the context is cancelled.
-func (s *Service) ValidateAccessTokenWithClaims(ctx context.Context, tokenString string) (*jwt.RegisteredClaims, map[string]interface{}, error) {
+func (m *Manager)ValidateAccessTokenWithClaims(ctx context.Context, tokenString string) (*jwt.RegisteredClaims, map[string]interface{}, error) {
 	// ===== STEP 1: Validate via Standard Path =====
 	// All error handling (signature, expiry, issuer, audience, metrics, logging)
 	// is handled by ValidateAccessToken — no duplication needed.
-	registered, err := s.ValidateAccessToken(ctx, tokenString)
+	registered, err := m.ValidateAccessToken(ctx, tokenString)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1283,63 +1283,63 @@ func (s *Service) ValidateAccessTokenWithClaims(ctx context.Context, tokenString
 // It retrieves the refresh token from storage, checks expiration and revocation
 // status, then calls IssueAccessToken for the token's owner.
 //
-// Returns ErrServiceNotRunning, ErrInvalidRefreshToken, ErrRefreshTokenExpired,
+// Returns ErrManagerNotRunning, ErrInvalidRefreshToken, ErrRefreshTokenExpired,
 // ErrTokenRevoked, or the context error.
-func (s *Service) RefreshAccessToken(ctx context.Context, refreshToken string) (string, error) {
+func (m *Manager)RefreshAccessToken(ctx context.Context, refreshToken string) (string, error) {
 	start := time.Now()
 	status := "error"
 	errorType := "error"
 	defer func() {
-		if s.metrics != nil {
-			s.metrics.IncrementCounter(metricTokensRefreshedTotal, map[string]string{
+		if m.metrics != nil {
+			m.metrics.IncrementCounter(metricTokensRefreshedTotal, map[string]string{
 				"status":     status,
 				"error_type": errorType,
 			})
-			s.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
+			m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 				"operation": "refresh_access_token",
 			})
 		}
 	}()
 
 	// ===== STEP 1: Service State Check =====
-	if !s.isRunning.Load() {
+	if !m.isRunning.Load() {
 		status = "not_running"
 		errorType = "not_running"
-		if s.logger != nil {
-			s.logger.Warn("attempted to refresh while service was stopped", ctx)
+		if m.logger != nil {
+			m.logger.Warn("attempted to refresh while service was stopped", ctx)
 		}
-		return "", ErrServiceNotRunning
+		return "", ErrManagerNotRunning
 	}
 
 	// ===== STEP 2: Context Check =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
 		errorType = "cancelled"
-		if s.logger != nil {
-			s.logger.Info("context cancelled during token refresh", ctx)
+		if m.logger != nil {
+			m.logger.Info("context cancelled during token refresh", ctx)
 		}
 		return "", err
 	}
 
-	if s.logger != nil {
-		s.logger.Debug("attempting token refresh", ctx)
+	if m.logger != nil {
+		m.logger.Debug("attempting token refresh", ctx)
 	}
 
 	// ===== STEP 3: Input Validation =====
 	if refreshToken == "" {
 		status = "invalid_input"
 		errorType = "invalid_input"
-		if s.logger != nil {
-			s.logger.Warn("empty refresh token provided", ctx)
+		if m.logger != nil {
+			m.logger.Warn("empty refresh token provided", ctx)
 		}
 		return "", ErrInvalidRefreshToken
 	}
 
 	// ===== STEP 4: Lookup Refresh Token =====
-	token, err := s.refreshStore.Retrieve(ctx, refreshToken)
+	token, err := m.refreshStore.Retrieve(ctx, refreshToken)
 	if err != nil {
-		if s.logger != nil {
-			s.logger.Warn("refresh token not found in store", ctx,
+		if m.logger != nil {
+			m.logger.Warn("refresh token not found in store", ctx,
 				"error", err)
 		}
 		// Propagate specific errors, default to invalid token for generic errors
@@ -1353,8 +1353,8 @@ func (s *Service) RefreshAccessToken(ctx context.Context, refreshToken string) (
 		return "", ErrInvalidRefreshToken
 	}
 
-	if s.logger != nil {
-		s.logger.Debug("refresh token retrieved from store", ctx,
+	if m.logger != nil {
+		m.logger.Debug("refresh token retrieved from store", ctx,
 			"userID", token.UserID,
 			"tokenID", token.TokenID)
 	}
@@ -1363,14 +1363,14 @@ func (s *Service) RefreshAccessToken(ctx context.Context, refreshToken string) (
 	if token.ExpiresAt.Before(time.Now()) {
 		status = "expired"
 		errorType = "expired"
-		if s.logger != nil {
-			s.logger.Warn("refresh token has expired", ctx,
+		if m.logger != nil {
+			m.logger.Warn("refresh token has expired", ctx,
 				"tokenID", refreshToken,
 				"expiredAt", token.ExpiresAt)
 		}
 
 		// Clean up expired token (ignore error — we're returning ErrRefreshTokenExpired anyway)
-		_ = s.refreshStore.Revoke(ctx, refreshToken)
+		_ = m.refreshStore.Revoke(ctx, refreshToken)
 
 		return "", ErrRefreshTokenExpired
 	}
@@ -1379,18 +1379,18 @@ func (s *Service) RefreshAccessToken(ctx context.Context, refreshToken string) (
 	if token.Revoked {
 		status = "revoked"
 		errorType = "revoked"
-		if s.logger != nil {
-			s.logger.Warn("refresh token has been revoked", ctx,
+		if m.logger != nil {
+			m.logger.Warn("refresh token has been revoked", ctx,
 				"tokenID", refreshToken)
 		}
 		return "", ErrTokenRevoked
 	}
 
 	// ===== STEP 7: Issue New Access Token =====
-	newAccessToken, err := s.IssueAccessToken(ctx, token.UserID)
+	newAccessToken, err := m.IssueAccessToken(ctx, token.UserID)
 	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("failed to issue new access token", ctx,
+		if m.logger != nil {
+			m.logger.Error("failed to issue new access token", ctx,
 				"userID", token.UserID,
 				"error", err)
 		}
@@ -1400,8 +1400,8 @@ func (s *Service) RefreshAccessToken(ctx context.Context, refreshToken string) (
 	// ===== STEP 9: Record Success and Log =====
 	status = "success"
 	errorType = ""
-	if s.logger != nil {
-		s.logger.Info("access token refreshed", ctx,
+	if m.logger != nil {
+		m.logger.Info("access token refreshed", ctx,
 			"userID", token.UserID,
 			"tokenID", refreshToken)
 	}
@@ -1413,37 +1413,37 @@ func (s *Service) RefreshAccessToken(ctx context.Context, refreshToken string) (
 // Subsequent calls to RefreshAccessToken or IntrospectToken will see the token
 // as inactive.
 //
-// Returns ErrServiceNotRunning, ErrInvalidRefreshToken for empty tokenID, or
+// Returns ErrManagerNotRunning, ErrInvalidRefreshToken for empty tokenID, or
 // the context error.
-func (s *Service) RevokeRefreshToken(ctx context.Context, tokenID string) error {
+func (m *Manager)RevokeRefreshToken(ctx context.Context, tokenID string) error {
 	start := time.Now()
 	status := "error"
 	defer func() {
-		if s.metrics != nil {
-			s.metrics.IncrementCounter(metricTokensRevokedTotal, map[string]string{
+		if m.metrics != nil {
+			m.metrics.IncrementCounter(metricTokensRevokedTotal, map[string]string{
 				"operation": "single",
 				"status":    status,
 			})
-			s.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
+			m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 				"operation": "revoke_token",
 			})
 		}
 	}()
 
 	// ===== STEP 1: Service State Check =====
-	if !s.isRunning.Load() {
+	if !m.isRunning.Load() {
 		status = "not_running"
-		if s.logger != nil {
-			s.logger.Warn("attempted to revoke token while service stopped", ctx)
+		if m.logger != nil {
+			m.logger.Warn("attempted to revoke token while service stopped", ctx)
 		}
-		return ErrServiceNotRunning
+		return ErrManagerNotRunning
 	}
 
 	// ===== STEP 2: Context Check =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
-		if s.logger != nil {
-			s.logger.Info("context cancelled during token revocation", ctx)
+		if m.logger != nil {
+			m.logger.Info("context cancelled during token revocation", ctx)
 		}
 		return err
 	}
@@ -1451,18 +1451,18 @@ func (s *Service) RevokeRefreshToken(ctx context.Context, tokenID string) error 
 	// ===== STEP 3: Input Validation =====
 	if tokenID == "" {
 		status = "invalid_input"
-		if s.logger != nil {
-			s.logger.Warn("empty token ID provided for revocation", ctx)
+		if m.logger != nil {
+			m.logger.Warn("empty token ID provided for revocation", ctx)
 		}
 		return ErrInvalidRefreshToken
 	}
 
 	// ===== STEP 4: Revoke Token =====
-	err := s.refreshStore.Revoke(ctx, tokenID)
+	err := m.refreshStore.Revoke(ctx, tokenID)
 	if err != nil {
-		if s.logger != nil {
+		if m.logger != nil {
 
-			s.logger.Error("failed to revoke refresh token", ctx,
+			m.logger.Error("failed to revoke refresh token", ctx,
 				"tokenID", tokenID,
 				"error", err)
 		}
@@ -1471,8 +1471,8 @@ func (s *Service) RevokeRefreshToken(ctx context.Context, tokenID string) error 
 
 	// ===== STEP 5: Record Success and Log =====
 	status = "success"
-	if s.logger != nil {
-		s.logger.Info("refresh token revoked", ctx,
+	if m.logger != nil {
+		m.logger.Info("refresh token revoked", ctx,
 			"tokenID", tokenID)
 	}
 
@@ -1480,39 +1480,39 @@ func (s *Service) RevokeRefreshToken(ctx context.Context, tokenID string) error 
 }
 
 // RevokeAllUserTokens revokes every refresh token belonging to the given user.
-// Use this for logout-all-devices or account suspension scenarios.
+// Use this for logout-all-devices or account suspension scenariom.
 //
-// Returns ErrServiceNotRunning, ErrInvalidUserID for empty userID, or the
+// Returns ErrManagerNotRunning, ErrInvalidUserID for empty userID, or the
 // context error.
-func (s *Service) RevokeAllUserTokens(ctx context.Context, userID string) error {
+func (m *Manager)RevokeAllUserTokens(ctx context.Context, userID string) error {
 	start := time.Now()
 	status := "error"
 	defer func() {
-		if s.metrics != nil {
-			s.metrics.IncrementCounter(metricTokensRevokedTotal, map[string]string{
+		if m.metrics != nil {
+			m.metrics.IncrementCounter(metricTokensRevokedTotal, map[string]string{
 				"operation": "all_user",
 				"status":    status,
 			})
-			s.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
+			m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 				"operation": "revoke_all_user_tokens",
 			})
 		}
 	}()
 
 	// ===== STEP 1: Service State Check =====
-	if !s.isRunning.Load() {
+	if !m.isRunning.Load() {
 		status = "not_running"
-		if s.logger != nil {
-			s.logger.Warn("attempted to revoke all user tokens while service stopped", ctx)
+		if m.logger != nil {
+			m.logger.Warn("attempted to revoke all user tokens while service stopped", ctx)
 		}
-		return ErrServiceNotRunning
+		return ErrManagerNotRunning
 	}
 
 	// ===== STEP 2: Context Check =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
-		if s.logger != nil {
-			s.logger.Info("context cancelled during bulk token revocation", ctx,
+		if m.logger != nil {
+			m.logger.Info("context cancelled during bulk token revocation", ctx,
 				"error", err)
 		}
 		return err
@@ -1521,17 +1521,17 @@ func (s *Service) RevokeAllUserTokens(ctx context.Context, userID string) error 
 	// ===== STEP 3: Input Validation =====
 	if userID == "" {
 		status = "invalid_input"
-		if s.logger != nil {
-			s.logger.Warn("empty user ID provided for bulk revocation", ctx)
+		if m.logger != nil {
+			m.logger.Warn("empty user ID provided for bulk revocation", ctx)
 		}
 		return ErrInvalidUserID // Note: Different error than single revoke
 	}
 
 	// ===== STEP 4: Revoke All Tokens For User =====
-	err := s.refreshStore.RevokeAllForUser(ctx, userID)
+	err := m.refreshStore.RevokeAllForUser(ctx, userID)
 	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("failed to revoke all user tokens", ctx,
+		if m.logger != nil {
+			m.logger.Error("failed to revoke all user tokens", ctx,
 				"userID", userID,
 				"error", err)
 		}
@@ -1540,8 +1540,8 @@ func (s *Service) RevokeAllUserTokens(ctx context.Context, userID string) error 
 
 	// ===== STEP 5: Record Success and Log =====
 	status = "success"
-	if s.logger != nil {
-		s.logger.Info("all refresh tokens revoked for user", ctx,
+	if m.logger != nil {
+		m.logger.Info("all refresh tokens revoked for user", ctx,
 			"userID", userID)
 	}
 
@@ -1555,60 +1555,60 @@ func (s *Service) RevokeAllUserTokens(ctx context.Context, userID string) error 
 // Only refresh tokens are supported. Access tokens (JWTs) should be validated
 // with ValidateAccessToken instead.
 //
-// Returns ErrServiceNotRunning, ErrInvalidRefreshToken for empty tokens, or
+// Returns ErrManagerNotRunning, ErrInvalidRefreshToken for empty tokens, or
 // the context error.
-func (s *Service) IntrospectToken(ctx context.Context, token string) (*TokenMetadata, error) {
+func (m *Manager)IntrospectToken(ctx context.Context, token string) (*TokenMetadata, error) {
 	start := time.Now()
 	status := "error"
 	defer func() {
-		if s.metrics != nil {
-			s.metrics.IncrementCounter(metricTokensIntrospectedTotal, map[string]string{
+		if m.metrics != nil {
+			m.metrics.IncrementCounter(metricTokensIntrospectedTotal, map[string]string{
 				"status": status,
 			})
-			s.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
+			m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 				"operation": "introspect_token",
 			})
 		}
 	}()
 
 	// ===== STEP 1: Service State Check =====
-	if !s.isRunning.Load() {
+	if !m.isRunning.Load() {
 		status = "not_running"
-		if s.logger != nil {
-			s.logger.Warn("attempted to introspect token while service is stopped", ctx)
+		if m.logger != nil {
+			m.logger.Warn("attempted to introspect token while service is stopped", ctx)
 		}
-		return nil, ErrServiceNotRunning
+		return nil, ErrManagerNotRunning
 	}
 
 	// ===== STEP 2: Context Check =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
-		if s.logger != nil {
-			s.logger.Info("context cancelled during token introspection", ctx)
+		if m.logger != nil {
+			m.logger.Info("context cancelled during token introspection", ctx)
 		}
 		return nil, err
 	}
 
-	if s.logger != nil {
-		s.logger.Debug("introspecting token", ctx)
+	if m.logger != nil {
+		m.logger.Debug("introspecting token", ctx)
 	}
 
 	// ===== STEP 3: Input Validation =====
 	if token == "" {
 		status = "invalid_input"
-		if s.logger != nil {
-			s.logger.Warn("empty token provided for introspection", ctx)
+		if m.logger != nil {
+			m.logger.Warn("empty token provided for introspection", ctx)
 		}
 		return nil, ErrInvalidRefreshToken
 	}
 
 	// ===== STEP 4: Retrieve Token From Storage =====
-	refreshToken, err := s.refreshStore.Retrieve(ctx, token)
+	refreshToken, err := m.refreshStore.Retrieve(ctx, token)
 	if err != nil {
 		// Return inactive metadata instead of error — introspect never errors on unknown tokens
 		status = "success"
-		if s.logger != nil {
-			s.logger.Info("token not found during introspection", ctx,
+		if m.logger != nil {
+			m.logger.Info("token not found during introspection", ctx,
 				"error", err)
 		}
 		return &TokenMetadata{
@@ -1626,8 +1626,8 @@ func (s *Service) IntrospectToken(ctx context.Context, token string) (*TokenMeta
 	// Check if expired
 	if refreshToken.ExpiresAt.Before(now) {
 		status = "success"
-		if s.logger != nil {
-			s.logger.Info("introspect token is expired", ctx,
+		if m.logger != nil {
+			m.logger.Info("introspect token is expired", ctx,
 				"token", token,
 				"expiredAt", refreshToken.ExpiresAt)
 		}
@@ -1643,8 +1643,8 @@ func (s *Service) IntrospectToken(ctx context.Context, token string) (*TokenMeta
 	// Check if revoked
 	if refreshToken.Revoked {
 		status = "success"
-		if s.logger != nil {
-			s.logger.Info("introspected token is revoked", ctx,
+		if m.logger != nil {
+			m.logger.Info("introspected token is revoked", ctx,
 				"tokenID", token)
 		}
 
@@ -1659,8 +1659,8 @@ func (s *Service) IntrospectToken(ctx context.Context, token string) (*TokenMeta
 
 	// ===== STEP 6: Record Success and Return Active Token Metadata =====
 	status = "success"
-	if s.logger != nil {
-		s.logger.Info("token introspection successfully", ctx,
+	if m.logger != nil {
+		m.logger.Info("token introspection successfully", ctx,
 			"tokenID", token,
 			"userID", refreshToken.UserID,
 			"active", true)
@@ -1676,48 +1676,48 @@ func (s *Service) IntrospectToken(ctx context.Context, token string) (*TokenMeta
 
 // CleanupExpiredTokens removes all expired refresh tokens from the RefreshStore.
 // The service also runs this automatically in the background at CleanupInterval,
-// so manual calls are only needed for on-demand sweeps.
+// so manual calls are only needed for on-demand sweepm.
 //
-// Returns the number of tokens deleted, ErrServiceNotRunning, or the context error.
-func (s *Service) CleanupExpiredTokens(ctx context.Context) (int, error) {
+// Returns the number of tokens deleted, ErrManagerNotRunning, or the context error.
+func (m *Manager)CleanupExpiredTokens(ctx context.Context) (int, error) {
 	start := time.Now()
 	status := "error"
 	defer func() {
-		if s.metrics != nil {
-			s.metrics.IncrementCounter(metricOperationsTotal, map[string]string{
+		if m.metrics != nil {
+			m.metrics.IncrementCounter(metricOperationsTotal, map[string]string{
 				"operation": "cleanup",
 				"status":    status,
 			})
-			s.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
+			m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 				"operation": "cleanup",
 			})
 		}
 	}()
 
 	// ===== STEP 1: Service State Check =====
-	if !s.isRunning.Load() {
+	if !m.isRunning.Load() {
 		status = "not_running"
-		if s.logger != nil {
-			s.logger.Warn("attempted cleanup while service stopped", ctx)
+		if m.logger != nil {
+			m.logger.Warn("attempted cleanup while service stopped", ctx)
 		}
-		return 0, ErrServiceNotRunning
+		return 0, ErrManagerNotRunning
 	}
 
 	// ===== STEP 2: Context Check =====
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
-		if s.logger != nil {
-			s.logger.Info("context cancelled during cleanup", ctx,
+		if m.logger != nil {
+			m.logger.Info("context cancelled during cleanup", ctx,
 				"error", err)
 		}
 		return 0, err
 	}
 
 	// ===== STEP 3: Run Cleanup =====
-	count, err := s.refreshStore.Cleanup(ctx)
+	count, err := m.refreshStore.Cleanup(ctx)
 	if err != nil {
-		if s.logger != nil {
-			s.logger.Error("failed to cleanup expired tokens", ctx,
+		if m.logger != nil {
+			m.logger.Error("failed to cleanup expired tokens", ctx,
 				"error", err)
 		}
 		return 0, fmt.Errorf("cleanup failed: %w", err)
@@ -1725,8 +1725,8 @@ func (s *Service) CleanupExpiredTokens(ctx context.Context) (int, error) {
 
 	// ===== STEP 4: Record Success and Log =====
 	status = "success"
-	if s.logger != nil {
-		s.logger.Info("expired tokens cleaned up", ctx,
+	if m.logger != nil {
+		m.logger.Info("expired tokens cleaned up", ctx,
 			"deleted", count)
 	}
 

--- a/pkg/tokens/manager_lifecycle_test.go
+++ b/pkg/tokens/manager_lifecycle_test.go
@@ -16,10 +16,10 @@ import (
 	"github.com/aetomala/jwtauth/pkg/tokens"
 )
 
-var _ = Describe("TokenService", func() {
+var _ = Describe("TokenManager", func() {
 	var (
 		ctrl       *gomock.Controller
-		service    *tokens.Service
+		service    *tokens.Manager
 		mockKM     *testutil.MockKeyManager
 		mockStore  *testutil.MockRefreshStore
 		mockLogger *testutil.MockLogger
@@ -59,8 +59,8 @@ var _ = Describe("TokenService", func() {
 		ctrl.Finish() // Verify all expectations were met
 	})
 
-	createService := func() *tokens.Service {
-		config := tokens.ServiceConfig{
+	createService := func() *tokens.Manager {
+		config := tokens.ManagerConfig{
 			KeyManager:           mockKM,
 			RefreshStore:         mockStore,
 			Logger:               mockLogger,
@@ -71,9 +71,9 @@ var _ = Describe("TokenService", func() {
 			Audience:             []string{"test-audience"},
 		}
 
-		svc, err := tokens.NewService(config)
+		mgr, err := tokens.NewManager(config)
 		Expect(err).NotTo(HaveOccurred())
-		return svc
+		return mgr
 	}
 
 	// ========================================================================
@@ -329,7 +329,7 @@ var _ = Describe("TokenService", func() {
 
 			// Try to issue token
 			_, err := service.IssueAccessToken(ctx, "user-123")
-			Expect(err).To(Equal(tokens.ErrServiceNotRunning))
+			Expect(err).To(Equal(tokens.ErrManagerNotRunning))
 		})
 
 		It("should return error if KeyManager fails to shutdown", func() {
@@ -418,7 +418,7 @@ var _ = Describe("TokenService", func() {
 
 			// Operations should fail after shutdown
 			_, err = service.IssueAccessToken(ctx, "user-456")
-			Expect(err).To(Equal(tokens.ErrServiceNotRunning))
+			Expect(err).To(Equal(tokens.ErrManagerNotRunning))
 		})
 	})
 })

--- a/pkg/tokens/manager_metrics_test.go
+++ b/pkg/tokens/manager_metrics_test.go
@@ -15,13 +15,13 @@ import (
 	"github.com/aetomala/jwtauth/pkg/tokens"
 )
 
-var _ = Describe("TokenService Metrics", func() {
+var _ = Describe("TokenManager Metrics", func() {
 	var (
 		ctrl      *gomock.Controller
 		mockKM    *testutil.MockKeyManager
 		mockStore *testutil.MockRefreshStore
 		mockM     *testutil.MockMetrics
-		service   *tokens.Service
+		service   *tokens.Manager
 		ctx       context.Context
 		cancel    context.CancelFunc
 		testKey   *rsa.PrivateKey
@@ -41,7 +41,7 @@ var _ = Describe("TokenService Metrics", func() {
 		mockStore = testutil.NewMockRefreshStore(ctrl)
 		mockM = testutil.NewMockMetrics(ctrl)
 
-		service, err = tokens.NewService(tokens.ServiceConfig{
+		service, err = tokens.NewManager(tokens.ManagerConfig{
 			KeyManager:           mockKM,
 			RefreshStore:         mockStore,
 			Metrics:              mockM,
@@ -122,7 +122,7 @@ var _ = Describe("TokenService Metrics", func() {
 				"operation": "issue_access_token",
 			})
 			_, err := service.IssueAccessToken(ctx, "user-1")
-			Expect(err).To(MatchError(tokens.ErrServiceNotRunning))
+			Expect(err).To(MatchError(tokens.ErrManagerNotRunning))
 		})
 
 		It("records invalid_input counter for empty user ID", func() {
@@ -210,7 +210,7 @@ var _ = Describe("TokenService Metrics", func() {
 				"operation": "validate_access_token",
 			})
 			_, err := service.ValidateAccessToken(ctx, "some-token")
-			Expect(err).To(MatchError(tokens.ErrServiceNotRunning))
+			Expect(err).To(MatchError(tokens.ErrManagerNotRunning))
 		})
 	})
 
@@ -385,7 +385,7 @@ var _ = Describe("TokenService Metrics", func() {
 
 	Describe("nil metrics", func() {
 		It("does not panic when Metrics is nil", func() {
-			nilService, nilMetricsErr := tokens.NewService(tokens.ServiceConfig{
+			nilService, nilMetricsErr := tokens.NewManager(tokens.ManagerConfig{
 				KeyManager:          mockKM,
 				RefreshStore:        mockStore,
 				Metrics:             nil,

--- a/pkg/tokens/manager_test.go
+++ b/pkg/tokens/manager_test.go
@@ -25,10 +25,10 @@ func TestTokens(t *testing.T) {
 	RunSpecs(t, "Tokens Suite")
 }
 
-var _ = Describe("TokenService", func() {
+var _ = Describe("TokenManager", func() {
 	var (
 		ctrl        *gomock.Controller
-		service     *tokens.Service
+		service     *tokens.Manager
 		mockKM      *testutil.MockKeyManager
 		mockStore   *testutil.MockRefreshStore
 		mockLogger  *testutil.MockLogger
@@ -72,8 +72,8 @@ var _ = Describe("TokenService", func() {
 		ctrl.Finish() // Verify all expectations were met
 	})
 
-	createService := func() *tokens.Service {
-		config := tokens.ServiceConfig{
+	createService := func() *tokens.Manager {
+		config := tokens.ManagerConfig{
 			KeyManager:           mockKM,
 			RefreshStore:         mockStore,
 			Logger:               mockLogger,
@@ -84,31 +84,31 @@ var _ = Describe("TokenService", func() {
 			Audience:             []string{"test-audience"},
 		}
 
-		svc, err := tokens.NewService(config)
+		mgr, err := tokens.NewManager(config)
 		Expect(err).NotTo(HaveOccurred())
-		return svc
+		return mgr
 	}
 
 	// ========================================================================
 	// NEWSERVICE TESTS
 	// ========================================================================
-	Describe("NewService", func() {
+	Describe("NewManager", func() {
 		Context("with valid configuration", func() {
 			It("should create service successfully", func() {
-				config := tokens.ServiceConfig{
+				config := tokens.ManagerConfig{
 					KeyManager:           mockKM,
 					RefreshStore:         mockStore,
 							Logger:               mockLogger,
 					AccessTokenDuration:  15 * time.Minute,
 					RefreshTokenDuration: 30 * 24 * time.Hour,
 				}
-				svc, err := tokens.NewService(config)
+				mgr, err := tokens.NewManager(config)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(svc).NotTo(BeNil())
+				Expect(mgr).NotTo(BeNil())
 			})
 
 			It("should work without optional logger", func() {
-				config := tokens.ServiceConfig{
+				config := tokens.ManagerConfig{
 					KeyManager:           mockKM,
 					RefreshStore:         mockStore,
 							Logger:               nil, // Optional
@@ -116,86 +116,86 @@ var _ = Describe("TokenService", func() {
 					RefreshTokenDuration: 30 * 24 * time.Hour,
 				}
 
-				svc, err := tokens.NewService(config)
+				mgr, err := tokens.NewManager(config)
 
 				Expect(err).NotTo(HaveOccurred())
-				Expect(svc).NotTo(BeNil())
+				Expect(mgr).NotTo(BeNil())
 			})
 
 			It("should use default durations when not specified", func() {
-				config := tokens.ServiceConfig{
+				config := tokens.ManagerConfig{
 					KeyManager:   mockKM,
 					RefreshStore: mockStore,
 						// Durations not specified
 				}
 
-				svc, err := tokens.NewService(config)
+				mgr, err := tokens.NewManager(config)
 
 				Expect(err).NotTo(HaveOccurred())
-				Expect(svc).NotTo(BeNil())
+				Expect(mgr).NotTo(BeNil())
 			})
 		})
 
 		Context("with invalid configuration", func() {
 			It("should return error when KeyManager is nil", func() {
-				config := tokens.ServiceConfig{
+				config := tokens.ManagerConfig{
 					KeyManager:   nil, // Required
 					RefreshStore: mockStore,
 					}
 
-				_, err := tokens.NewService(config)
+				_, err := tokens.NewManager(config)
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("KeyManager"))
 			})
 
 			It("should return error when RefreshStore is nil", func() {
-				config := tokens.ServiceConfig{
+				config := tokens.ManagerConfig{
 					KeyManager:   mockKM,
 					RefreshStore: nil, // Required
 					}
-				_, err := tokens.NewService(config)
+				_, err := tokens.NewManager(config)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("RefreshStore"))
 			})
 
 
 			It("should return error for invalid token durations", func() {
-				config := tokens.ServiceConfig{
+				config := tokens.ManagerConfig{
 					KeyManager:           mockKM,
 					RefreshStore:         mockStore,
 							AccessTokenDuration:  -1 * time.Minute, // Invalid
 					RefreshTokenDuration: 30 * 24 * time.Hour,
 				}
 
-				_, err := tokens.NewService(config)
+				_, err := tokens.NewManager(config)
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("AccessTokenDuration"))
 			})
 
 			It("should return error for invalid refresh token durations", func() {
-				config := tokens.ServiceConfig{
+				config := tokens.ManagerConfig{
 					KeyManager:           mockKM,
 					RefreshStore:         mockStore,
 							AccessTokenDuration:  5 * time.Minute,
 					RefreshTokenDuration: -1 * 24 * time.Hour, // Invalid
 				}
 
-				_, err := tokens.NewService(config)
+				_, err := tokens.NewManager(config)
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("RefreshTokenDuration"))
 			})
 
 			It("should return error for negative ClockSkew", func() {
-				config := tokens.ServiceConfig{
+				config := tokens.ManagerConfig{
 					KeyManager: mockKM,
 					RefreshStore: mockStore,
 					ClockSkew:  -1 * time.Second,
 				}
 
-				_, err := tokens.NewService(config)
+				_, err := tokens.NewManager(config)
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("ClockSkew"))
@@ -323,10 +323,10 @@ var _ = Describe("TokenService", func() {
 		})
 
 		Context("IssueAccessTokenWithClaims guard conditions", func() {
-			It("should return ErrServiceNotRunning", func() {
-				svc := createService()
-				_, err := svc.IssueAccessTokenWithClaims(ctx, testUserID, nil)
-				Expect(err).To(Equal(tokens.ErrServiceNotRunning))
+			It("should return ErrManagerNotRunning", func() {
+				mgr := createService()
+				_, err := mgr.IssueAccessTokenWithClaims(ctx, testUserID, nil)
+				Expect(err).To(Equal(tokens.ErrManagerNotRunning))
 			})
 
 			It("should return context error when context is cancelled", func() {
@@ -471,10 +471,10 @@ var _ = Describe("TokenService", func() {
 		})
 
 		Context("guard conditions", func() {
-			It("should return ErrServiceNotRunning", func() {
-				svc := createService()
-				_, err := svc.IssueRefreshToken(ctx, "user-123")
-				Expect(err).To(Equal(tokens.ErrServiceNotRunning))
+			It("should return ErrManagerNotRunning", func() {
+				mgr := createService()
+				_, err := mgr.IssueRefreshToken(ctx, "user-123")
+				Expect(err).To(Equal(tokens.ErrManagerNotRunning))
 			})
 
 			It("should return context error when context is cancelled", func() {
@@ -496,7 +496,7 @@ var _ = Describe("TokenService", func() {
 
 				_, err := stoppedService.IssueRefreshTokenWithMetadata(ctx, testUserID, nil)
 
-				Expect(err).To(MatchError(tokens.ErrServiceNotRunning))
+				Expect(err).To(MatchError(tokens.ErrManagerNotRunning))
 			})
 
 			It("should return error when context is cancelled", func() {
@@ -608,10 +608,10 @@ var _ = Describe("TokenService", func() {
 		})
 
 		Context("guard conditions", func() {
-			It("should return ErrServiceNotRunning", func() {
-				svc := createService()
-				_, _, err := svc.IssueTokenPair(ctx, "user-123")
-				Expect(err).To(Equal(tokens.ErrServiceNotRunning))
+			It("should return ErrManagerNotRunning", func() {
+				mgr := createService()
+				_, _, err := mgr.IssueTokenPair(ctx, "user-123")
+				Expect(err).To(Equal(tokens.ErrManagerNotRunning))
 			})
 
 			It("should return context error when context is cancelled", func() {
@@ -747,10 +747,10 @@ var _ = Describe("TokenService", func() {
 		})
 
 		Context("with clock skew leeway configured", func() {
-			var leewayService *tokens.Service
+			var leewayService *tokens.Manager
 
 			BeforeEach(func() {
-				config := tokens.ServiceConfig{
+				config := tokens.ManagerConfig{
 					KeyManager:          mockKM,
 					RefreshStore:        mockStore,
 					Logger:              mockLogger,
@@ -761,7 +761,7 @@ var _ = Describe("TokenService", func() {
 					ClockSkew:           30 * time.Second,
 				}
 				var err error
-				leewayService, err = tokens.NewService(config)
+				leewayService, err = tokens.NewManager(config)
 				Expect(err).NotTo(HaveOccurred())
 
 				mockKM.EXPECT().Start(gomock.Any()).Return(nil)
@@ -915,10 +915,10 @@ var _ = Describe("TokenService", func() {
 		})
 
 		Context("guard conditions", func() {
-			It("should return ErrServiceNotRunning", func() {
-				svc := createService()
-				_, err := svc.ValidateAccessToken(ctx, validToken)
-				Expect(err).To(Equal(tokens.ErrServiceNotRunning))
+			It("should return ErrManagerNotRunning", func() {
+				mgr := createService()
+				_, err := mgr.ValidateAccessToken(ctx, validToken)
+				Expect(err).To(Equal(tokens.ErrManagerNotRunning))
 			})
 
 			It("should return context error when context is cancelled", func() {
@@ -1107,10 +1107,10 @@ var _ = Describe("TokenService", func() {
 		})
 
 		Context("guard conditions", func() {
-			It("should return ErrServiceNotRunning when service is not running", func() {
-				svc := createService()
-				_, err := svc.RefreshAccessToken(ctx, "any-token")
-				Expect(err).To(Equal(tokens.ErrServiceNotRunning))
+			It("should return ErrManagerNotRunning when manager is not running", func() {
+				mgr := createService()
+				_, err := mgr.RefreshAccessToken(ctx, "any-token")
+				Expect(err).To(Equal(tokens.ErrManagerNotRunning))
 			})
 
 			It("should return context error when context is cancelled", func() {
@@ -1211,10 +1211,10 @@ var _ = Describe("TokenService", func() {
 		})
 
 		Context("guard conditions", func() {
-			It("should return ErrServiceNotRunning when service is not running", func() {
-				svc := createService()
-				err := svc.RevokeRefreshToken(ctx, "any-token")
-				Expect(err).To(Equal(tokens.ErrServiceNotRunning))
+			It("should return ErrManagerNotRunning when manager is not running", func() {
+				mgr := createService()
+				err := mgr.RevokeRefreshToken(ctx, "any-token")
+				Expect(err).To(Equal(tokens.ErrManagerNotRunning))
 			})
 
 			It("should return context error when context is cancelled", func() {
@@ -1271,10 +1271,10 @@ var _ = Describe("TokenService", func() {
 		})
 
 		Context("guard conditions", func() {
-			It("should return ErrServiceNotRunning when service is not running", func() {
-				svc := createService()
-				err := svc.RevokeAllUserTokens(ctx, "user-123")
-				Expect(err).To(Equal(tokens.ErrServiceNotRunning))
+			It("should return ErrManagerNotRunning when manager is not running", func() {
+				mgr := createService()
+				err := mgr.RevokeAllUserTokens(ctx, "user-123")
+				Expect(err).To(Equal(tokens.ErrManagerNotRunning))
 			})
 
 			It("should return context error when context is cancelled", func() {
@@ -1400,7 +1400,7 @@ var _ = Describe("TokenService", func() {
 
 				_, err := stoppedService.IntrospectToken(ctx, refreshToken)
 
-				Expect(err).To(MatchError(tokens.ErrServiceNotRunning))
+				Expect(err).To(MatchError(tokens.ErrManagerNotRunning))
 			})
 		})
 
@@ -1477,7 +1477,7 @@ var _ = Describe("TokenService", func() {
 
 				_, err := stoppedService.CleanupExpiredTokens(ctx)
 
-				Expect(err).To(MatchError(tokens.ErrServiceNotRunning))
+				Expect(err).To(MatchError(tokens.ErrManagerNotRunning))
 			})
 		})
 

--- a/pkg/tokens/observability.go
+++ b/pkg/tokens/observability.go
@@ -1,6 +1,6 @@
 package tokens
 
-// Metric names for TokenService operations. All implementations record the
+// Metric names for TokenManager operations. All implementations record the
 // same set of metrics so the names are defined once here and referenced by
 // all methods.
 const (


### PR DESCRIPTION
## Summary

- **Rebranding** — `tokens.Service` → `tokens.Manager`, `ServiceConfig` → `ManagerConfig`, `NewService` → `NewManager`, `ErrServiceNotRunning` → `ErrManagerNotRunning`, `AuthMiddleware` → `BearerMiddleware`, `loginHandler` → `issueTokensHandler`
- **README "Why This Library?" rewrite** — new positioning (authz engine, not authn), comparisons vs. golang-jwt/jwt, framework middleware, JOSE toolkits; security guarantees block; horizontal scale path table
- **Logging documentation brought to current state** — correlation ID system fully documented (`WithCorrelationID`, `CorrelationIDHandler`, `NewCorrelationJSONLogger`), Debug level added, Zap/Zerolog adapter examples fixed (were missing `Debug` method), Quick Start updated
- **`examples/correlation-example/README.md`** — new file; full README matching Gin/Chi/Echo structure
- **`examples/README.md`** — corrected title, added correlation-example entry and comparison table column
- **`doc/ARCHITECTURE.md`** — correlation-example in file tree, Correlation ID subsection, Integration Pattern example updated with `ctx` kwarg
- **CHANGELOG** — documented all of the above under `[Unreleased] — v0.4.0`

## Test plan

- [ ] `go build ./...` passes
- [ ] Docs render correctly on GitHub