### PR TITLE
docs: surface value proposition, add migration guide and ADRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,23 @@ All notable changes to this project will be documented in this file.
 
 ### Documentation
 
+- **`README.md` — value proposition audit** — added elevator pitch above the fold (one sentence stating the problem jwtauth solves); moved "Why This Library?" from line ~892 to immediately after Overview; added "What Problem Does This Solve?" section framing the post-login token lifecycle gap; strengthened comparison matrix to include golang-jwt, gin-jwt, jwx, and Auth0; added "When NOT to Use This" section with four explicit anti-use-cases and recommended alternatives.
+
+- **`README.md` — terminology** — replaced all "TokenManager" prose references with "TokenService" (concept) or `Manager` (Go type); added "stateful" qualifier consistently throughout; replaced "authentication" with "authorization" in post-login contexts to align with what jwtauth actually does.
+
+- **`doc/ARCHITECTURE.md` — terminology and positioning** — updated title and overview to reflect stateful JWT authorization engine positioning; replaced all "TokenManager" occurrences with "TokenService" / `Manager`.
+
+- **`doc/MIGRATION.md`** — new file; step-by-step migration guides from `golang-jwt/jwt` (manual token management → jwtauth), `gin-jwt` (framework lock-in → framework-agnostic middleware), and `lestrrat-go/jwx` (JOSE toolkit → focused engine). Covers common patterns (adding refresh tokens, adding revocation, zero-downtime key rotation), single-instance-to-distributed upgrade path, and a 10-item migration checklist.
+
+- **`doc/adr/`** — new directory; three Architecture Decision Records:
+  - `001-no-rate-limiting.md` — rate limiting belongs at the infrastructure layer (API Gateway, Ingress); jwtauth stays focused on token lifecycle.
+  - `002-stateful-refresh-tokens.md` — refresh tokens are opaque UUIDs stored server-side for instant revocation; stateless refresh tokens were rejected because they cannot be revoked before expiry.
+  - `003-rs256-only.md` — RS256 asserted unconditionally in `ValidateAccessToken` to prevent algorithm confusion attacks (CVE-2015-9235); ES256 and configurable algorithms were rejected.
+
+- **`pkg/tokens` — package doc comment** — added `// Package tokens ...` comment with key capability list (access token issuance, refresh token rotation, instant revocation, distributed cleanup) and canonical usage example covering the full token lifecycle.
+
+- **`pkg/keymanager` — package doc comment** — added `// Package keymanager ...` comment with rotation timeline ASCII diagram (Day 0 → Day 30 → Day 30+1h) and storage backend summary.
+
 - **`README.md` — "Why This Library?" rewrite** — new positioning statement (authz layer, not authn), comparison vs. `golang-jwt/jwt` (build-vs-buy table), vs. framework JWT middleware (`gin-jwt`, `echo-jwt`) — previously missing entirely, vs. `lestrrat-go/jwx` / `go-jose/go-jose` JOSE toolkits, concrete security guarantees block (algorithm confusion, reserved claim protection, 10 sentinel errors, instant revocation), horizontal scale path table (`DiskKeyStore`+`MemoryRefreshStore` → `RedisKeyStore`+`RedisRefreshStore`), and "What jwtauth is not" closing paragraph.
 
 - **`pkg/logging/README.md` — brought up to date** — corrected "3 log levels" to 4, added `Debug` level section with examples, updated Quick Start to recommend `NewCorrelationJSONLogger` as the production default, added full Correlation ID section (setup, HTTP middleware pattern, output examples, log aggregator filtering, and API reference table), fixed third-party adapter examples for Zap and Zerolog (both were missing the `Debug` method and would not satisfy the `Logger` interface), fixed broken `See Also` link.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,75 @@ Swap the constructor arguments. The `KeyManager` and `TokenService` interfaces a
 
 **What jwtauth is not:** a full authorization server (no login flows, no OAuth2/OIDC), a session management library, or a rate limiter. For managed auth infrastructure, Keycloak, Dex, or Ory Hydra serve that role. jwtauth is the token engine you'd wire underneath them, or build directly into a service that already verifies identity by other means.
 
+## When NOT to Use This
+
+Good libraries state their boundaries. Here's when jwtauth is the **wrong choice**:
+
+### ❌ You Need a Complete Authentication Server
+
+**Don't use jwtauth if you need:**
+- Login flows (username/password, OAuth callbacks, SAML assertion handling)
+- User registration and account management
+- Password reset flows and email verification
+- Multi-factor authentication (MFA/2FA)
+- Session management with cookies
+- Identity provider integration (Google, GitHub, Auth0)
+
+**Use instead:** [Keycloak](https://www.keycloak.org/), [Ory Hydra](https://www.ory.sh/hydra/), [Auth0](https://auth0.com/), [Dex](https://dexidp.io/)
+
+**Why:** These provide complete authentication infrastructure. jwtauth assumes you've already verified identity and just need token machinery.
+
+### ❌ You Only Need Stateless JWT Signing/Validation
+
+**Don't use jwtauth if:**
+- You don't need refresh tokens (short-lived access tokens are enough)
+- You don't need revocation (expiry-based invalidation is acceptable)
+- You're okay with manual key rotation (or no rotation at all)
+- Single-instance deployment (no horizontal scaling)
+
+**Use instead:** [golang-jwt/jwt](https://github.com/golang-jwt/jwt) — simpler, fewer dependencies, does one thing well
+
+**Why:** Stateless JWT is conceptually simpler. If you don't need the stateful machinery (refresh tokens, revocation, key rotation), you're carrying unnecessary complexity.
+
+### ❌ You Need Encrypted Tokens (JWE) or Multi-Algorithm JOSE
+
+**Don't use jwtauth if you need:**
+- JWE (JSON Web Encryption) for encrypted token payloads
+- JWS detached payloads or nested tokens
+- Multiple signing algorithms (ES256, EdDSA, etc.)
+- Full JOSE (JWS, JWE, JWK, JWA) operations
+
+**Use instead:** [lestrrat-go/jwx](https://github.com/lestrrat-go/jwx), [go-jose/go-jose](https://github.com/go-jose/go-jose)
+
+**Why:** jwtauth supports RS256 only. If you need the full JOSE suite, reach for a comprehensive library.
+
+### ❌ Framework-Specific Convenience is Your Priority
+
+**Don't use jwtauth if:**
+- You're using Gin and want zero configuration
+- You want middleware that "just works" with your framework
+- You're building a prototype and don't care about production operations
+- Single file, copy-paste simplicity is more valuable than flexibility
+
+**Use instead:** [gin-jwt/jwt](https://github.com/appleboy/gin-jwt) (for Gin), [echo-jwt](https://github.com/labstack/echo-jwt) (for Echo)
+
+**Why:** Framework-specific middleware trades flexibility for convenience. If you're not running distributed systems in production, that trade-off might be worth it.
+
+---
+
+### ✅ Use jwtauth When
+
+You've already verified identity and need **production-grade token machinery** for distributed systems:
+- Zero-downtime key rotation (not manual)
+- Instant revocation (not expiry-based)
+- Horizontal scale with refresh token state
+- Observability (metrics, logging, tracing)
+- Stateful refresh token lifecycle
+
+**Good fit:** Microservices, multi-instance deployments, production systems where token operations are critical infrastructure.
+
+**Not a fit:** MVPs, single-instance apps, stateless architectures, or when you need an all-in-one auth server.
+
 ### Design Philosophy
 
 - **Dependency Inversion**: All components depend on interfaces, not concrete implementations

--- a/README.md
+++ b/README.md
@@ -6,11 +6,93 @@
 
 **Production-grade JWT authorization token engine for distributed Go applications**
 
+**You verify identity. jwtauth manages everything after:** zero-downtime key rotation, access token issuance, refresh token lifecycle, and instant revocation across horizontal scale.
+
 > ⚠️ **Beta Status**: KeyManager and RefreshStore are production-ready and fully tested. TokenManager is in beta — core operations are complete with comprehensive test coverage. API may change before v1.0.0.
 
 ## Overview
 
 `jwtauth` is a JWT authorization token engine for Go, built from the ground up with **observability, testability, and production operations** as first-class concerns. It manages the stateful machinery that production token systems require — cryptographic key generation and zero-downtime rotation, access token issuance and validation, and refresh token lifecycle with revocation support. Identity verification is intentionally out of scope: jwtauth takes a verified subject ID and handles everything after.
+
+## Why This Library?
+
+`jwtauth` occupies a specific layer: it takes a verified subject ID and manages everything after — signing, key rotation, refresh token lifecycle, and revocation. Identity verification (password check, OAuth exchange, SAML assertion) is out of scope and belongs in the layer above.
+
+If that's your gap, here's what you'd be comparing against:
+
+---
+
+### vs. `golang-jwt/jwt` — building the engine yourself
+
+`golang-jwt/jwt` signs and validates tokens against a key you supply. It does exactly one thing and does it well. Most teams start here and then spend weeks building the surrounding machinery:
+
+| What you build yourself | What jwtauth provides |
+|---|---|
+| Key generation and storage | `KeyManager` with `DiskKeyStore` / `RedisKeyStore` |
+| Zero-downtime key rotation + overlap | Built in — old key stays valid during overlap period |
+| Refresh token storage and lookup | `MemoryRefreshStore` / `RedisRefreshStore` |
+| Revocation (single token, all user sessions) | `RevokeRefreshToken`, `RevokeAllUserTokens` |
+| Custom claims round-trip without re-parsing | `IssueAccessTokenWithClaims` + `ValidateAccessTokenWithClaims` |
+| Clock skew tolerance for distributed deployments | `ManagerConfig.ClockSkew` |
+| 22 Prometheus metrics across all operations | Pre-registered, zero config |
+| 10 typed sentinel errors for middleware logic | `ErrTokenExpired`, `ErrTokenRevoked`, `ErrInvalidAudience`, … |
+
+**jwtauth is what you'd build on top of golang-jwt after a few months in production.**
+
+---
+
+### vs. framework JWT middleware (`gin-jwt`, `echo-jwt`, similar)
+
+Framework-specific JWT packages bundle signing, validation, and middleware into a single dependency. They're the fastest path to a working login endpoint but carry structural limitations:
+
+- **No key rotation** — one static secret or key pair for the lifetime of the service
+- **No refresh token state** — revocation requires a separate blocklist you build yourself
+- **Framework lock-in** — the middleware only works with your chosen framework; switching means rewriting auth
+- **No metrics** — you don't know how many tokens are being issued, validated, or rejected
+
+`jwtauth` is framework-agnostic. The middleware in the examples is ~20 lines you own; swapping Gin for Chi or Echo is a one-file change.
+
+---
+
+### vs. `lestrrat-go/jwx` / `go-jose/go-jose` — JOSE toolkits
+
+Both are comprehensive JOSE implementations covering JWS, JWE, JWK, JWT, and more. `jwtauth` is narrower and higher-level:
+
+- The token lifecycle API (issue → validate → refresh → revoke) is ready — you're not assembling it from primitives
+- Key rotation is built in, not something you wire together from JWK set operations
+- Structured logging and metrics are first-class, not an afterthought
+- Less surface area to reason about if you only need RS256 JWT tokens
+
+If you need JWE (encrypted tokens), JWS detached payloads, or multi-algorithm JOSE operations, reach for one of those libraries instead.
+
+---
+
+### Concrete security guarantees
+
+1. **Algorithm confusion prevented unconditionally** — `ValidateAccessToken` asserts `*jwt.SigningMethodRSA` before any key lookup. HS256, ECDSA, and `none` are rejected — not configurably, unconditionally.
+
+2. **Reserved claim protection** — `IssueAccessTokenWithClaims` rejects custom claims that would overwrite `sub`, `exp`, `iat`, `nbf`, `jti`, `iss`, or `aud`. Application fields cannot collide with registered claims silently.
+
+3. **10 granular sentinel errors, all `errors.Is()`-compatible** — middleware can distinguish `ErrTokenExpired` from `ErrTokenRevoked` from `ErrInvalidAudience` and return specific JSON error codes (`token_expired`, `token_revoked`, `invalid_audience`) that clients can act on.
+
+4. **Instant revocation, not expiry-based** — `RevokeAllUserTokens` invalidates all sessions for a compromised account immediately. No waiting for short-lived tokens to expire.
+
+---
+
+### Horizontal scale path
+
+The storage backends are designed to move from single-instance to distributed without code changes:
+
+| Deployment | KeyStore | RefreshStore |
+|---|---|---|
+| Single instance (dev, small prod) | `DiskKeyStore` | `MemoryRefreshStore` |
+| Multi-instance (Kubernetes, load-balanced) | `RedisKeyStore` | `RedisRefreshStore` |
+
+Swap the constructor arguments. The `KeyManager` and `TokenManager` interfaces are unchanged.
+
+---
+
+**What jwtauth is not:** a full authentication server (no login flows, no OAuth2/OIDC), a session management library, or a rate limiter. For managed auth infrastructure, Keycloak, Dex, or Ory Hydra serve that role. jwtauth is the token engine you'd wire underneath them, or build directly into a service that already verifies identity by other means.
 
 ### Design Philosophy
 
@@ -753,86 +835,6 @@ Tests follow **progressive phase-based development**:
 2. Organized by concern (not chronology) for clarity
 3. Shared test utilities in `internal/testutil` (MockLogger, etc.)
 4. Race detection on all tests (catches concurrency bugs)
-
-## Why This Library?
-
-`jwtauth` occupies a specific layer: it takes a verified subject ID and manages everything after — signing, key rotation, refresh token lifecycle, and revocation. Identity verification (password check, OAuth exchange, SAML assertion) is out of scope and belongs in the layer above.
-
-If that's your gap, here's what you'd be comparing against:
-
----
-
-### vs. `golang-jwt/jwt` — building the engine yourself
-
-`golang-jwt/jwt` signs and validates tokens against a key you supply. It does exactly one thing and does it well. Most teams start here and then spend weeks building the surrounding machinery:
-
-| What you build yourself | What jwtauth provides |
-|---|---|
-| Key generation and storage | `KeyManager` with `DiskKeyStore` / `RedisKeyStore` |
-| Zero-downtime key rotation + overlap | Built in — old key stays valid during overlap period |
-| Refresh token storage and lookup | `MemoryRefreshStore` / `RedisRefreshStore` |
-| Revocation (single token, all user sessions) | `RevokeRefreshToken`, `RevokeAllUserTokens` |
-| Custom claims round-trip without re-parsing | `IssueAccessTokenWithClaims` + `ValidateAccessTokenWithClaims` |
-| Clock skew tolerance for distributed deployments | `ManagerConfig.ClockSkew` |
-| 22 Prometheus metrics across all operations | Pre-registered, zero config |
-| 10 typed sentinel errors for middleware logic | `ErrTokenExpired`, `ErrTokenRevoked`, `ErrInvalidAudience`, … |
-
-**jwtauth is what you'd build on top of golang-jwt after a few months in production.**
-
----
-
-### vs. framework JWT middleware (`gin-jwt`, `echo-jwt`, similar)
-
-Framework-specific JWT packages bundle signing, validation, and middleware into a single dependency. They're the fastest path to a working login endpoint but carry structural limitations:
-
-- **No key rotation** — one static secret or key pair for the lifetime of the service
-- **No refresh token state** — revocation requires a separate blocklist you build yourself
-- **Framework lock-in** — the middleware only works with your chosen framework; switching means rewriting auth
-- **No metrics** — you don't know how many tokens are being issued, validated, or rejected
-
-`jwtauth` is framework-agnostic. The middleware in the examples is ~20 lines you own; swapping Gin for Chi or Echo is a one-file change.
-
----
-
-### vs. `lestrrat-go/jwx` / `go-jose/go-jose` — JOSE toolkits
-
-Both are comprehensive JOSE implementations covering JWS, JWE, JWK, JWT, and more. `jwtauth` is narrower and higher-level:
-
-- The token lifecycle API (issue → validate → refresh → revoke) is ready — you're not assembling it from primitives
-- Key rotation is built in, not something you wire together from JWK set operations
-- Structured logging and metrics are first-class, not an afterthought
-- Less surface area to reason about if you only need RS256 JWT tokens
-
-If you need JWE (encrypted tokens), JWS detached payloads, or multi-algorithm JOSE operations, reach for one of those libraries instead.
-
----
-
-### Concrete security guarantees
-
-1. **Algorithm confusion prevented unconditionally** — `ValidateAccessToken` asserts `*jwt.SigningMethodRSA` before any key lookup. HS256, ECDSA, and `none` are rejected — not configurably, unconditionally.
-
-2. **Reserved claim protection** — `IssueAccessTokenWithClaims` rejects custom claims that would overwrite `sub`, `exp`, `iat`, `nbf`, `jti`, `iss`, or `aud`. Application fields cannot collide with registered claims silently.
-
-3. **10 granular sentinel errors, all `errors.Is()`-compatible** — middleware can distinguish `ErrTokenExpired` from `ErrTokenRevoked` from `ErrInvalidAudience` and return specific JSON error codes (`token_expired`, `token_revoked`, `invalid_audience`) that clients can act on.
-
-4. **Instant revocation, not expiry-based** — `RevokeAllUserTokens` invalidates all sessions for a compromised account immediately. No waiting for short-lived tokens to expire.
-
----
-
-### Horizontal scale path
-
-The storage backends are designed to move from single-instance to distributed without code changes:
-
-| Deployment | KeyStore | RefreshStore |
-|---|---|---|
-| Single instance (dev, small prod) | `DiskKeyStore` | `MemoryRefreshStore` |
-| Multi-instance (Kubernetes, load-balanced) | `RedisKeyStore` | `RedisRefreshStore` |
-
-Swap the constructor arguments. The `KeyManager` and `TokenManager` interfaces are unchanged.
-
----
-
-**What jwtauth is not:** a full authentication server (no login flows, no OAuth2/OIDC), a session management library, or a rate limiter. For managed auth infrastructure, Keycloak, Dex, or Ory Hydra serve that role. jwtauth is the token engine you'd wire underneath them, or build directly into a service that already verifies identity by other means.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,51 @@
 
 `jwtauth` is a **stateful** JWT authorization token engine for Go, built from the ground up with **observability, testability, and production operations** as first-class concerns. It manages the stateful machinery that production token systems require — cryptographic key generation and zero-downtime rotation, access token issuance and validation, and refresh token lifecycle with revocation support. Identity verification is intentionally out of scope: jwtauth takes a verified subject ID and handles everything after.
 
+## What Problem Does This Solve?
+
+**Most JWT libraries sign tokens. You still build the engine.**
+
+After evaluating golang-jwt, gin-jwt, or jwx, teams realize the library solves 20% of the problem. You still need to build:
+
+- **Key generation and zero-downtime rotation** — Weeks of careful work to ensure old tokens stay valid during rotation periods. Get it wrong and you force every user to re-authenticate.
+
+- **Refresh token storage and lookup** — Days of work designing the schema, choosing the backend (Redis? Postgres?), handling expiration and revocation checks correctly.
+
+- **Instant revocation without waiting for expiry** — Complex state management across distributed instances. Session compromise requires immediate invalidation, not waiting 15 minutes for token expiry.
+
+- **Observability across the token lifecycle** — Usually ignored until production, then bolted on inconsistently. You need metrics on issuance rates, validation failures, rotation success, and revocation patterns.
+
+- **Horizontal scale without state conflicts** — Hard to get right. Multiple instances need shared key storage and coordinated refresh token state. Most teams start with in-memory storage, hit production, then scramble to add Redis.
+
+**jwtauth is the engine you'd build on top of those libraries** after a few months in production. We built it once, correctly, so you don't have to.
+
+### What You Get
+
+Everything after identity verification is handled:
+- You verify identity (password check, OAuth exchange, SAML assertion)
+- jwtauth issues access tokens, manages refresh tokens, rotates keys, and revokes sessions
+- Your application validates tokens and enforces authorization rules
+
+**Your boundary:** Identity verification (who is this user?)  
+**jwtauth's job:** Token lifecycle management (how do I prove it to your API?)
+
 ## Why This Library?
 
-`jwtauth` occupies a specific layer: it takes a verified subject ID and manages everything after — signing, key rotation, **stateful** refresh token lifecycle, and revocation. Identity verification (password check, OAuth exchange, SAML assertion) is out of scope and belongs in the layer above.
+If you've already decided you need stateful token management, here's how jwtauth compares to the alternatives you'd be evaluating:
 
-If that's your gap, here's what you'd be comparing against:
+| Feature | golang-jwt | gin-jwt | jwx | jwtauth |
+|---------|-----------|---------|-----|---------|
+| **Sign/Validate JWT** | ✅ | ✅ | ✅ | ✅ |
+| **Custom claims** | ✅ | ✅ | ✅ | ✅ |
+| **Key rotation** | ❌ Manual | ❌ | ❌ | ✅ Zero-downtime |
+| **Refresh tokens** | ❌ | ❌ | ❌ | ✅ Stateful storage |
+| **Instant revocation** | ❌ | ❌ | ❌ | ✅ RevokeAllUserTokens |
+| **Distributed state** | N/A | ❌ | N/A | ✅ Redis backend |
+| **Metrics** | ❌ | ❌ | ❌ | ✅ 22 Prometheus metrics |
+| **Correlation logging** | ❌ | ❌ | ❌ | ✅ Built-in |
+| **Framework lock-in** | ❌ | ✅ Gin only | ❌ | ❌ |
+| **Complexity** | Low | Medium | High (JOSE) | Medium |
+| **Use when** | Stateless | Gin + stateless | JWE, JWS | Stateful + distributed |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@
 ![Go Version](https://img.shields.io/badge/go-1.21+-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 
-**Production-grade JWT authorization token engine for distributed Go applications**
+**Stateful JWT authorization token engine for distributed Go applications**
 
 **You verify identity. jwtauth manages everything after:** zero-downtime key rotation, access token issuance, refresh token lifecycle, and instant revocation across horizontal scale.
 
-> ⚠️ **Beta Status**: KeyManager and RefreshStore are production-ready and fully tested. TokenManager is in beta — core operations are complete with comprehensive test coverage. API may change before v1.0.0.
+> ⚠️ **Beta Status**: KeyManager and RefreshStore are production-ready and fully tested. TokenService is in beta — core operations are complete with comprehensive test coverage. API may change before v1.0.0.
 
 ## Overview
 
-`jwtauth` is a JWT authorization token engine for Go, built from the ground up with **observability, testability, and production operations** as first-class concerns. It manages the stateful machinery that production token systems require — cryptographic key generation and zero-downtime rotation, access token issuance and validation, and refresh token lifecycle with revocation support. Identity verification is intentionally out of scope: jwtauth takes a verified subject ID and handles everything after.
+`jwtauth` is a **stateful** JWT authorization token engine for Go, built from the ground up with **observability, testability, and production operations** as first-class concerns. It manages the stateful machinery that production token systems require — cryptographic key generation and zero-downtime rotation, access token issuance and validation, and refresh token lifecycle with revocation support. Identity verification is intentionally out of scope: jwtauth takes a verified subject ID and handles everything after.
 
 ## Why This Library?
 
-`jwtauth` occupies a specific layer: it takes a verified subject ID and manages everything after — signing, key rotation, refresh token lifecycle, and revocation. Identity verification (password check, OAuth exchange, SAML assertion) is out of scope and belongs in the layer above.
+`jwtauth` occupies a specific layer: it takes a verified subject ID and manages everything after — signing, key rotation, **stateful** refresh token lifecycle, and revocation. Identity verification (password check, OAuth exchange, SAML assertion) is out of scope and belongs in the layer above.
 
 If that's your gap, here's what you'd be comparing against:
 
@@ -88,11 +88,11 @@ The storage backends are designed to move from single-instance to distributed wi
 | Single instance (dev, small prod) | `DiskKeyStore` | `MemoryRefreshStore` |
 | Multi-instance (Kubernetes, load-balanced) | `RedisKeyStore` | `RedisRefreshStore` |
 
-Swap the constructor arguments. The `KeyManager` and `TokenManager` interfaces are unchanged.
+Swap the constructor arguments. The `KeyManager` and `TokenService` interfaces are unchanged.
 
 ---
 
-**What jwtauth is not:** a full authentication server (no login flows, no OAuth2/OIDC), a session management library, or a rate limiter. For managed auth infrastructure, Keycloak, Dex, or Ory Hydra serve that role. jwtauth is the token engine you'd wire underneath them, or build directly into a service that already verifies identity by other means.
+**What jwtauth is not:** a full authorization server (no login flows, no OAuth2/OIDC), a session management library, or a rate limiter. For managed auth infrastructure, Keycloak, Dex, or Ory Hydra serve that role. jwtauth is the token engine you'd wire underneath them, or build directly into a service that already verifies identity by other means.
 
 ### Design Philosophy
 
@@ -118,7 +118,7 @@ Swap the constructor arguments. The `KeyManager` and `TokenManager` interfaces a
 - **Full metrics instrumentation** — KeyStore and Manager operations via `jwtauth_keystore_*` and `jwtauth_key_*` metrics
 - **Comprehensive test coverage** with race detection
 
-**TokenManager** (Beta)
+**TokenService** (Beta)
 - **Access token issuance** (IssueAccessToken, IssueAccessTokenWithClaims, IssueTokenPair)
 - **Refresh token issuance** (IssueRefreshToken, IssueRefreshTokenWithMetadata)
 - **Access token validation** with registered and custom claims extraction (ValidateAccessToken, ValidateAccessTokenWithClaims)
@@ -157,7 +157,7 @@ Swap the constructor arguments. The `KeyManager` and `TokenManager` interfaces a
 
 ### 🚧 In Development (v0.4.0)
 
-- **OpenTelemetry / Distributed Tracing**: `pkg/tracing` interfaces (`Tracer`, `Span`) and `NoOpTracer` are scaffolded. Full wiring into KeyManager, TokenManager, and RefreshStore — with an OpenTelemetry adapter — is planned for v0.4.0.
+- **OpenTelemetry / Distributed Tracing**: `pkg/tracing` interfaces (`Tracer`, `Span`) and `NoOpTracer` are scaffolded. Full wiring into KeyManager, TokenService, and RefreshStore — with an OpenTelemetry adapter — is planned for v0.4.0.
 
 ## Architecture Highlights
 
@@ -335,7 +335,7 @@ func main() {
 }
 ```
 
-### TokenManager Usage (Beta)
+### TokenService Usage (Beta)
 
 ```go
 package main
@@ -350,7 +350,7 @@ import (
 )
 
 func main() {
-    // Create TokenManager with storage
+    // Create TokenService with storage
     config := tokens.ManagerConfig{
         KeyManager:           keyManager,      // from KeyManager above
         RefreshStore:         refreshStore,    // RefreshStore implementation
@@ -468,11 +468,11 @@ config := keymanager.ManagerConfig{
 
 ## Error Reference
 
-All `TokenManager` errors are exported sentinels compatible with `errors.Is()`. Middleware and API handlers should switch on these to return specific responses.
+All `TokenService` errors are exported sentinels compatible with `errors.Is()`. Middleware and API handlers should switch on these to return specific responses.
 
 | Error | Trigger | Client-side action |
 |-------|---------|-------------------|
-| `tokens.ErrTokenExpired` | Token past `exp` (including `ClockSkew` window) | Prompt token refresh or re-authentication |
+| `tokens.ErrTokenExpired` | Token past `exp` (including `ClockSkew` window) | Prompt token refresh or re-authorization |
 | `tokens.ErrTokenNotYetValid` | Current time before `nbf` claim | Retry after a short delay |
 | `tokens.ErrInvalidIssuer` | `iss` claim does not match configured issuer | Do not retry — configuration mismatch |
 | `tokens.ErrInvalidAudience` | `aud` claim does not match configured audience | Do not retry — configuration mismatch |
@@ -533,7 +533,7 @@ func (m *MyZapAdapter) Info(msg string, args ...interface{}) {
 
 ### Correlation ID
 
-Correlation IDs let you filter all log lines from a single request across every internal component — KeyManager, RefreshStore, and TokenManager — with a single `jq` query.
+Correlation IDs let you filter all log lines from a single request across every internal component — KeyManager, RefreshStore, and TokenService — with a single `jq` query.
 
 **Quick start**:
 
@@ -674,7 +674,7 @@ jwtauth_key_active_versions_count
 **Alerting guidance**:
 - `jwtauth_key_active_versions_count == 0` → critical — no signing key available, all token issuance will fail
 - `rate(jwtauth_key_rotations_total{status!="success"}[1h]) > 0` → warning — key rotation is failing
-- `jwtauth_service_running == 0` → critical — TokenManager has stopped
+- `jwtauth_service_running == 0` → critical — TokenService has stopped
 
 For the full operator reference including Grafana dashboard guidance and label cardinality analysis, see [doc/METRICS.md](doc/METRICS.md).
 
@@ -710,7 +710,7 @@ github.com/aetomala/jwtauth/
 │   │   ├── disk_test.go          # 9-phase DiskKeyStore tests (38 specs)
 │   │   └── redis_test.go         # 9-phase RedisKeyStore tests (35 specs, miniredis)
 │   ├── tokens/                   # JWT operations (Beta) 🟡
-│   │   ├── manager.go            # TokenManager implementation
+│   │   ├── manager.go            # TokenService implementation
 │   │   ├── claims.go             # Claims management
 │   │   ├── manager_test.go       # Token operations tests
 │   │   ├── manager_lifecycle_test.go  # Lifecycle management tests
@@ -748,7 +748,7 @@ github.com/aetomala/jwtauth/
 
 ### Test Coverage
 
-**Current**: 605 comprehensive tests across KeyManager, TokenManager, RefreshStore, Metrics, Logging, and Tracing, all passing with race detection (KeyManager ~90%, TokenManager ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%)
+**Current**: 605 comprehensive tests across KeyManager, TokenService, RefreshStore, Metrics, Logging, and Tracing, all passing with race detection (KeyManager ~90%, TokenService ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%)
 
 **KeyManager** (3 test suites — 125 total specs):
 - **9-phase Manager tests** (52 specs, MockKeyStore — no I/O):
@@ -768,7 +768,7 @@ github.com/aetomala/jwtauth/
   - Error handling: corrupt metadata, missing metadata entry, Redis unavailability via SetError
   - Concurrency, metrics recording (storage_backend: "redis")
 
-**TokenManager** (7 test suites, 153 total tests):
+**TokenService** (7 test suites, 153 total tests):
 - **Lifecycle Management Tests** (20 tests):
   - Start: idempotency, logging, background cleanup, failure handling, context cancellation
   - Shutdown: logging, cleanup termination, goroutine coordination, timeout respect, idempotency
@@ -846,14 +846,14 @@ Tests follow **progressive phase-based development**:
 - ✅ Architecture documentation
 
 ### v0.2.0 ✅ Complete
-- ✅ TokenManager: JWT creation with RS256 signing
-- ✅ TokenManager: Lifecycle management (Start/Shutdown/IsRunning)
-- ✅ TokenManager: Claims management with custom claims support and reserved claim protection
-- ✅ TokenManager: Access token validation with issuer/audience enforcement (ValidateAccessToken)
-- ✅ TokenManager: Refresh token rotation with expiration and revocation checks (RefreshAccessToken)
-- ✅ TokenManager: Token revocation — single and bulk (RevokeRefreshToken, RevokeAllUserTokens)
-- ✅ TokenManager: Token introspection per RFC 7662 (IntrospectToken)
-- ✅ TokenManager: Manual cleanup sweep (CleanupExpiredTokens)
+- ✅ TokenService: JWT creation with RS256 signing
+- ✅ TokenService: Lifecycle management (Start/Shutdown/IsRunning)
+- ✅ TokenService: Claims management with custom claims support and reserved claim protection
+- ✅ TokenService: Access token validation with issuer/audience enforcement (ValidateAccessToken)
+- ✅ TokenService: Refresh token rotation with expiration and revocation checks (RefreshAccessToken)
+- ✅ TokenService: Token revocation — single and bulk (RevokeRefreshToken, RevokeAllUserTokens)
+- ✅ TokenService: Token introspection per RFC 7662 (IntrospectToken)
+- ✅ TokenService: Manual cleanup sweep (CleanupExpiredTokens)
 - ✅ RefreshStore: Shared test suite pattern (eliminates duplication, runs against all implementations)
 - ✅ RefreshStore: MemoryRefreshStore with defensive copying and concurrent safety
 - ✅ RefreshStore: RedisRefreshStore for distributed deployments with go-redis/v9
@@ -861,9 +861,9 @@ Tests follow **progressive phase-based development**:
 - ✅ KeyStore interface extracted from KeyManager — `DiskKeyStore` for single-instance, `RedisKeyStore` for distributed deployments
 
 ### v0.3.0 (Current — Beta)
-- ✅ TokenManager: Clock skew tolerance (`ClockSkew` field, `jwt.WithLeeway()` integration)
-- ✅ TokenManager: `ValidateAccessTokenWithClaims` — registered and custom claims returned after validation
-- ✅ Wire metrics into all components — KeyStore, Manager, TokenManager, RefreshStore with `error_type` label and context propagation
+- ✅ TokenService: Clock skew tolerance (`ClockSkew` field, `jwt.WithLeeway()` integration)
+- ✅ TokenService: `ValidateAccessTokenWithClaims` — registered and custom claims returned after validation
+- ✅ Wire metrics into all components — KeyStore, Manager, TokenService, RefreshStore with `error_type` label and context propagation
 - ✅ Example middleware returns specific JSON error codes (`token_expired`, `token_revoked`, etc.) via sentinel error mapping
 - ✅ `KeyManager` interface extended with context on all read methods (`GetCurrentSigningKey`, `GetPublicKey`, `GetJWKS`)
 - ✅ Correlation ID logging — `CorrelationIDHandler`, `WithCorrelationID`/`GetCorrelationID` helpers, `NewCorrelationJSONLogger`/`NewCorrelationTextLogger`, context-aware `SlogAdapter`
@@ -875,7 +875,7 @@ Tests follow **progressive phase-based development**:
 - ✅ `pkg/tracing` interfaces scaffolded — `Tracer`, `Span`, `SpanOption`, `StatusCode`, `SpanKind`
 - ✅ `NoOpTracer` / `NoOpSpan` implementations (36 tests, race-detection clean)
 - ✅ `MockTracer` / `MockSpan` generated for dependency injection in component tests
-- 🚧 Wire tracing into KeyManager, TokenManager, and RefreshStore
+- 🚧 Wire tracing into KeyManager, TokenService, and RefreshStore
 - 🚧 OpenTelemetry adapter (`pkg/tracing/otel`) bridging `pkg/tracing.Tracer` to `go.opentelemetry.io/otel`
 
 ### v1.0.0 (Stable)
@@ -974,6 +974,6 @@ Built by a Senior Platform Engineer with 28 years of experience in distributed s
 
 **Status**: Beta (Active Development)
 **Version**: 0.3.0-beta
-**Components**: KeyManager ✅ | TokenManager (Beta) 🟡 | RefreshStore (Memory + Redis) ✅ | Metrics (Prometheus) ✅ | Logging (Correlation ID) ✅ | Tracing (scaffold) 🚧
-**Test Coverage**: 605 tests (KeyManager ~90%, TokenManager ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%), all passing, race-detection enabled
+**Components**: KeyManager ✅ | TokenService (Beta) 🟡 | RefreshStore (Memory + Redis) ✅ | Metrics (Prometheus) ✅ | Logging (Correlation ID) ✅ | Tracing (scaffold) 🚧
+**Test Coverage**: 605 tests (KeyManager ~90%, TokenService ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%), all passing, race-detection enabled
 **Last Updated**: April 14, 2026

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# jwtauth — JWT Authorization Token Engine
+# jwtauth — Stateful JWT Authorization Token Engine
 
 This document explains the design decisions, patterns, and principles used in the JWT authorization token engine.
 
@@ -17,7 +17,7 @@ This document explains the design decisions, patterns, and principles used in th
 
 ## Overview
 
-jwtauth is designed as a **production-ready, highly observable, and testable** JWT authorization token engine for Go applications. It manages the stateful machinery that production token systems require — cryptographic key generation and zero-downtime rotation, access token issuance and validation, and refresh token lifecycle with revocation support. Identity verification is intentionally out of scope.
+jwtauth is designed as a production-ready, highly observable, and testable **stateful** JWT authorization token engine for Go applications. It manages the stateful machinery that production token systems require — cryptographic key generation and zero-downtime rotation, access token issuance and validation, and refresh token lifecycle with revocation support. Identity verification is intentionally out of scope.
 
 ### Key Features
 
@@ -112,7 +112,7 @@ github.com/aetomala/jwtauth/
 │   │   ├── disk_test.go           # 9-phase DiskKeyStore tests (38 specs)
 │   │   └── redis_test.go          # 9-phase RedisKeyStore tests (35 specs, miniredis)
 │   ├── tokens/                    # JWT token operations (Beta)
-│   │   ├── manager.go             # TokenManager implementation
+│   │   ├── manager.go             # TokenService implementation
 │   │   ├── claims.go              # Claims management
 │   │   ├── manager_test.go        # Token operations tests
 │   │   ├── manager_lifecycle_test.go  # Lifecycle management tests
@@ -541,7 +541,7 @@ Keys carry no TTL — Manager owns the lifecycle and calls `Delete` explicitly v
 
 `SetGauge(jwtauth_keystore_keys_count)` is recorded only by `LoadAll` — set to the count of valid non-expired keys returned. This is sufficient because `GetCurrentSigningKey` never calls the store after startup and `GetPublicKey` only calls `LoadKey` on rare cache misses, so KeyStore operations are not on the hot path.
 
-### TokenManager (Beta)
+### TokenService (Beta)
 
 **Responsibilities**:
 - Issue access tokens (short-lived, e.g., 15 minutes) with optional custom claims
@@ -566,7 +566,7 @@ Created → Start() → Running → Shutdown() → Stopped
 - **Synchronization**: `atomic.Bool` for running state; cleanup uses channel signaling and `sync.WaitGroup` for graceful shutdown
 
 **Key Design Decisions**:
-- Rate limiting is intentionally **not** in TokenManager — it belongs at the infrastructure layer (API Gateway, Ingress, Load Balancer) where per-route and per-IP policies apply globally
+- Rate limiting is intentionally **not** in TokenService — it belongs at the infrastructure layer (API Gateway, Ingress, Load Balancer) where per-route and per-IP policies apply globally
 - All storage operations accept `context.Context` for cancellation propagation
 - Reserved JWT claims (`sub`, `iss`, `aud`, `exp`, `iat`, `jti`) cannot be overridden by custom claims
 
@@ -910,9 +910,9 @@ Catches:
 - ✅ Prometheus implementation (`PrometheusMetrics`) with 22 pre-registered metrics, 100% test coverage
 - ✅ NoOp implementation
 - ✅ gomock `MockMetrics` for dependency injection in tests
-- ✅ Wired into KeyManager, TokenManager, and RefreshStore — all components fully instrumented
+- ✅ Wired into KeyManager, TokenService, and RefreshStore — all components fully instrumented
 
-### Phase 3: TokenManager ✅ (Beta)
+### Phase 3: TokenService ✅ (Beta)
 - ✅ JWT creation with RS256 signing and custom claims
 - ✅ Access token validation (signature, expiration, issuer, audience)
 - ✅ Refresh token rotation with revocation checks
@@ -953,10 +953,10 @@ Catches:
   - `Manager` unit tests are now filesystem-free (use `MockKeyStore`)
   - 44 Manager specs + 38 DiskKeyStore specs (9 phases), all race-clean
   - `MockKeyStore` generated via gomock
-- ✅ Wire `PrometheusMetrics` into TokenManager — deferred closure pattern with `error_type` label, context propagation
+- ✅ Wire `PrometheusMetrics` into TokenService — deferred closure pattern with `error_type` label, context propagation
 - ✅ `RedisKeyStore` implementation — `ks:pem:<id>` / `ks:meta:<id>` Redis layout, atomic Pipeline writes, SCAN-based `LoadAll`, full metrics with `storage_backend: "redis"`
 - ✅ Correlation ID logging — `CorrelationIDHandler` wraps any `slog.Handler`; `WithCorrelationID`/`GetCorrelationID` context helpers; `SlogAdapter` context-aware routing; `NewCorrelationJSONLogger`/`NewCorrelationTextLogger` convenience constructors
-- ✅ All component logging call sites forward `ctx` — correlation ID propagates through KeyManager, TokenManager, and RefreshStore without Logger interface changes
+- ✅ All component logging call sites forward `ctx` — correlation ID propagates through KeyManager, TokenService, and RefreshStore without Logger interface changes
 - ✅ `KeyManager` interface extended with context on all read methods (`GetCurrentSigningKey`, `GetPublicKey`, `GetJWKS`)
 - ✅ Context cancellation guards in `GetJWKS` and `cleanupExpiredKeys` with warning log on early return
 - ✅ Redis integration tests via miniredis (`pkg/tokens/integration`) covering distributed token operations end-to-end
@@ -965,7 +965,7 @@ Catches:
 - ✅ `pkg/tracing` — `Tracer` and `Span` interfaces defined; `SpanOption` functional options; `StatusCode` and `SpanKind` enumerations
 - ✅ `NoOpTracer` / `NoOpSpan` — zero-allocation implementations; 36 tests, race-detection clean
 - ✅ `MockTracer` / `MockSpan` generated via gomock for dependency injection in component tests
-- ⏳ Wire tracing into KeyManager, TokenManager, and RefreshStore
+- ⏳ Wire tracing into KeyManager, TokenService, and RefreshStore
 - ⏳ OpenTelemetry adapter (`pkg/tracing/otel`) bridging `pkg/tracing.Tracer` to `go.opentelemetry.io/otel`
 
 ---

--- a/doc/MIGRATION.md
+++ b/doc/MIGRATION.md
@@ -1,0 +1,350 @@
+# Migration Guide
+
+This guide helps you migrate from other JWT libraries to jwtauth.
+
+---
+
+## Migrating from golang-jwt/jwt
+
+### What You're Currently Doing
+
+```go
+import "github.com/golang-jwt/jwt/v5"
+
+// You manage keys manually
+privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+publicKey := &privateKey.PublicKey
+
+// You sign tokens yourself
+claims := jwt.MapClaims{
+    "sub": userID,
+    "exp": time.Now().Add(15 * time.Minute).Unix(),
+}
+token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+tokenString, _ := token.SignedString(privateKey)
+
+// You validate tokens yourself
+parsed, _ := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+    return publicKey, nil
+})
+```
+
+**What you handle manually:**
+- Key generation and storage
+- Key rotation (if you do it at all)
+- Refresh token storage
+- Revocation logic
+
+### Migrating to jwtauth
+
+```go
+import (
+    "github.com/aetomala/jwtauth/pkg/keymanager"
+    "github.com/aetomala/jwtauth/pkg/storage"
+    "github.com/aetomala/jwtauth/pkg/tokens"
+)
+
+// Step 1: Create KeyManager (handles keys + rotation)
+ks, _ := keymanager.NewDiskKeyStore("./keys", 2048, nil, nil)
+km, _ := keymanager.NewManager(keymanager.ManagerConfig{
+    KeyStore:            ks,
+    KeyRotationInterval: 30 * 24 * time.Hour,
+    KeyOverlapDuration:  1 * time.Hour,
+})
+
+// Step 2: Create RefreshStore (handles refresh tokens)
+refreshStore := storage.NewMemoryRefreshStore(nil, nil)
+
+// Step 3: Create TokenManager (coordinates everything)
+mgr, _ := tokens.NewManager(tokens.ManagerConfig{
+    KeyManager:           km,
+    RefreshStore:         refreshStore,
+    AccessTokenDuration:  15 * time.Minute,
+    RefreshTokenDuration: 30 * 24 * time.Hour,
+    Issuer:               "my-app",
+    Audience:             []string{"my-app-api"},
+})
+
+// Step 4: Start lifecycle
+ctx := context.Background()
+km.Start(ctx)
+mgr.Start(ctx)
+defer km.Shutdown(ctx)
+defer mgr.Shutdown(ctx)
+
+// Now: Issue tokens (access + refresh in one call)
+accessToken, refreshToken, _ := mgr.IssueTokenPair(ctx, userID)
+
+// Later: Validate tokens
+claims, _ := mgr.ValidateAccessToken(ctx, accessToken)
+
+// Later: Refresh access token
+newAccessToken, _ := mgr.RefreshAccessToken(ctx, refreshToken)
+
+// On logout: Revoke all sessions
+mgr.RevokeAllUserTokens(ctx, userID)
+```
+
+**What jwtauth handles for you:**
+- ✅ Key rotation (automatic, zero-downtime)
+- ✅ Refresh token storage (memory or Redis)
+- ✅ Revocation (instant, not expiry-based)
+- ✅ Background cleanup
+- ✅ Observability (optional logging/metrics)
+
+---
+
+## Migrating from gin-jwt
+
+### What You're Currently Doing
+
+```go
+import "github.com/appleboy/gin-jwt/v2"
+
+// Gin-specific middleware configuration
+authMiddleware, _ := jwt.New(&jwt.GinJWTMiddleware{
+    Realm:       "test zone",
+    Key:         []byte("secret key"),
+    Timeout:     time.Hour,
+    MaxRefresh:  time.Hour,
+    IdentityKey: "userID",
+    PayloadFunc: func(data interface{}) jwt.MapClaims {
+        return jwt.MapClaims{"userID": data}
+    },
+    Authenticator: func(c *gin.Context) (interface{}, error) {
+        // Your login logic
+    },
+})
+
+// Routes are tied to Gin
+router.POST("/login", authMiddleware.LoginHandler)
+router.Use(authMiddleware.MiddlewareFunc())
+```
+
+**Limitations:**
+- ❌ Framework lock-in (Gin only)
+- ❌ No key rotation
+- ❌ No revocation
+- ❌ Single-instance only (state in memory)
+
+### Migrating to jwtauth
+
+jwtauth is framework-agnostic. You write the middleware yourself (20 lines):
+
+```go
+import (
+    "github.com/gin-gonic/gin"
+    "github.com/aetomala/jwtauth/pkg/tokens"
+)
+
+// Create TokenManager once at startup (see golang-jwt migration above)
+var mgr *tokens.Manager
+
+// Your middleware (framework-agnostic logic)
+func AuthMiddleware() gin.HandlerFunc {
+    return func(c *gin.Context) {
+        authHeader := c.GetHeader("Authorization")
+        if authHeader == "" {
+            c.JSON(401, gin.H{"error": "missing_token"})
+            c.Abort()
+            return
+        }
+
+        token := strings.TrimPrefix(authHeader, "Bearer ")
+        claims, err := mgr.ValidateAccessToken(c.Request.Context(), token)
+        if err != nil {
+            c.JSON(401, gin.H{"error": "invalid_token"})
+            c.Abort()
+            return
+        }
+
+        c.Set("userID", claims.Subject)
+        c.Next()
+    }
+}
+
+// Routes
+router.POST("/login", LoginHandler)  // You implement login
+router.Use(AuthMiddleware())         // Your middleware
+```
+
+**Benefits:**
+- ✅ Works with any framework (Gin, Echo, Chi, stdlib)
+- ✅ Key rotation built in
+- ✅ Refresh tokens with revocation
+- ✅ Distributed-ready (Redis backend)
+- ✅ 20 lines you own and control
+
+**See also:** `examples/gin-example/` for complete working example
+
+---
+
+## Migrating from jwx
+
+### What You're Currently Doing
+
+```go
+import "github.com/lestrrat-go/jwx/v2/jwt"
+
+// You use jwx for its comprehensive JOSE support
+token, _ := jwt.NewBuilder().
+    Subject(userID).
+    Issuer("my-app").
+    Expiration(time.Now().Add(15 * time.Minute)).
+    Build()
+
+signed, _ := jwt.Sign(token, jwt.WithKey(jwa.RS256, privateKey))
+```
+
+**jwx strengths:**
+- Full JOSE suite (JWS, JWE, JWK, JWA)
+- Multiple algorithms
+- Encrypted tokens (JWE)
+
+### When to Use jwtauth vs. jwx
+
+**Use jwtauth if:**
+- You only need RS256 JWT tokens (not JWE)
+- You want stateful refresh tokens + revocation
+- You want automatic key rotation
+- You want production observability (metrics, logging)
+
+**Stay with jwx if:**
+- You need JWE (encrypted tokens)
+- You need multiple signing algorithms (ES256, EdDSA, etc.)
+- You need detached payloads or nested tokens
+
+**Migration approach:**
+
+jwtauth uses RS256 only. If that's sufficient:
+
+```go
+// Replace jwx token builder with jwtauth
+mgr, _ := tokens.NewManager(config)  // See golang-jwt migration
+
+// Issue tokens
+accessToken, refreshToken, _ := mgr.IssueTokenPair(ctx, userID)
+
+// Validate tokens
+claims, _ := mgr.ValidateAccessToken(ctx, accessToken)
+```
+
+If you need JWE or multiple algorithms, **don't migrate** — jwx is the right tool.
+
+---
+
+## Common Migration Patterns
+
+### Pattern 1: Adding Refresh Tokens
+
+**Before (stateless):**
+```go
+// Issue 15-minute access token
+// User must re-authenticate when it expires
+```
+
+**After (stateful):**
+```go
+// Issue both tokens
+accessToken, refreshToken, _ := mgr.IssueTokenPair(ctx, userID)
+
+// Client stores refreshToken securely
+// When accessToken expires, client calls:
+newAccessToken, _ := mgr.RefreshAccessToken(ctx, refreshToken)
+```
+
+### Pattern 2: Adding Revocation
+
+**Before (expiry-based):**
+```go
+// Issue token with 15-minute expiry
+// No way to revoke early — must wait 15 minutes
+```
+
+**After (instant revocation):**
+```go
+// On logout or password change:
+mgr.RevokeAllUserTokens(ctx, userID)
+
+// All refresh tokens invalidated immediately
+// Access tokens expire in 15 minutes (or shorter if you reduce duration)
+```
+
+### Pattern 3: Key Rotation
+
+**Before (manual):**
+```go
+// Generate new key manually
+// Deploy new key
+// Hope old tokens still validate (they won't)
+```
+
+**After (zero-downtime):**
+```go
+km, _ := keymanager.NewManager(keymanager.ManagerConfig{
+    KeyStore:            ks,
+    KeyRotationInterval: 30 * 24 * time.Hour, // Auto-rotate every 30 days
+    KeyOverlapDuration:  1 * time.Hour,        // Old key valid for 1 hour
+})
+
+// Automatic rotation:
+// Day 0:     Key A signs, Key A validates
+// Day 30:    Rotate → Key B signs, Key A+B validate (overlap)
+// Day 30+1h: Key B signs, Key B validates
+```
+
+---
+
+## Deployment Considerations
+
+### Single-Instance → Distributed
+
+**Development/Single-Instance:**
+```go
+// Use in-memory storage
+ks, _ := keymanager.NewDiskKeyStore("./keys", 2048, nil, nil)
+refreshStore := storage.NewMemoryRefreshStore(nil, nil)
+```
+
+**Production/Multi-Instance:**
+```go
+// Use Redis for shared state
+import "github.com/redis/go-redis/v9"
+
+client := redis.NewClient(&redis.Options{Addr: "redis:6379"})
+
+// Shared key storage
+ks, _ := keymanager.NewRedisKeyStore(client, logger, metrics)
+
+// Shared refresh token storage
+refreshStore := storage.NewRedisRefreshStore(client, logger, metrics)
+```
+
+**No code changes** — just swap the storage backend.
+
+---
+
+## Migration Checklist
+
+- [ ] Create KeyManager with appropriate KeyStore (Disk or Redis)
+- [ ] Create RefreshStore (Memory or Redis)
+- [ ] Create TokenManager with config
+- [ ] Update login endpoint to issue token pairs (IssueTokenPair)
+- [ ] Add refresh endpoint (RefreshAccessToken)
+- [ ] Add logout endpoint (RevokeRefreshToken or RevokeAllUserTokens)
+- [ ] Update auth middleware to validate tokens (ValidateAccessToken)
+- [ ] Start lifecycle in main() (Start) and defer shutdown (Shutdown)
+- [ ] Test token issuance, validation, refresh, revocation
+- [ ] Add observability (optional Logger, Metrics)
+
+---
+
+## Need Help?
+
+- See `examples/` directory for complete working examples (Chi, Gin, Echo)
+- Read `doc/ARCHITECTURE.md` for design rationale
+- Check `doc/DEPLOYMENT.md` for production deployment patterns
+
+---
+
+**Migration support:** If you're stuck, open an issue at https://github.com/aetomala/jwtauth/issues

--- a/doc/adr/001-no-rate-limiting.md
+++ b/doc/adr/001-no-rate-limiting.md
@@ -1,0 +1,61 @@
+# ADR-001: No Rate Limiting in Library
+
+**Status**: Accepted  
+**Date**: 2024-04-01  
+**Deciders**: Architecture Team
+
+## Context
+
+Rate limiting is a common requirement for authentication systems. Should jwtauth include rate limiting?
+
+Several factors influenced this decision:
+
+1. **Layer Mismatch**: Rate limiting is most effective at the infrastructure layer (API Gateway, Load Balancer, Ingress) where per-IP, per-route, and per-user limits can be enforced globally.
+
+2. **Deployment Variance**: Rate limiting strategies vary widely:
+   - Per-IP limits (stop brute force)
+   - Per-user limits (prevent abuse)
+   - Per-route limits (protect expensive endpoints)
+   - Geographic limits (compliance requirements)
+
+3. **Distributed Challenge**: Application-level rate limiting requires shared state (Redis, distributed counters). This duplicates what API Gateways already provide.
+
+4. **Scope Creep**: jwtauth focuses on token lifecycle management. Rate limiting is a separate concern.
+
+## Decision
+
+**We will NOT include rate limiting in the jwtauth library.**
+
+Users should implement rate limiting at the infrastructure layer:
+- API Gateway (Kong, AWS API Gateway, Azure APIM)
+- Kubernetes Ingress (nginx.ingress.kubernetes.io/limit-rps)
+- Load Balancer
+- Cloudflare / CDN
+
+For application-level rate limiting, users can choose from existing Go libraries:
+- `golang.org/x/time/rate` (standard library)
+- `github.com/ulule/limiter` (Redis-backed)
+- `github.com/throttled/throttled` (flexible)
+
+## Consequences
+
+**Positive:**
+- Library stays focused on token management
+- No forced dependency on Redis or distributed counters
+- Users deploy rate limiting where it's most effective (per-route, per-IP)
+- Cleaner separation of concerns
+
+**Negative:**
+- Users must implement rate limiting separately
+- Documentation must guide users toward best practices
+- May surprise users who expect "batteries-included" auth library
+
+**Mitigation:**
+- Provide clear documentation in doc/DEPLOYMENT.md
+- Include examples of API Gateway configuration
+- State this boundary clearly in README ("What jwtauth is not")
+
+## References
+
+- Related: ADR-002 (focuses on token lifecycle, not request control)
+- See: doc/DEPLOYMENT.md for rate limiting configuration examples

--- a/doc/adr/002-stateful-refresh-tokens.md
+++ b/doc/adr/002-stateful-refresh-tokens.md
@@ -1,0 +1,73 @@
+# ADR-002: Stateful Refresh Tokens
+
+**Status**: Accepted  
+**Date**: 2024-04-01  
+**Deciders**: Architecture Team
+
+## Context
+
+JWT tokens can be stateless (no server-side storage) or stateful (server tracks issued tokens). Should jwtauth use stateful refresh tokens?
+
+**Stateless approach:**
+- Refresh tokens are self-contained JWTs
+- No server-side storage required
+- Cannot revoke before expiry
+
+**Stateful approach:**
+- Refresh tokens are opaque IDs stored server-side
+- Requires storage backend (Memory, Redis, Postgres)
+- Can revoke instantly
+
+**Use cases requiring revocation:**
+- User logout (invalidate all sessions)
+- Password change (force re-authentication)
+- Account compromise (emergency revocation)
+- Device management (revoke specific device)
+
+## Decision
+
+**We will use stateful refresh tokens with server-side storage.**
+
+Refresh tokens are opaque identifiers (UUIDs) stored in a RefreshStore backend. Access tokens remain stateless JWTs (no storage required for validation).
+
+**Storage backends:**
+- `MemoryRefreshStore`: In-memory (single-instance, testing)
+- `RedisRefreshStore`: Redis (distributed, production)
+- Extensible via RefreshStore interface
+
+## Consequences
+
+**Positive:**
+- Instant revocation (RevokeRefreshToken, RevokeAllUserTokens)
+- Session management (know which devices are logged in)
+- Security event response (compromise → revoke immediately)
+- Compliance (GDPR "right to be forgotten" — revoke all tokens)
+
+**Negative:**
+- Storage dependency (Redis for distributed deployments)
+- Slightly slower refresh operations (storage lookup required)
+- Cleanup required (expired tokens must be purged)
+
+**Mitigations:**
+- Background cleanup goroutine (automatic)
+- RefreshStore interface (swap storage backends)
+- MemoryRefreshStore for single-instance deployments
+- Document horizontal scale path (Memory → Redis)
+
+## Alternatives Considered
+
+**Alternative 1: Stateless refresh tokens**
+- Rejected: Cannot revoke before expiry
+- Security issue for compromised accounts
+
+**Alternative 2: Blocklist**
+- Store revoked token IDs instead of issued tokens
+- Rejected: Blocklist grows indefinitely, cleanup complex
+
+**Alternative 3: Hybrid (stateless with optional revocation)**
+- Rejected: Adds complexity, most users need revocation
+
+## References
+
+- Related: Storage interface design (pkg/storage/interface.go)
+- See: Horizontal scale path in README.md

--- a/doc/adr/003-rs256-only.md
+++ b/doc/adr/003-rs256-only.md
@@ -1,0 +1,76 @@
+# ADR-003: RS256 Only (No Algorithm Flexibility)
+
+**Status**: Accepted  
+**Date**: 2024-04-01  
+**Deciders**: Architecture Team
+
+## Context
+
+JWT supports multiple signing algorithms: HS256 (HMAC), RS256 (RSA), ES256 (ECDSA), EdDSA, and more.
+
+**Should jwtauth support multiple algorithms or standardize on one?**
+
+Considerations:
+1. **Security**: Algorithm confusion attacks (force HS256 on RS256 key)
+2. **Simplicity**: Fewer algorithms = clearer security model
+3. **Flexibility**: Users may want ES256 or EdDSA
+4. **Key Rotation**: Asymmetric keys (RS256) enable public key distribution
+
+## Decision
+
+**We will support RS256 (RSA-SHA256) only.**
+
+- Access tokens signed with RS256
+- Validation rejects HS256, ES256, EdDSA, none
+- Key Manager generates RSA key pairs (2048-bit minimum)
+
+## Consequences
+
+**Positive:**
+- No algorithm confusion attacks (RS256 asserted unconditionally)
+- Clear security model (asymmetric crypto only)
+- Simpler key management (one algorithm, one key type)
+- Public key distribution works (JWKS endpoint)
+- Zero-downtime key rotation feasible (asymmetric keys required)
+
+**Negative:**
+- No support for HS256 (symmetric keys)
+- No support for ES256, EdDSA (different crypto)
+- Users wanting other algorithms must use different library
+
+**Mitigation:**
+- Document this boundary clearly ("When NOT to Use This")
+- Recommend `lestrrat-go/jwx` for multi-algorithm JOSE operations
+- Focus on doing RS256 exceptionally well
+
+## Alternatives Considered
+
+**Alternative 1: Support multiple algorithms**
+- Rejected: Algorithm confusion risk, complexity
+- Would require algorithm negotiation, key type abstraction
+
+**Alternative 2: Support ES256 (ECDSA)**
+- Considered: ES256 is modern, smaller keys
+- Rejected: RS256 is more widely supported, proven at scale
+
+**Alternative 3: Configurable algorithm**
+- Rejected: Adds configuration surface, algorithm confusion risk
+- Better to be opinionated and secure by default
+
+## Security Considerations
+
+Algorithm confusion attacks historically exploited libraries that:
+1. Accept algorithm from token header
+2. Use same key for multiple algorithms
+3. Don't validate algorithm matches expectation
+
+**jwtauth prevents this by:**
+- Asserting RS256 unconditionally in ValidateAccessToken
+- Rejecting any other algorithm (HS256, none, etc.)
+- No algorithm configuration (cannot be misconfigured)
+
+## References
+
+- Related: CVE-2015-9235 (algorithm confusion)
+- Related: Key Manager design (asymmetric only)
+- See: "When NOT to Use This" in README.md

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -1,0 +1,21 @@
+# Architecture Decision Records (ADRs)
+
+This directory contains records of major architectural decisions made for jwtauth.
+
+## What is an ADR?
+
+An Architecture Decision Record (ADR) captures an important architectural decision along with its context and consequences.
+
+## Format
+
+Each ADR includes:
+- **Status**: Proposed, Accepted, Deprecated, Superseded
+- **Context**: The issue motivating this decision
+- **Decision**: The change we're proposing or have agreed to
+- **Consequences**: The resulting context, positive and negative
+
+## Index
+
+- [ADR-001: No Rate Limiting in Library](001-no-rate-limiting.md)
+- [ADR-002: Stateful Refresh Tokens](002-stateful-refresh-tokens.md)
+- [ADR-003: RS256 Only](003-rs256-only.md)

--- a/pkg/keymanager/keymanager.go
+++ b/pkg/keymanager/keymanager.go
@@ -1,3 +1,69 @@
+// Package keymanager provides zero-downtime RSA key rotation for JWT signing.
+//
+// KeyManager generates RSA key pairs, rotates them on a configurable schedule, and
+// maintains an overlap period where both old and new keys remain valid. This enables
+// key rotation without service restarts or forced re-authentication — tokens signed
+// with the old key continue to validate during the overlap window.
+//
+// Key rotation timeline example:
+//
+//	Day 0:      Key A (current, signs new tokens)
+//	Day 30:     Rotate → Key A (validates old tokens), Key B (current, signs new tokens)
+//	Day 30+1h:  Overlap ends → Key B (current, only valid key)
+//
+// Manager delegates all key persistence to an injected KeyStore implementation:
+//   - DiskKeyStore:  Single-instance deployments (PEM + JSON files on local filesystem)
+//   - RedisKeyStore: Distributed/multi-instance deployments (shared Redis backend)
+//
+// The Manager handles lifecycle (Start/Shutdown), automatic rotation scheduling, and
+// cleanup of expired keys. It never performs I/O directly — all storage operations
+// go through the KeyStore interface.
+//
+// Example usage:
+//
+//	// Create a KeyStore (choose based on deployment)
+//	ks, err := keymanager.NewDiskKeyStore("./keys", 2048, logger, metrics)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	// Create KeyManager
+//	config := keymanager.ManagerConfig{
+//	    KeyStore:            ks,
+//	    KeyRotationInterval: 30 * 24 * time.Hour, // 30 days
+//	    KeyOverlapDuration:  1 * time.Hour,        // 1 hour overlap
+//	    Logger:              logger,               // Optional
+//	    Metrics:             metrics,              // Optional
+//	}
+//
+//	mgr, err := keymanager.NewManager(config)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	// Start background rotation
+//	ctx := context.Background()
+//	if err := mgr.Start(ctx); err != nil {
+//	    log.Fatal(err)
+//	}
+//	defer mgr.Shutdown(ctx)
+//
+//	// Get current signing key (for TokenService to use)
+//	privateKey, keyID, err := mgr.GetCurrentSigningKey(ctx)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	// Get JWKS for token validation endpoints
+//	jwks, err := mgr.GetJWKS(ctx)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	// Manual rotation (optional, for testing or emergency rotation)
+//	if err := mgr.RotateKeys(ctx); err != nil {
+//	    log.Fatal(err)
+//	}
 package keymanager
 
 import (

--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -1,3 +1,71 @@
+// Package tokens provides stateful JWT authorization token management.
+//
+// Manager handles the complete token lifecycle: access token issuance with
+// RS256 signing, refresh token rotation with expiration checks, instant revocation
+// (single token and bulk operations), and coordinated cleanup across distributed
+// deployments.
+//
+// Identity verification is out of scope. Pass a verified subject ID (user ID) to
+// IssueTokenPair or IssueAccessToken after you've authenticated the user.
+//
+// Key capabilities:
+//   - Access token issuance (short-lived, typically 15 minutes)
+//   - Refresh token issuance and rotation (long-lived, typically 30 days)
+//   - Token validation with signature verification and claims enforcement
+//   - Instant revocation (RevokeRefreshToken, RevokeAllUserTokens)
+//   - Token introspection per RFC 7662 (IntrospectToken)
+//   - Background cleanup of expired refresh tokens
+//   - Clock skew tolerance for distributed deployments (ClockSkew field)
+//   - Custom claims support with reserved claim protection
+//
+// Example usage:
+//
+//	config := tokens.ManagerConfig{
+//	    KeyManager:   keyManager,        // Handles RSA keys and rotation
+//	    RefreshStore: refreshStore,      // Persists refresh tokens (Redis, Memory, etc.)
+//	    Logger:       logger,            // Optional structured logging
+//	    Metrics:      metrics,           // Optional Prometheus metrics
+//	    AccessTokenDuration:  15 * time.Minute,
+//	    RefreshTokenDuration: 30 * 24 * time.Hour,
+//	    ClockSkew:    30 * time.Second,  // Optional leeway for NTP drift
+//	    Issuer:       "my-app",
+//	    Audience:     []string{"my-app-api"},
+//	}
+//
+//	mgr, err := tokens.NewManager(config)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	// Start lifecycle (background cleanup, etc.)
+//	ctx := context.Background()
+//	if err := mgr.Start(ctx); err != nil {
+//	    log.Fatal(err)
+//	}
+//	defer mgr.Shutdown(ctx)
+//
+//	// Issue token pair (access + refresh)
+//	accessToken, refreshToken, err := mgr.IssueTokenPair(ctx, userID)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	// Later: validate access token
+//	claims, err := mgr.ValidateAccessToken(ctx, accessToken)
+//	if err != nil {
+//	    // Handle error (expired, revoked, invalid, etc.)
+//	}
+//
+//	// Later: refresh access token
+//	newAccessToken, err := mgr.RefreshAccessToken(ctx, refreshToken)
+//	if err != nil {
+//	    // Handle error (refresh token expired, revoked, etc.)
+//	}
+//
+//	// On logout: revoke all user sessions
+//	if err := mgr.RevokeAllUserTokens(ctx, userID); err != nil {
+//	    log.Fatal(err)
+//	}
 package tokens
 
 import (


### PR DESCRIPTION
Merging dev into main. See aetomala/jwtauth#68 for full details.

Includes 6-phase documentation audit:
- README: elevator pitch, problem statement, comparison matrix, anti-use-cases, terminology fixes
- ARCHITECTURE.md: terminology alignment, stateful positioning
- doc/MIGRATION.md: new migration guide (golang-jwt, gin-jwt, jwx)
- doc/adr/: three ADRs (no rate limiting, stateful refresh tokens, RS256 only)
- pkg/tokens, pkg/keymanager: package-level Go doc comments