### PR TITLE
docs: standardize TokenService → TokenManager across all documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **You verify identity. jwtauth manages everything after:** zero-downtime key rotation, access token issuance, refresh token lifecycle, and instant revocation across horizontal scale.
 
-> ⚠️ **Beta Status**: KeyManager and RefreshStore are production-ready and fully tested. TokenService is in beta — core operations are complete with comprehensive test coverage. API may change before v1.0.0.
+> ⚠️ **Beta Status**: KeyManager and RefreshStore are production-ready and fully tested. TokenManager is in beta — core operations are complete with comprehensive test coverage. API may change before v1.0.0.
 
 ## Overview
 
@@ -128,7 +128,7 @@ The storage backends are designed to move from single-instance to distributed wi
 | Single instance (dev, small prod) | `DiskKeyStore` | `MemoryRefreshStore` |
 | Multi-instance (Kubernetes, load-balanced) | `RedisKeyStore` | `RedisRefreshStore` |
 
-Swap the constructor arguments. The `KeyManager` and `TokenService` interfaces are unchanged.
+Swap the constructor arguments. The `KeyManager` and `TokenManager` interfaces are unchanged.
 
 ---
 
@@ -227,7 +227,7 @@ You've already verified identity and need **production-grade token machinery** f
 - **Full metrics instrumentation** — KeyStore and Manager operations via `jwtauth_keystore_*` and `jwtauth_key_*` metrics
 - **Comprehensive test coverage** with race detection
 
-**TokenService** (Beta)
+**TokenManager** (Beta)
 - **Access token issuance** (IssueAccessToken, IssueAccessTokenWithClaims, IssueTokenPair)
 - **Refresh token issuance** (IssueRefreshToken, IssueRefreshTokenWithMetadata)
 - **Access token validation** with registered and custom claims extraction (ValidateAccessToken, ValidateAccessTokenWithClaims)
@@ -266,7 +266,7 @@ You've already verified identity and need **production-grade token machinery** f
 
 ### 🚧 In Development (v0.4.0)
 
-- **OpenTelemetry / Distributed Tracing**: `pkg/tracing` interfaces (`Tracer`, `Span`) and `NoOpTracer` are scaffolded. Full wiring into KeyManager, TokenService, and RefreshStore — with an OpenTelemetry adapter — is planned for v0.4.0.
+- **OpenTelemetry / Distributed Tracing**: `pkg/tracing` interfaces (`Tracer`, `Span`) and `NoOpTracer` are scaffolded. Full wiring into KeyManager, TokenManager, and RefreshStore — with an OpenTelemetry adapter — is planned for v0.4.0.
 
 ## Architecture Highlights
 
@@ -444,7 +444,7 @@ func main() {
 }
 ```
 
-### TokenService Usage (Beta)
+### TokenManager Usage (Beta)
 
 ```go
 package main
@@ -459,7 +459,7 @@ import (
 )
 
 func main() {
-    // Create TokenService with storage
+    // Create TokenManager with storage
     config := tokens.ManagerConfig{
         KeyManager:           keyManager,      // from KeyManager above
         RefreshStore:         refreshStore,    // RefreshStore implementation
@@ -577,7 +577,7 @@ config := keymanager.ManagerConfig{
 
 ## Error Reference
 
-All `TokenService` errors are exported sentinels compatible with `errors.Is()`. Middleware and API handlers should switch on these to return specific responses.
+All `TokenManager` errors are exported sentinels compatible with `errors.Is()`. Middleware and API handlers should switch on these to return specific responses.
 
 | Error | Trigger | Client-side action |
 |-------|---------|-------------------|
@@ -642,7 +642,7 @@ func (m *MyZapAdapter) Info(msg string, args ...interface{}) {
 
 ### Correlation ID
 
-Correlation IDs let you filter all log lines from a single request across every internal component — KeyManager, RefreshStore, and TokenService — with a single `jq` query.
+Correlation IDs let you filter all log lines from a single request across every internal component — KeyManager, RefreshStore, and TokenManager — with a single `jq` query.
 
 **Quick start**:
 
@@ -783,7 +783,7 @@ jwtauth_key_active_versions_count
 **Alerting guidance**:
 - `jwtauth_key_active_versions_count == 0` → critical — no signing key available, all token issuance will fail
 - `rate(jwtauth_key_rotations_total{status!="success"}[1h]) > 0` → warning — key rotation is failing
-- `jwtauth_service_running == 0` → critical — TokenService has stopped
+- `jwtauth_service_running == 0` → critical — TokenManager has stopped
 
 For the full operator reference including Grafana dashboard guidance and label cardinality analysis, see [doc/METRICS.md](doc/METRICS.md).
 
@@ -819,7 +819,7 @@ github.com/aetomala/jwtauth/
 │   │   ├── disk_test.go          # 9-phase DiskKeyStore tests (38 specs)
 │   │   └── redis_test.go         # 9-phase RedisKeyStore tests (35 specs, miniredis)
 │   ├── tokens/                   # JWT operations (Beta) 🟡
-│   │   ├── manager.go            # TokenService implementation
+│   │   ├── manager.go            # TokenManager implementation
 │   │   ├── claims.go             # Claims management
 │   │   ├── manager_test.go       # Token operations tests
 │   │   ├── manager_lifecycle_test.go  # Lifecycle management tests
@@ -857,7 +857,7 @@ github.com/aetomala/jwtauth/
 
 ### Test Coverage
 
-**Current**: 605 comprehensive tests across KeyManager, TokenService, RefreshStore, Metrics, Logging, and Tracing, all passing with race detection (KeyManager ~90%, TokenService ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%)
+**Current**: 605 comprehensive tests across KeyManager, TokenManager, RefreshStore, Metrics, Logging, and Tracing, all passing with race detection (KeyManager ~90%, TokenManager ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%)
 
 **KeyManager** (3 test suites — 125 total specs):
 - **9-phase Manager tests** (52 specs, MockKeyStore — no I/O):
@@ -877,7 +877,7 @@ github.com/aetomala/jwtauth/
   - Error handling: corrupt metadata, missing metadata entry, Redis unavailability via SetError
   - Concurrency, metrics recording (storage_backend: "redis")
 
-**TokenService** (7 test suites, 153 total tests):
+**TokenManager** (7 test suites, 153 total tests):
 - **Lifecycle Management Tests** (20 tests):
   - Start: idempotency, logging, background cleanup, failure handling, context cancellation
   - Shutdown: logging, cleanup termination, goroutine coordination, timeout respect, idempotency
@@ -955,14 +955,14 @@ Tests follow **progressive phase-based development**:
 - ✅ Architecture documentation
 
 ### v0.2.0 ✅ Complete
-- ✅ TokenService: JWT creation with RS256 signing
-- ✅ TokenService: Lifecycle management (Start/Shutdown/IsRunning)
-- ✅ TokenService: Claims management with custom claims support and reserved claim protection
-- ✅ TokenService: Access token validation with issuer/audience enforcement (ValidateAccessToken)
-- ✅ TokenService: Refresh token rotation with expiration and revocation checks (RefreshAccessToken)
-- ✅ TokenService: Token revocation — single and bulk (RevokeRefreshToken, RevokeAllUserTokens)
-- ✅ TokenService: Token introspection per RFC 7662 (IntrospectToken)
-- ✅ TokenService: Manual cleanup sweep (CleanupExpiredTokens)
+- ✅ TokenManager: JWT creation with RS256 signing
+- ✅ TokenManager: Lifecycle management (Start/Shutdown/IsRunning)
+- ✅ TokenManager: Claims management with custom claims support and reserved claim protection
+- ✅ TokenManager: Access token validation with issuer/audience enforcement (ValidateAccessToken)
+- ✅ TokenManager: Refresh token rotation with expiration and revocation checks (RefreshAccessToken)
+- ✅ TokenManager: Token revocation — single and bulk (RevokeRefreshToken, RevokeAllUserTokens)
+- ✅ TokenManager: Token introspection per RFC 7662 (IntrospectToken)
+- ✅ TokenManager: Manual cleanup sweep (CleanupExpiredTokens)
 - ✅ RefreshStore: Shared test suite pattern (eliminates duplication, runs against all implementations)
 - ✅ RefreshStore: MemoryRefreshStore with defensive copying and concurrent safety
 - ✅ RefreshStore: RedisRefreshStore for distributed deployments with go-redis/v9
@@ -970,9 +970,9 @@ Tests follow **progressive phase-based development**:
 - ✅ KeyStore interface extracted from KeyManager — `DiskKeyStore` for single-instance, `RedisKeyStore` for distributed deployments
 
 ### v0.3.0 (Current — Beta)
-- ✅ TokenService: Clock skew tolerance (`ClockSkew` field, `jwt.WithLeeway()` integration)
-- ✅ TokenService: `ValidateAccessTokenWithClaims` — registered and custom claims returned after validation
-- ✅ Wire metrics into all components — KeyStore, Manager, TokenService, RefreshStore with `error_type` label and context propagation
+- ✅ TokenManager: Clock skew tolerance (`ClockSkew` field, `jwt.WithLeeway()` integration)
+- ✅ TokenManager: `ValidateAccessTokenWithClaims` — registered and custom claims returned after validation
+- ✅ Wire metrics into all components — KeyStore, Manager, TokenManager, RefreshStore with `error_type` label and context propagation
 - ✅ Example middleware returns specific JSON error codes (`token_expired`, `token_revoked`, etc.) via sentinel error mapping
 - ✅ `KeyManager` interface extended with context on all read methods (`GetCurrentSigningKey`, `GetPublicKey`, `GetJWKS`)
 - ✅ Correlation ID logging — `CorrelationIDHandler`, `WithCorrelationID`/`GetCorrelationID` helpers, `NewCorrelationJSONLogger`/`NewCorrelationTextLogger`, context-aware `SlogAdapter`
@@ -984,7 +984,7 @@ Tests follow **progressive phase-based development**:
 - ✅ `pkg/tracing` interfaces scaffolded — `Tracer`, `Span`, `SpanOption`, `StatusCode`, `SpanKind`
 - ✅ `NoOpTracer` / `NoOpSpan` implementations (36 tests, race-detection clean)
 - ✅ `MockTracer` / `MockSpan` generated for dependency injection in component tests
-- 🚧 Wire tracing into KeyManager, TokenService, and RefreshStore
+- 🚧 Wire tracing into KeyManager, TokenManager, and RefreshStore
 - 🚧 OpenTelemetry adapter (`pkg/tracing/otel`) bridging `pkg/tracing.Tracer` to `go.opentelemetry.io/otel`
 
 ### v1.0.0 (Stable)
@@ -1083,6 +1083,6 @@ Built by a Senior Platform Engineer with 28 years of experience in distributed s
 
 **Status**: Beta (Active Development)
 **Version**: 0.3.0-beta
-**Components**: KeyManager ✅ | TokenService (Beta) 🟡 | RefreshStore (Memory + Redis) ✅ | Metrics (Prometheus) ✅ | Logging (Correlation ID) ✅ | Tracing (scaffold) 🚧
-**Test Coverage**: 605 tests (KeyManager ~90%, TokenService ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%), all passing, race-detection enabled
+**Components**: KeyManager ✅ | TokenManager (Beta) 🟡 | RefreshStore (Memory + Redis) ✅ | Metrics (Prometheus) ✅ | Logging (Correlation ID) ✅ | Tracing (scaffold) 🚧
+**Test Coverage**: 605 tests (KeyManager ~90%, TokenManager ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%), all passing, race-detection enabled
 **Last Updated**: April 14, 2026

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -112,7 +112,7 @@ github.com/aetomala/jwtauth/
 │   │   ├── disk_test.go           # 9-phase DiskKeyStore tests (38 specs)
 │   │   └── redis_test.go          # 9-phase RedisKeyStore tests (35 specs, miniredis)
 │   ├── tokens/                    # JWT token operations (Beta)
-│   │   ├── manager.go             # TokenService implementation
+│   │   ├── manager.go             # TokenManager implementation
 │   │   ├── claims.go              # Claims management
 │   │   ├── manager_test.go        # Token operations tests
 │   │   ├── manager_lifecycle_test.go  # Lifecycle management tests
@@ -541,7 +541,7 @@ Keys carry no TTL — Manager owns the lifecycle and calls `Delete` explicitly v
 
 `SetGauge(jwtauth_keystore_keys_count)` is recorded only by `LoadAll` — set to the count of valid non-expired keys returned. This is sufficient because `GetCurrentSigningKey` never calls the store after startup and `GetPublicKey` only calls `LoadKey` on rare cache misses, so KeyStore operations are not on the hot path.
 
-### TokenService (Beta)
+### TokenManager (Beta)
 
 **Responsibilities**:
 - Issue access tokens (short-lived, e.g., 15 minutes) with optional custom claims
@@ -566,7 +566,7 @@ Created → Start() → Running → Shutdown() → Stopped
 - **Synchronization**: `atomic.Bool` for running state; cleanup uses channel signaling and `sync.WaitGroup` for graceful shutdown
 
 **Key Design Decisions**:
-- Rate limiting is intentionally **not** in TokenService — it belongs at the infrastructure layer (API Gateway, Ingress, Load Balancer) where per-route and per-IP policies apply globally
+- Rate limiting is intentionally **not** in TokenManager — it belongs at the infrastructure layer (API Gateway, Ingress, Load Balancer) where per-route and per-IP policies apply globally
 - All storage operations accept `context.Context` for cancellation propagation
 - Reserved JWT claims (`sub`, `iss`, `aud`, `exp`, `iat`, `jti`) cannot be overridden by custom claims
 
@@ -910,9 +910,9 @@ Catches:
 - ✅ Prometheus implementation (`PrometheusMetrics`) with 22 pre-registered metrics, 100% test coverage
 - ✅ NoOp implementation
 - ✅ gomock `MockMetrics` for dependency injection in tests
-- ✅ Wired into KeyManager, TokenService, and RefreshStore — all components fully instrumented
+- ✅ Wired into KeyManager, TokenManager, and RefreshStore — all components fully instrumented
 
-### Phase 3: TokenService ✅ (Beta)
+### Phase 3: TokenManager ✅ (Beta)
 - ✅ JWT creation with RS256 signing and custom claims
 - ✅ Access token validation (signature, expiration, issuer, audience)
 - ✅ Refresh token rotation with revocation checks
@@ -953,10 +953,10 @@ Catches:
   - `Manager` unit tests are now filesystem-free (use `MockKeyStore`)
   - 44 Manager specs + 38 DiskKeyStore specs (9 phases), all race-clean
   - `MockKeyStore` generated via gomock
-- ✅ Wire `PrometheusMetrics` into TokenService — deferred closure pattern with `error_type` label, context propagation
+- ✅ Wire `PrometheusMetrics` into TokenManager — deferred closure pattern with `error_type` label, context propagation
 - ✅ `RedisKeyStore` implementation — `ks:pem:<id>` / `ks:meta:<id>` Redis layout, atomic Pipeline writes, SCAN-based `LoadAll`, full metrics with `storage_backend: "redis"`
 - ✅ Correlation ID logging — `CorrelationIDHandler` wraps any `slog.Handler`; `WithCorrelationID`/`GetCorrelationID` context helpers; `SlogAdapter` context-aware routing; `NewCorrelationJSONLogger`/`NewCorrelationTextLogger` convenience constructors
-- ✅ All component logging call sites forward `ctx` — correlation ID propagates through KeyManager, TokenService, and RefreshStore without Logger interface changes
+- ✅ All component logging call sites forward `ctx` — correlation ID propagates through KeyManager, TokenManager, and RefreshStore without Logger interface changes
 - ✅ `KeyManager` interface extended with context on all read methods (`GetCurrentSigningKey`, `GetPublicKey`, `GetJWKS`)
 - ✅ Context cancellation guards in `GetJWKS` and `cleanupExpiredKeys` with warning log on early return
 - ✅ Redis integration tests via miniredis (`pkg/tokens/integration`) covering distributed token operations end-to-end
@@ -965,7 +965,7 @@ Catches:
 - ✅ `pkg/tracing` — `Tracer` and `Span` interfaces defined; `SpanOption` functional options; `StatusCode` and `SpanKind` enumerations
 - ✅ `NoOpTracer` / `NoOpSpan` — zero-allocation implementations; 36 tests, race-detection clean
 - ✅ `MockTracer` / `MockSpan` generated via gomock for dependency injection in component tests
-- ⏳ Wire tracing into KeyManager, TokenService, and RefreshStore
+- ⏳ Wire tracing into KeyManager, TokenManager, and RefreshStore
 - ⏳ OpenTelemetry adapter (`pkg/tracing/otel`) bridging `pkg/tracing.Tracer` to `go.opentelemetry.io/otel`
 
 ---

--- a/examples/chi-example/README.md
+++ b/examples/chi-example/README.md
@@ -5,7 +5,7 @@ This example demonstrates how to use `jwtauth` with [Chi](https://github.com/go-
 ## Overview
 
 The example shows:
-- Creating and starting a `TokenService` with `KeyManager` and `RefreshStore`
+- Creating and starting a `TokenManager` with `KeyManager` and `RefreshStore`
 - Writing a custom authentication middleware for Chi
 - Public endpoints for login and token refresh
 - Protected endpoints that require a valid JWT token
@@ -50,7 +50,7 @@ You'll see output like:
 
 ```
 2026-03-30T12:34:56.123Z	info	KeyManager started	{"active_keys": 1, "current_key_id": "..."}
-2026-03-30T12:34:56.124Z	info	TokenService started	{"issuer": "chi-example"}
+2026-03-30T12:34:56.124Z	info	TokenManager started	{"issuer": "chi-example"}
 Starting server on :8080
 ```
 

--- a/examples/echo-example/README.md
+++ b/examples/echo-example/README.md
@@ -5,7 +5,7 @@ This example demonstrates how to use `jwtauth` with [Echo](https://echo.labstack
 ## Overview
 
 The example shows:
-- Creating and starting a `TokenService` with `KeyManager` and `RefreshStore`
+- Creating and starting a `TokenManager` with `KeyManager` and `RefreshStore`
 - Writing a custom authentication middleware for Echo
 - Public endpoints for login and token refresh
 - Protected endpoints that require a valid JWT token
@@ -50,7 +50,7 @@ You'll see output like:
 
 ```
 2026-03-30T12:34:56.123Z	info	KeyManager started	{"active_keys": 1, "current_key_id": "..."}
-2026-03-30T12:34:56.124Z	info	TokenService started	{"issuer": "echo-example"}
+2026-03-30T12:34:56.124Z	info	TokenManager started	{"issuer": "echo-example"}
 ⇨ http server started on [::]:8080
 ```
 

--- a/examples/gin-example/README.md
+++ b/examples/gin-example/README.md
@@ -5,7 +5,7 @@ This example demonstrates how to use `jwtauth` with [Gin](https://github.com/gin
 ## Overview
 
 The example shows:
-- Creating and starting a `TokenService` with `KeyManager` and `RefreshStore`
+- Creating and starting a `TokenManager` with `KeyManager` and `RefreshStore`
 - Writing a custom authentication middleware for Gin
 - Public endpoints for login and token refresh
 - Protected endpoints that require a valid JWT token
@@ -49,7 +49,7 @@ You'll see output like:
 
 ```
 2026-03-30T12:34:56.123Z	info	KeyManager started	{"active_keys": 1, "current_key_id": "..."}
-2026-03-30T12:34:56.124Z	info	TokenService started	{"issuer": "gin-example"}
+2026-03-30T12:34:56.124Z	info	TokenManager started	{"issuer": "gin-example"}
 Starting server on :8080
 ```
 


### PR DESCRIPTION
## Summary

Replaces all 40 occurrences of "TokenService" with "TokenManager" across documentation files for consistent terminology. CHANGELOG.md is intentionally left unchanged (historical record).

## Files Changed

- `README.md` — 26 occurrences
- `doc/ARCHITECTURE.md` — 8 occurrences
- `examples/gin-example/README.md` — 2 occurrences
- `examples/chi-example/README.md` — 2 occurrences
- `examples/echo-example/README.md` — 2 occurrences