### PR TITLE
Tracing/phase 1 disk keystore

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  GOTOOLCHAIN: local
 
 jobs:
   lint:
@@ -22,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.x'
+          go-version: '1.25.x'
           cache: true
 
       - name: Download dependencies
@@ -34,7 +33,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.64.8
+          version: latest
 
   test:
     name: Test
@@ -47,7 +46,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.x'
+          go-version: '1.25.x'
           cache: true
 
       - name: Download dependencies

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.24.x'
           cache: true
 
       - name: Download dependencies
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.24.x'
           cache: true
 
       - name: Download dependencies

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  GOTOOLCHAIN: local
 
 jobs:
   lint:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,9 +31,9 @@ jobs:
         run: go vet ./...
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.11.4
 
   test:
     name: Test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,25 +1,39 @@
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-    - govet
     - errcheck
-    - staticcheck
-    - gosimple
+    - govet
     - ineffassign
-
-linters-settings:
-  errcheck:
-    check-type-assertions: false
-    exclude-functions:
-      # Ginkgo test assertions and helpers
-      - (*github.com/onsi/gomega.GomegaWithT).Expect
-      - (github.com/onsi/gomega.Expect)
-
+    - staticcheck
+  settings:
+    errcheck:
+      check-type-assertions: false
+      exclude-functions:
+        - (*github.com/onsi/gomega.GomegaWithT).Expect
+        - (github.com/onsi/gomega.Expect)
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - errcheck
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude-rules:
-    # Ignore error checks in test files
-    - path: _test\.go
-      linters:
-        - errcheck
   max-issues-per-linter: 0
   max-same-issues: 0
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/examples/chi-example/main.go
+++ b/examples/chi-example/main.go
@@ -27,7 +27,7 @@ func main() {
 	pm := metrics.NewPrometheusMetrics(metrics.PrometheusConfig{})
 
 	// Create KeyStore and KeyManager
-	ks, err := keymanager.NewDiskKeyStore("./keys", 2048, logger, pm)
+	ks, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: "./keys", KeySize: 2048, Logger: logger, Metrics: pm})
 	if err != nil {
 		log.Fatal("Failed to create DiskKeyStore:", err)
 	}

--- a/examples/correlation-example/main.go
+++ b/examples/correlation-example/main.go
@@ -28,7 +28,7 @@ func main() {
 	logger := logging.NewCorrelationJSONLogger(slog.LevelDebug)
 
 	// ===== KeyManager =====
-	ks, err := keymanager.NewDiskKeyStore("./keys", 2048, logger, nil)
+	ks, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: "./keys", KeySize: 2048, Logger: logger})
 	if err != nil {
 		slog.Error("failed to create key store", "error", err)
 		os.Exit(1)

--- a/examples/echo-example/main.go
+++ b/examples/echo-example/main.go
@@ -25,7 +25,7 @@ func main() {
 	pm := metrics.NewPrometheusMetrics(metrics.PrometheusConfig{})
 
 	// Create KeyStore and KeyManager
-	ks, err := keymanager.NewDiskKeyStore("./keys", 2048, logger, pm)
+	ks, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: "./keys", KeySize: 2048, Logger: logger, Metrics: pm})
 	if err != nil {
 		log.Fatal("Failed to create DiskKeyStore:", err)
 	}

--- a/examples/gin-example/main.go
+++ b/examples/gin-example/main.go
@@ -25,7 +25,7 @@ func main() {
 	pm := metrics.NewPrometheusMetrics(metrics.PrometheusConfig{})
 
 	// Create KeyStore and KeyManager
-	ks, err := keymanager.NewDiskKeyStore("./keys", 2048, logger, pm)
+	ks, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: "./keys", KeySize: 2048, Logger: logger, Metrics: pm})
 	if err != nil {
 		log.Fatal("Failed to create DiskKeyStore:", err)
 	}

--- a/examples/health-check/main.go
+++ b/examples/health-check/main.go
@@ -17,7 +17,7 @@ func main() {
 	logger := logging.NewTextLogger(slog.LevelInfo)
 
 	// ===== STEP 1: Create KeyManager =====
-	ks, err := keymanager.NewDiskKeyStore("./keys", 2048, logger, nil)
+	ks, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: "./keys", KeySize: 2048, Logger: logger})
 	if err != nil {
 		log.Fatal("Failed to create DiskKeyStore:", err)
 	}

--- a/examples/prometheus-metrics/main.go
+++ b/examples/prometheus-metrics/main.go
@@ -37,7 +37,7 @@ func main() {
 	logger := logging.NewTextLogger(slog.LevelInfo)
 
 	// ===== STEP 1: Create KeyManager =====
-	ks, err := keymanager.NewDiskKeyStore("./keys", 2048, logger, nil)
+	ks, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: "./keys", KeySize: 2048, Logger: logger})
 	if err != nil {
 		log.Fatal("Failed to create DiskKeyStore:", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aetomala/jwtauth
 
-go 1.24
+go 1.25.0
 
 require (
 	github.com/alicebob/miniredis/v2 v2.37.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aetomala/jwtauth
 
-go 1.25.0
+go 1.24
 
 require (
 	github.com/alicebob/miniredis/v2 v2.37.0

--- a/pkg/keymanager/disk.go
+++ b/pkg/keymanager/disk.go
@@ -21,10 +21,21 @@ import (
 // DiskKeyStoreConfig holds configuration for a DiskKeyStore instance.
 type DiskKeyStoreConfig struct {
 	Dir     string          // Absolute or relative path to the key storage directory.
-	KeySize int             // Minimum accepted RSA key bit-size for load-time validation.
-	Logger  logging.Logger  // Optional; nil disables logging.
-	Metrics metrics.Metrics // Optional; nil disables metrics.
+	KeySize int             // Minimum accepted RSA key bit-size for load-time validation. Defaults to 2048.
+	Logger  logging.Logger  // Optional; nil defaults to NoOpLogger.
+	Metrics metrics.Metrics // Optional; nil defaults to NoOpMetrics.
 	Tracer  tracing.Tracer  // Optional; nil defaults to NoOpTracer.
+}
+
+// DiskKeyStoreConfigDefault returns a DiskKeyStoreConfig with sensible defaults.
+// NewDiskKeyStore applies these automatically for any zero-value or nil fields.
+func DiskKeyStoreConfigDefault() DiskKeyStoreConfig {
+	return DiskKeyStoreConfig{
+		KeySize: 2048,
+		Logger:  &logging.NoOpLogger{},
+		Metrics: metrics.NewNoOpMetrics(),
+		Tracer:  tracing.NewNoOpTracer(),
+	}
 }
 
 // DiskKeyStore is a thread-safe, filesystem-backed implementation of KeyStore.
@@ -38,46 +49,51 @@ type DiskKeyStore struct {
 	keySize int    // minimum accepted RSA key bit-size for load-time validation
 
 	// ===== Observability =====
-	logger  logging.Logger  // Optional; nil disables logging
-	metrics metrics.Metrics // Optional; nil disables metrics
+	logger  logging.Logger  // never nil; defaults to NoOpLogger
+	metrics metrics.Metrics // never nil; defaults to NoOpMetrics
 	tracer  tracing.Tracer  // never nil; defaults to NoOpTracer
 	backend string          // always "disk"
 }
 
-// NewDiskKeyStore returns a new DiskKeyStore using cfg. The directory is
-// created if it does not already exist. Returns ErrInvalidKeyDirectory if
-// cfg.Dir is empty or the directory cannot be created.
+// NewDiskKeyStore returns a new DiskKeyStore using cfg. Zero-value and nil
+// fields are filled with defaults from DiskKeyStoreConfigDefault. The
+// directory is created if it does not already exist. Returns
+// ErrInvalidKeyDirectory if cfg.Dir is empty or the directory cannot be created.
 func NewDiskKeyStore(cfg DiskKeyStoreConfig) (*DiskKeyStore, error) {
 	// ===== STEP 1: Validate Directory =====
 	if strings.TrimSpace(cfg.Dir) == "" {
 		return nil, ErrInvalidKeyDirectory
 	}
 
-	// ===== STEP 2: Create Directory =====
+	// ===== STEP 2: Apply Defaults =====
+	defaults := DiskKeyStoreConfigDefault()
+	if cfg.KeySize == 0 {
+		cfg.KeySize = defaults.KeySize
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = defaults.Logger
+	}
+	if cfg.Metrics == nil {
+		cfg.Metrics = defaults.Metrics
+	}
+	if cfg.Tracer == nil {
+		cfg.Tracer = defaults.Tracer
+	}
+
+	// ===== STEP 3: Create Directory =====
 	if err := os.MkdirAll(cfg.Dir, 0755); err != nil {
 		return nil, fmt.Errorf("create key directory: %w", err)
 	}
 
-	// ===== STEP 3: Default Optional Fields =====
-	t := cfg.Tracer
-	if t == nil {
-		t = tracing.NewNoOpTracer()
-	}
-
 	// ===== STEP 4: Return Initialized Store =====
-	store := &DiskKeyStore{
+	return &DiskKeyStore{
 		dir:     cfg.Dir,
 		keySize: cfg.KeySize,
 		backend: "disk",
-		tracer:  t,
-	}
-	if cfg.Logger != nil {
-		store.logger = cfg.Logger
-	}
-	if cfg.Metrics != nil {
-		store.metrics = cfg.Metrics
-	}
-	return store, nil
+		logger:  cfg.Logger,
+		metrics: cfg.Metrics,
+		tracer:  cfg.Tracer,
+	}, nil
 }
 
 // startSpan begins a new tracing span with storage.backend pre-set to "disk".

--- a/pkg/keymanager/disk.go
+++ b/pkg/keymanager/disk.go
@@ -15,7 +15,17 @@ import (
 
 	"github.com/aetomala/jwtauth/pkg/logging"
 	"github.com/aetomala/jwtauth/pkg/metrics"
+	"github.com/aetomala/jwtauth/pkg/tracing"
 )
+
+// DiskKeyStoreConfig holds configuration for a DiskKeyStore instance.
+type DiskKeyStoreConfig struct {
+	Dir     string          // Absolute or relative path to the key storage directory.
+	KeySize int             // Minimum accepted RSA key bit-size for load-time validation.
+	Logger  logging.Logger  // Optional; nil disables logging.
+	Metrics metrics.Metrics // Optional; nil disables metrics.
+	Tracer  tracing.Tracer  // Optional; nil defaults to NoOpTracer.
+}
 
 // DiskKeyStore is a thread-safe, filesystem-backed implementation of KeyStore.
 // Each key pair is persisted as a PKCS#1 PEM file alongside a companion JSON
@@ -30,36 +40,53 @@ type DiskKeyStore struct {
 	// ===== Observability =====
 	logger  logging.Logger  // Optional; nil disables logging
 	metrics metrics.Metrics // Optional; nil disables metrics
+	tracer  tracing.Tracer  // never nil; defaults to NoOpTracer
 	backend string          // always "disk"
 }
 
-// NewDiskKeyStore returns a new DiskKeyStore rooted at dir. The directory is
-// created if it does not already exist. Returns ErrInvalidKeyDirectory if dir
-// is empty or the directory cannot be created.
-func NewDiskKeyStore(dir string, keySize int, logger logging.Logger, m metrics.Metrics) (*DiskKeyStore, error) {
+// NewDiskKeyStore returns a new DiskKeyStore using cfg. The directory is
+// created if it does not already exist. Returns ErrInvalidKeyDirectory if
+// cfg.Dir is empty or the directory cannot be created.
+func NewDiskKeyStore(cfg DiskKeyStoreConfig) (*DiskKeyStore, error) {
 	// ===== STEP 1: Validate Directory =====
-	if strings.TrimSpace(dir) == "" {
+	if strings.TrimSpace(cfg.Dir) == "" {
 		return nil, ErrInvalidKeyDirectory
 	}
 
 	// ===== STEP 2: Create Directory =====
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(cfg.Dir, 0755); err != nil {
 		return nil, fmt.Errorf("create key directory: %w", err)
 	}
 
-	// ===== STEP 3: Return Initialized Store =====
+	// ===== STEP 3: Default Optional Fields =====
+	t := cfg.Tracer
+	if t == nil {
+		t = tracing.NewNoOpTracer()
+	}
+
+	// ===== STEP 4: Return Initialized Store =====
 	store := &DiskKeyStore{
-		dir:     dir,
-		keySize: keySize,
+		dir:     cfg.Dir,
+		keySize: cfg.KeySize,
 		backend: "disk",
+		tracer:  t,
 	}
-	if logger != nil {
-		store.logger = logger
+	if cfg.Logger != nil {
+		store.logger = cfg.Logger
 	}
-	if m != nil {
-		store.metrics = m
+	if cfg.Metrics != nil {
+		store.metrics = cfg.Metrics
 	}
 	return store, nil
+}
+
+// startSpan begins a new tracing span with storage.backend pre-set to "disk".
+func (d *DiskKeyStore) startSpan(ctx context.Context, operation string) (context.Context, tracing.Span) {
+	return d.tracer.Start(ctx, "DiskKeyStore."+operation,
+		tracing.WithAttributes(map[string]any{
+			"storage.backend": d.backend,
+		}),
+	)
 }
 
 // LoadAll returns every valid (non-expired) key in the directory. Corrupted PEM
@@ -67,6 +94,9 @@ func NewDiskKeyStore(dir string, keySize int, logger logging.Logger, m metrics.M
 // an empty slice when no valid keys exist — this is not an error. Returns the
 // context error if the context is cancelled before completion.
 func (d *DiskKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
+	ctx, span := d.startSpan(ctx, "LoadAll")
+	defer span.End()
+
 	start := time.Now()
 	status := "error"
 	errorType := "error"
@@ -95,6 +125,8 @@ func (d *DiskKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
 		errorType = "cancelled"
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
 		return nil, err
 	}
 
@@ -105,6 +137,8 @@ func (d *DiskKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 		if d.logger != nil {
 			d.logger.Error("failed to glob key files", ctx, "error", err)
 		}
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, "glob key files failed")
 		return nil, fmt.Errorf("glob key files: %w", err)
 	}
 
@@ -159,6 +193,7 @@ func (d *DiskKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 	if d.logger != nil {
 		d.logger.Info("loaded keys from disk", ctx, "count", keyCount)
 	}
+	span.SetStatus(tracing.StatusOK, "")
 	return keys, nil
 }
 
@@ -166,6 +201,10 @@ func (d *DiskKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 // with 0600 permissions. If the metadata write fails, the PEM file is removed to
 // maintain consistency. Returns the context error if the context is cancelled.
 func (d *DiskKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.PrivateKey, meta KeyMetadata) error {
+	ctx, span := d.startSpan(ctx, "Save")
+	defer span.End()
+	span.SetAttribute("key_id", keyID)
+
 	start := time.Now()
 	status := "error"
 	errorType := "error"
@@ -188,6 +227,8 @@ func (d *DiskKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.P
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
 		errorType = "cancelled"
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
 		return err
 	}
 
@@ -207,6 +248,8 @@ func (d *DiskKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.P
 				"keyID", keyID,
 				"error", err)
 		}
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, "create key file failed")
 		return fmt.Errorf("create key file: %w", err)
 	}
 	defer file.Close()
@@ -217,6 +260,8 @@ func (d *DiskKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.P
 				"keyID", keyID,
 				"error", err)
 		}
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, "write key file failed")
 		return fmt.Errorf("write key file: %w", err)
 	}
 
@@ -229,6 +274,8 @@ func (d *DiskKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.P
 				"keyID", keyID,
 				"error", err)
 		}
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, "save key metadata failed")
 		return fmt.Errorf("save key metadata: %w", err)
 	}
 
@@ -238,6 +285,7 @@ func (d *DiskKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.P
 	if d.logger != nil {
 		d.logger.Info("saved key to disk", ctx, "keyID", keyID)
 	}
+	span.SetStatus(tracing.StatusOK, "")
 	return nil
 }
 
@@ -246,6 +294,10 @@ func (d *DiskKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.P
 // Returns ErrKeyStoreKeyNotFound if the PEM file for keyID does not exist.
 // Returns the context error if the context is cancelled.
 func (d *DiskKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta KeyMetadata) error {
+	ctx, span := d.startSpan(ctx, "UpdateMetadata")
+	defer span.End()
+	span.SetAttribute("key_id", keyID)
+
 	start := time.Now()
 	status := "error"
 	errorType := "error"
@@ -268,6 +320,8 @@ func (d *DiskKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta Ke
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
 		errorType = "cancelled"
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
 		return err
 	}
 
@@ -276,6 +330,7 @@ func (d *DiskKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta Ke
 	if _, err := os.Stat(pemPath); errors.Is(err, os.ErrNotExist) {
 		status = "not_found"
 		errorType = "not_found"
+		span.SetStatus(tracing.StatusError, "key not found")
 		return ErrKeyStoreKeyNotFound
 	}
 
@@ -286,6 +341,8 @@ func (d *DiskKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta Ke
 				"keyID", keyID,
 				"error", err)
 		}
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, "update metadata failed")
 		return fmt.Errorf("update metadata: %w", err)
 	}
 
@@ -295,6 +352,7 @@ func (d *DiskKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta Ke
 	if d.logger != nil {
 		d.logger.Info("updated key metadata", ctx, "keyID", keyID)
 	}
+	span.SetStatus(tracing.StatusOK, "")
 	return nil
 }
 
@@ -302,6 +360,10 @@ func (d *DiskKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta Ke
 // GetPublicKey cache miss. Returns ErrKeyStoreInvalidKeyID if keyID is empty or
 // whitespace-only, ErrKeyStoreKeyNotFound if the key does not exist on disk.
 func (d *DiskKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.PrivateKey, *KeyMetadata, error) {
+	ctx, span := d.startSpan(ctx, "LoadKey")
+	defer span.End()
+	span.SetAttribute("key_id", keyID)
+
 	start := time.Now()
 	status := "error"
 	errorType := "error"
@@ -324,6 +386,8 @@ func (d *DiskKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.PrivateK
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
 		errorType = "cancelled"
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
 		return nil, nil, err
 	}
 
@@ -331,6 +395,7 @@ func (d *DiskKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.PrivateK
 	if strings.TrimSpace(keyID) == "" {
 		status = "not_found"
 		errorType = "not_found"
+		span.SetStatus(tracing.StatusError, "invalid key ID")
 		return nil, nil, ErrKeyStoreInvalidKeyID
 	}
 
@@ -341,6 +406,7 @@ func (d *DiskKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.PrivateK
 		if errors.Is(err, os.ErrNotExist) || strings.Contains(err.Error(), "no such file") {
 			status = "not_found"
 			errorType = "not_found"
+			span.SetStatus(tracing.StatusError, "key not found")
 			return nil, nil, ErrKeyStoreKeyNotFound
 		}
 		if d.logger != nil {
@@ -348,6 +414,8 @@ func (d *DiskKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.PrivateK
 				"keyID", keyID,
 				"error", err)
 		}
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, "load key file failed")
 		return nil, nil, fmt.Errorf("load key: %w", err)
 	}
 
@@ -359,6 +427,8 @@ func (d *DiskKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.PrivateK
 				"keyID", keyID,
 				"error", err)
 		}
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, "load metadata failed")
 		return nil, nil, fmt.Errorf("load metadata: %w", err)
 	}
 
@@ -368,6 +438,7 @@ func (d *DiskKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.PrivateK
 	if d.logger != nil {
 		d.logger.Debug("loaded key from disk", ctx, "keyID", keyID)
 	}
+	span.SetStatus(tracing.StatusOK, "")
 	return privateKey, &meta, nil
 }
 
@@ -375,6 +446,10 @@ func (d *DiskKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.PrivateK
 // If the key does not exist, no error is returned — the call is idempotent.
 // Returns the context error if the context is cancelled.
 func (d *DiskKeyStore) Delete(ctx context.Context, keyID string) error {
+	ctx, span := d.startSpan(ctx, "Delete")
+	defer span.End()
+	span.SetAttribute("key_id", keyID)
+
 	start := time.Now()
 	status := "error"
 	errorType := "error"
@@ -397,6 +472,8 @@ func (d *DiskKeyStore) Delete(ctx context.Context, keyID string) error {
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
 		errorType = "cancelled"
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
 		return err
 	}
 
@@ -408,6 +485,8 @@ func (d *DiskKeyStore) Delete(ctx context.Context, keyID string) error {
 				"keyID", keyID,
 				"error", err)
 		}
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, "delete key file failed")
 		return fmt.Errorf("delete key file: %w", err)
 	}
 
@@ -419,6 +498,8 @@ func (d *DiskKeyStore) Delete(ctx context.Context, keyID string) error {
 				"keyID", keyID,
 				"error", err)
 		}
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, "delete metadata file failed")
 		return fmt.Errorf("delete metadata file: %w", err)
 	}
 
@@ -428,6 +509,7 @@ func (d *DiskKeyStore) Delete(ctx context.Context, keyID string) error {
 	if d.logger != nil {
 		d.logger.Info("deleted key from disk", ctx, "keyID", keyID)
 	}
+	span.SetStatus(tracing.StatusOK, "")
 	return nil
 }
 

--- a/pkg/keymanager/disk_test.go
+++ b/pkg/keymanager/disk_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aetomala/jwtauth/internal/testutil"
 	"github.com/aetomala/jwtauth/pkg/keymanager"
 	"github.com/aetomala/jwtauth/pkg/metrics"
+	"github.com/aetomala/jwtauth/pkg/tracing"
 )
 
 // writePEMFile writes a PKCS#1 PEM file for key at dir/keyID.pem with 0600 permissions.
@@ -34,7 +35,7 @@ func writePEMFile(dir, keyID string, key *rsa.PrivateKey) {
 func writeMetaFile(dir, keyID string, meta keymanager.KeyMetadata) {
 	// Re-use DiskKeyStore serialisation by saving through the store
 	// — this avoids duplicating JSON logic in tests.
-	ds, err := keymanager.NewDiskKeyStore(dir, 2048, nil, nil)
+	ds, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: 2048})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(ds.UpdateMetadata(context.Background(), keyID, meta)).To(Succeed())
 }
@@ -54,14 +55,14 @@ var _ = Describe("DiskKeyStore", func() {
 	Describe("Phase 1: Constructor and Initialization", func() {
 		Context("with a valid directory", func() {
 			It("should create a DiskKeyStore successfully", func() {
-				ds, err := keymanager.NewDiskKeyStore(dir, 2048, nil, nil)
+				ds, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: 2048})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(ds).NotTo(BeNil())
 			})
 
 			It("should create a non-existent directory automatically", func() {
 				newDir := filepath.Join(dir, "auto-created")
-				ds, err := keymanager.NewDiskKeyStore(newDir, 2048, nil, nil)
+				ds, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: newDir, KeySize: 2048})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(ds).NotTo(BeNil())
 				_, statErr := os.Stat(newDir)
@@ -70,7 +71,7 @@ var _ = Describe("DiskKeyStore", func() {
 
 			It("should accept a logger and metrics without error", func() {
 				mockLogger := testutil.NewMockLogger()
-				ds, err := keymanager.NewDiskKeyStore(dir, 2048, mockLogger, nil)
+				ds, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: 2048, Logger: mockLogger})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(ds).NotTo(BeNil())
 			})
@@ -78,12 +79,12 @@ var _ = Describe("DiskKeyStore", func() {
 
 		Context("with an invalid directory", func() {
 			It("should return ErrInvalidKeyDirectory for an empty string", func() {
-				_, err := keymanager.NewDiskKeyStore("", 2048, nil, nil)
+				_, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: "", KeySize: 2048})
 				Expect(err).To(MatchError(keymanager.ErrInvalidKeyDirectory))
 			})
 
 			It("should return ErrInvalidKeyDirectory for a whitespace-only string", func() {
-				_, err := keymanager.NewDiskKeyStore("   ", 2048, nil, nil)
+				_, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: "   ", KeySize: 2048})
 				Expect(err).To(MatchError(keymanager.ErrInvalidKeyDirectory))
 			})
 		})
@@ -95,7 +96,7 @@ var _ = Describe("DiskKeyStore", func() {
 
 		BeforeEach(func() {
 			var err error
-			ds, err = keymanager.NewDiskKeyStore(dir, 2048, nil, nil)
+			ds, err = keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: 2048})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -154,7 +155,7 @@ var _ = Describe("DiskKeyStore", func() {
 
 		BeforeEach(func() {
 			var err error
-			ds, err = keymanager.NewDiskKeyStore(dir, 2048, nil, nil)
+			ds, err = keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: 2048})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -225,7 +226,7 @@ var _ = Describe("DiskKeyStore", func() {
 
 		BeforeEach(func() {
 			var err error
-			ds, err = keymanager.NewDiskKeyStore(dir, 2048, nil, nil)
+			ds, err = keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: 2048})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -287,7 +288,7 @@ var _ = Describe("DiskKeyStore", func() {
 
 		BeforeEach(func() {
 			var err error
-			ds, err = keymanager.NewDiskKeyStore(dir, 2048, nil, nil)
+			ds, err = keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: 2048})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -333,7 +334,7 @@ var _ = Describe("DiskKeyStore", func() {
 
 		BeforeEach(func() {
 			var err error
-			ds, err = keymanager.NewDiskKeyStore(dir, 2048, nil, nil)
+			ds, err = keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: 2048})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -383,7 +384,7 @@ var _ = Describe("DiskKeyStore", func() {
 
 		BeforeEach(func() {
 			var err error
-			ds, err = keymanager.NewDiskKeyStore(dir, 2048, nil, nil)
+			ds, err = keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: 2048})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -418,7 +419,7 @@ var _ = Describe("DiskKeyStore", func() {
 
 		BeforeEach(func() {
 			var err error
-			ds, err = keymanager.NewDiskKeyStore(dir, 2048, nil, nil)
+			ds, err = keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: 2048})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -500,7 +501,7 @@ var _ = Describe("DiskKeyStore", func() {
 		AfterEach(func() { ctrl.Finish() })
 
 		newMetricStore := func() *keymanager.DiskKeyStore {
-			ds, err := keymanager.NewDiskKeyStore(dir, 2048, nil, mockM)
+			ds, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: 2048, Metrics: mockM})
 			Expect(err).NotTo(HaveOccurred())
 			return ds
 		}
@@ -546,7 +547,7 @@ var _ = Describe("DiskKeyStore", func() {
 		Context("LoadKey", func() {
 			It("should record success metrics", func() {
 				// Pre-save via unmetered store
-				plain, _ := keymanager.NewDiskKeyStore(dir, 2048, nil, nil)
+				plain, _ := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: 2048})
 				key := newTestKey()
 				Expect(plain.Save(ctx, "metric-load-key", key, keymanager.KeyMetadata{ID: "metric-load-key", CreatedAt: time.Now()})).To(Succeed())
 
@@ -566,7 +567,7 @@ var _ = Describe("DiskKeyStore", func() {
 
 		Context("UpdateMetadata", func() {
 			It("should record success metrics", func() {
-				plain, _ := keymanager.NewDiskKeyStore(dir, 2048, nil, nil)
+				plain, _ := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: 2048})
 				key := newTestKey()
 				Expect(plain.Save(ctx, "metric-update-key", key, keymanager.KeyMetadata{ID: "metric-update-key", CreatedAt: time.Now()})).To(Succeed())
 
@@ -578,7 +579,7 @@ var _ = Describe("DiskKeyStore", func() {
 
 		Context("Delete", func() {
 			It("should record success metrics", func() {
-				plain, _ := keymanager.NewDiskKeyStore(dir, 2048, nil, nil)
+				plain, _ := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: 2048})
 				key := newTestKey()
 				Expect(plain.Save(ctx, "metric-delete-key", key, keymanager.KeyMetadata{ID: "metric-delete-key", CreatedAt: time.Now()})).To(Succeed())
 
@@ -590,7 +591,7 @@ var _ = Describe("DiskKeyStore", func() {
 
 		Context("nil metrics", func() {
 			It("should not panic when metrics is nil", func() {
-				ds, err := keymanager.NewDiskKeyStore(dir, 2048, nil, nil)
+				ds, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: 2048})
 				Expect(err).NotTo(HaveOccurred())
 
 				key := newTestKey()
@@ -601,6 +602,79 @@ var _ = Describe("DiskKeyStore", func() {
 					_ = ds.UpdateMetadata(ctx, "nil-metrics-key", keymanager.KeyMetadata{ID: "nil-metrics-key", CreatedAt: time.Now()})
 				}).NotTo(Panic())
 				Expect(func() { _ = ds.Delete(ctx, "nil-metrics-key") }).NotTo(Panic())
+			})
+		})
+	})
+
+	// ===== PHASE 10: Config =====
+	Describe("Phase 10: Config", func() {
+		It("should default to a NoOpTracer when Tracer is nil", func() {
+			ds, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: 2048})
+			Expect(err).NotTo(HaveOccurred())
+			// NoOpTracer: Save must not panic even though no tracer was provided explicitly.
+			key := newTestKey()
+			Expect(ds.Save(ctx, "noop-tracer-key", key, keymanager.KeyMetadata{ID: "noop-tracer-key", CreatedAt: time.Now()})).To(Succeed())
+		})
+
+		It("should store an explicit Tracer without error", func() {
+			ctrl := gomock.NewController(GinkgoT())
+			defer ctrl.Finish()
+
+			mockTracer := testutil.NewMockTracer(ctrl)
+			mockSpan := testutil.NewMockSpan(ctrl)
+
+			mockTracer.EXPECT().Start(gomock.Any(), gomock.Any(), gomock.Any()).Return(ctx, mockSpan).AnyTimes()
+			mockSpan.EXPECT().End().AnyTimes()
+			mockSpan.EXPECT().SetAttribute(gomock.Any(), gomock.Any()).AnyTimes()
+			mockSpan.EXPECT().SetStatus(gomock.Any(), gomock.Any()).AnyTimes()
+
+			ds, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: 2048, Tracer: mockTracer})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ds).NotTo(BeNil())
+		})
+	})
+
+	// ===== PHASE 11: Tracing =====
+	Describe("Phase 11: Tracing", func() {
+		var (
+			ctrl        *gomock.Controller
+			mockTracer  *testutil.MockTracer
+			mockSpan    *testutil.MockSpan
+			tracingStore *keymanager.DiskKeyStore
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			mockTracer = testutil.NewMockTracer(ctrl)
+			mockSpan = testutil.NewMockSpan(ctrl)
+			var err error
+			tracingStore, err = keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: 2048, Tracer: mockTracer})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() { ctrl.Finish() })
+
+		Context("Save — success path", func() {
+			It("should start a span named DiskKeyStore.Save with key_id and StatusOK", func() {
+				mockTracer.EXPECT().Start(gomock.Any(), "DiskKeyStore.Save", gomock.Any()).Return(ctx, mockSpan)
+				mockSpan.EXPECT().SetAttribute("key_id", "trace-save-key")
+				mockSpan.EXPECT().SetStatus(tracing.StatusOK, "")
+				mockSpan.EXPECT().End()
+
+				key := newTestKey()
+				Expect(tracingStore.Save(ctx, "trace-save-key", key, keymanager.KeyMetadata{ID: "trace-save-key", CreatedAt: time.Now()})).To(Succeed())
+			})
+		})
+
+		Context("LoadKey — error path", func() {
+			It("should call RecordError and StatusError when key is not found", func() {
+				mockTracer.EXPECT().Start(gomock.Any(), "DiskKeyStore.LoadKey", gomock.Any()).Return(ctx, mockSpan)
+				mockSpan.EXPECT().SetAttribute("key_id", "missing-trace-key")
+				mockSpan.EXPECT().SetStatus(tracing.StatusError, gomock.Any())
+				mockSpan.EXPECT().End()
+
+				_, _, err := tracingStore.LoadKey(ctx, "missing-trace-key")
+				Expect(err).To(MatchError(keymanager.ErrKeyStoreKeyNotFound))
 			})
 		})
 	})

--- a/pkg/keymanager/disk_test.go
+++ b/pkg/keymanager/disk_test.go
@@ -75,6 +75,27 @@ var _ = Describe("DiskKeyStore", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(ds).NotTo(BeNil())
 			})
+
+			It("should default to NoOpTracer when Tracer is nil", func() {
+				ds, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: 2048})
+				Expect(err).NotTo(HaveOccurred())
+				key := newTestKey()
+				Expect(ds.Save(ctx, "noop-tracer-key", key, keymanager.KeyMetadata{ID: "noop-tracer-key", CreatedAt: time.Now()})).To(Succeed())
+			})
+
+			It("should accept an explicit Tracer without error", func() {
+				ctrl := gomock.NewController(GinkgoT())
+				defer ctrl.Finish()
+				mockTracer := testutil.NewMockTracer(ctrl)
+				mockSpan := testutil.NewMockSpan(ctrl)
+				mockTracer.EXPECT().Start(gomock.Any(), gomock.Any(), gomock.Any()).Return(ctx, mockSpan).AnyTimes()
+				mockSpan.EXPECT().End().AnyTimes()
+				mockSpan.EXPECT().SetAttribute(gomock.Any(), gomock.Any()).AnyTimes()
+				mockSpan.EXPECT().SetStatus(gomock.Any(), gomock.Any()).AnyTimes()
+				ds, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: 2048, Tracer: mockTracer})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ds).NotTo(BeNil())
+			})
 		})
 
 		Context("with an invalid directory", func() {
@@ -606,36 +627,8 @@ var _ = Describe("DiskKeyStore", func() {
 		})
 	})
 
-	// ===== PHASE 10: Config =====
-	Describe("Phase 10: Config", func() {
-		It("should default to a NoOpTracer when Tracer is nil", func() {
-			ds, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: 2048})
-			Expect(err).NotTo(HaveOccurred())
-			// NoOpTracer: Save must not panic even though no tracer was provided explicitly.
-			key := newTestKey()
-			Expect(ds.Save(ctx, "noop-tracer-key", key, keymanager.KeyMetadata{ID: "noop-tracer-key", CreatedAt: time.Now()})).To(Succeed())
-		})
-
-		It("should store an explicit Tracer without error", func() {
-			ctrl := gomock.NewController(GinkgoT())
-			defer ctrl.Finish()
-
-			mockTracer := testutil.NewMockTracer(ctrl)
-			mockSpan := testutil.NewMockSpan(ctrl)
-
-			mockTracer.EXPECT().Start(gomock.Any(), gomock.Any(), gomock.Any()).Return(ctx, mockSpan).AnyTimes()
-			mockSpan.EXPECT().End().AnyTimes()
-			mockSpan.EXPECT().SetAttribute(gomock.Any(), gomock.Any()).AnyTimes()
-			mockSpan.EXPECT().SetStatus(gomock.Any(), gomock.Any()).AnyTimes()
-
-			ds, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: 2048, Tracer: mockTracer})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ds).NotTo(BeNil())
-		})
-	})
-
-	// ===== PHASE 11: Tracing =====
-	Describe("Phase 11: Tracing", func() {
+	// ===== PHASE 10: Tracing =====
+	Describe("Phase 10: Tracing", func() {
 		var (
 			ctrl        *gomock.Controller
 			mockTracer  *testutil.MockTracer

--- a/pkg/keymanager/disk_test.go
+++ b/pkg/keymanager/disk_test.go
@@ -76,11 +76,14 @@ var _ = Describe("DiskKeyStore", func() {
 				Expect(ds).NotTo(BeNil())
 			})
 
-			It("should default to NoOpTracer when Tracer is nil", func() {
-				ds, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: 2048})
+			It("should apply defaults from DiskKeyStoreConfigDefault when optional fields are nil", func() {
+				// Dir only — all optional fields nil/zero; must not panic on any operation.
+				ds, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir})
 				Expect(err).NotTo(HaveOccurred())
 				key := newTestKey()
-				Expect(ds.Save(ctx, "noop-tracer-key", key, keymanager.KeyMetadata{ID: "noop-tracer-key", CreatedAt: time.Now()})).To(Succeed())
+				Expect(ds.Save(ctx, "defaults-key", key, keymanager.KeyMetadata{ID: "defaults-key", CreatedAt: time.Now()})).To(Succeed())
+				_, _, err = ds.LoadKey(ctx, "defaults-key")
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should accept an explicit Tracer without error", func() {

--- a/pkg/keymanager/keymanager.go
+++ b/pkg/keymanager/keymanager.go
@@ -22,7 +22,7 @@
 // Example usage:
 //
 //	// Create a KeyStore (choose based on deployment)
-//	ks, err := keymanager.NewDiskKeyStore("./keys", 2048, logger, metrics)
+//	ks, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: "./keys", KeySize: 2048, Logger: logger, Metrics: metrics})
 //	if err != nil {
 //	    log.Fatal(err)
 //	}

--- a/pkg/tokens/integration/disk_memory_test.go
+++ b/pkg/tokens/integration/disk_memory_test.go
@@ -24,7 +24,7 @@ func diskMemoryFactory(cfg tokens.ManagerConfig) (*tokens.Manager, *keymanager.M
 	tmpDir, err := os.MkdirTemp("", "integration-disk-*")
 	Expect(err).NotTo(HaveOccurred())
 
-	ks, err := keymanager.NewDiskKeyStore(tmpDir, 2048, nil, nil)
+	ks, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: tmpDir, KeySize: 2048})
 	Expect(err).NotTo(HaveOccurred())
 
 	km, err := keymanager.NewManager(keymanager.ManagerConfig{


### PR DESCRIPTION
**Summary**

- Introduces DiskKeyStoreConfig (Dir, KeySize, Logger, Metrics, Tracer), replacing the old positional NewDiskKeyStore signature to match the ManagerConfig pattern
- Adds DiskKeyStoreConfigDefault() returning NoOp implementations for all three optional observability fields — consistent with ConfigDefault() in KeyManager and DefaultManagerConfig() in TokenManager
- NewDiskKeyStore applies defaults for any nil/zero-value field, so logger, metrics, and tracer are guaranteed non-nil after construction; existing nil guards are preserved for a future cleanup pass
- Adds a startSpan helper and instruments all 5 methods (LoadAll, Save, UpdateMetadata, LoadKey, Delete) with storage.backend="disk" and key_id attributes
- Updates all callers: 5 example main.go files, integration test, keymanager.go doc comment

**Test changes**

- All Phase 1–9 construction calls migrated to DiskKeyStoreConfig{}
- Phase 1 (Constructor): "should apply defaults from DiskKeyStoreConfigDefault when optional fields are nil" — Dir-only config exercises all methods without panic; "should accept an explicit Tracer without error" — verifies explicit tracer wiring
- Phase 10 (Tracing): MockTracer/MockSpan verifies span name, key_id attribute, StatusOK on success, StatusError on not-found

**Test plan**

- [x]  146/146 keymanager specs pass (go test -race ./pkg/keymanager/...)
- [x]  Full CI clean (bash run-ci-locally.sh)
