### PR TITLE
feat(keymanager): wire tracing into RedisKeyStore (Phase 2)

### DIFF
--- a/pkg/keymanager/redis.go
+++ b/pkg/keymanager/redis.go
@@ -15,7 +15,26 @@ import (
 
 	"github.com/aetomala/jwtauth/pkg/logging"
 	"github.com/aetomala/jwtauth/pkg/metrics"
+	"github.com/aetomala/jwtauth/pkg/tracing"
 )
+
+// RedisKeyStoreConfig holds configuration for a RedisKeyStore instance.
+type RedisKeyStoreConfig struct {
+	Client  *redis.Client   // Required; must not be nil.
+	Logger  logging.Logger  // Optional; nil defaults to NoOpLogger.
+	Metrics metrics.Metrics // Optional; nil defaults to NoOpMetrics.
+	Tracer  tracing.Tracer  // Optional; nil defaults to NoOpTracer.
+}
+
+// RedisKeyStoreConfigDefault returns a RedisKeyStoreConfig with NoOp defaults
+// for all optional observability fields.
+func RedisKeyStoreConfigDefault() RedisKeyStoreConfig {
+	return RedisKeyStoreConfig{
+		Logger:  &logging.NoOpLogger{},
+		Metrics: metrics.NewNoOpMetrics(),
+		Tracer:  tracing.NewNoOpTracer(),
+	}
+}
 
 // RedisKeyStore is a thread-safe, Redis-backed implementation of KeyStore.
 // Each key pair is persisted as a PKCS#1 PEM string alongside a companion
@@ -28,33 +47,48 @@ type RedisKeyStore struct {
 	client *redis.Client // Thread-safe Redis client
 
 	// ===== Observability =====
-	logger  logging.Logger  // Optional; nil disables logging
-	metrics metrics.Metrics // Optional; nil disables metrics
+	logger  logging.Logger  // never nil; defaults to NoOpLogger
+	metrics metrics.Metrics // never nil; defaults to NoOpMetrics
+	tracer  tracing.Tracer  // never nil; defaults to NoOpTracer
 	backend string          // always "redis"
 }
 
-// NewRedisKeyStore returns a new RedisKeyStore using the provided Redis client.
-// Returns ErrNilRedisClient if client is nil. Pass a logging.Logger for
-// structured log output; pass nil to disable logging. Pass a metrics.Metrics
-// for instrumentation; pass nil to disable metrics.
-func NewRedisKeyStore(client *redis.Client, logger logging.Logger, m metrics.Metrics) (*RedisKeyStore, error) {
+// NewRedisKeyStore returns a new RedisKeyStore using the provided config.
+// Returns ErrNilRedisClient if cfg.Client is nil.
+func NewRedisKeyStore(cfg RedisKeyStoreConfig) (*RedisKeyStore, error) {
 	// ===== STEP 1: Validate Client =====
-	if client == nil {
+	if cfg.Client == nil {
 		return nil, ErrNilRedisClient
 	}
 
-	// ===== STEP 2: Return Initialized Store =====
-	r := &RedisKeyStore{
-		client:  client,
+	// ===== STEP 2: Apply Defaults =====
+	defaults := RedisKeyStoreConfigDefault()
+	if cfg.Logger == nil {
+		cfg.Logger = defaults.Logger
+	}
+	if cfg.Metrics == nil {
+		cfg.Metrics = defaults.Metrics
+	}
+	if cfg.Tracer == nil {
+		cfg.Tracer = defaults.Tracer
+	}
+
+	// ===== STEP 3: Return Initialized Store =====
+	return &RedisKeyStore{
+		client:  cfg.Client,
+		logger:  cfg.Logger,
+		metrics: cfg.Metrics,
+		tracer:  cfg.Tracer,
 		backend: "redis",
-	}
-	if logger != nil {
-		r.logger = logger
-	}
-	if m != nil {
-		r.metrics = m
-	}
-	return r, nil
+	}, nil
+}
+
+// startSpan starts a new span for the given operation name, pre-seeded with
+// the storage.backend attribute.
+func (r *RedisKeyStore) startSpan(ctx context.Context, operation string) (context.Context, tracing.Span) {
+	return r.tracer.Start(ctx, "RedisKeyStore."+operation,
+		tracing.WithAttributes(map[string]any{"storage.backend": r.backend}),
+	)
 }
 
 // LoadAll returns every valid (non-expired) key in Redis. Keys with missing or
@@ -62,6 +96,9 @@ func NewRedisKeyStore(client *redis.Client, logger logging.Logger, m metrics.Met
 // valid keys exist — this is not an error. Returns the context error if the
 // context is cancelled before completion.
 func (r *RedisKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
+	ctx, span := r.startSpan(ctx, "LoadAll")
+	defer span.End()
+
 	start := time.Now()
 	status := "error"
 	errorType := "error"
@@ -90,6 +127,8 @@ func (r *RedisKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
 		errorType = "cancelled"
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
 		return nil, err
 	}
 
@@ -168,6 +207,8 @@ func (r *RedisKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 		if r.logger != nil {
 			r.logger.Error("failed to scan redis keys", ctx, "error", err)
 		}
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
 		return nil, fmt.Errorf("scan redis keys: %w", err)
 	}
 
@@ -178,6 +219,7 @@ func (r *RedisKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 	if r.logger != nil {
 		r.logger.Info("loaded keys from redis", ctx, "count", keyCount)
 	}
+	span.SetStatus(tracing.StatusOK, "")
 	return keys, nil
 }
 
@@ -185,6 +227,10 @@ func (r *RedisKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 // Both the PEM and metadata are written together — if either fails, neither is
 // stored. Returns the context error if the context is cancelled.
 func (r *RedisKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.PrivateKey, meta KeyMetadata) error {
+	ctx, span := r.startSpan(ctx, "Save")
+	defer span.End()
+	span.SetAttribute("key_id", keyID)
+
 	start := time.Now()
 	status := "error"
 	errorType := "error"
@@ -207,6 +253,8 @@ func (r *RedisKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
 		errorType = "cancelled"
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
 		return err
 	}
 
@@ -221,6 +269,8 @@ func (r *RedisKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.
 				"keyID", keyID,
 				"error", err)
 		}
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
 		return fmt.Errorf("marshal key metadata: %w", err)
 	}
 
@@ -235,6 +285,8 @@ func (r *RedisKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.
 				"keyID", keyID,
 				"error", err)
 		}
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
 		return fmt.Errorf("save key to redis: %w", err)
 	}
 
@@ -244,6 +296,7 @@ func (r *RedisKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.
 	if r.logger != nil {
 		r.logger.Info("saved key to redis", ctx, "keyID", keyID)
 	}
+	span.SetStatus(tracing.StatusOK, "")
 	return nil
 }
 
@@ -252,6 +305,10 @@ func (r *RedisKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.
 // Returns ErrKeyStoreKeyNotFound if no PEM key exists for keyID in Redis.
 // Returns the context error if the context is cancelled.
 func (r *RedisKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta KeyMetadata) error {
+	ctx, span := r.startSpan(ctx, "UpdateMetadata")
+	defer span.End()
+	span.SetAttribute("key_id", keyID)
+
 	start := time.Now()
 	status := "error"
 	errorType := "error"
@@ -274,6 +331,8 @@ func (r *RedisKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta K
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
 		errorType = "cancelled"
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
 		return err
 	}
 
@@ -285,11 +344,15 @@ func (r *RedisKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta K
 				"keyID", keyID,
 				"error", err)
 		}
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
 		return fmt.Errorf("check key existence: %w", err)
 	}
 	if exists == 0 {
 		status = "not_found"
 		errorType = "not_found"
+		span.RecordError(ErrKeyStoreKeyNotFound)
+		span.SetStatus(tracing.StatusError, ErrKeyStoreKeyNotFound.Error())
 		return ErrKeyStoreKeyNotFound
 	}
 
@@ -301,6 +364,8 @@ func (r *RedisKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta K
 				"keyID", keyID,
 				"error", err)
 		}
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
 		return fmt.Errorf("marshal key metadata: %w", err)
 	}
 
@@ -310,6 +375,8 @@ func (r *RedisKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta K
 				"keyID", keyID,
 				"error", err)
 		}
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
 		return fmt.Errorf("update metadata: %w", err)
 	}
 
@@ -319,6 +386,7 @@ func (r *RedisKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta K
 	if r.logger != nil {
 		r.logger.Info("updated key metadata", ctx, "keyID", keyID)
 	}
+	span.SetStatus(tracing.StatusOK, "")
 	return nil
 }
 
@@ -327,6 +395,10 @@ func (r *RedisKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta K
 // empty or whitespace-only, ErrKeyStoreKeyNotFound if the key does not exist
 // in Redis. Returns the context error if the context is cancelled.
 func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.PrivateKey, *KeyMetadata, error) {
+	ctx, span := r.startSpan(ctx, "LoadKey")
+	defer span.End()
+	span.SetAttribute("key_id", keyID)
+
 	start := time.Now()
 	status := "error"
 	errorType := "error"
@@ -349,6 +421,8 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
 		errorType = "cancelled"
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
 		return nil, nil, err
 	}
 
@@ -356,6 +430,8 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 	if strings.TrimSpace(keyID) == "" {
 		status = "not_found"
 		errorType = "not_found"
+		span.RecordError(ErrKeyStoreInvalidKeyID)
+		span.SetStatus(tracing.StatusError, ErrKeyStoreInvalidKeyID.Error())
 		return nil, nil, ErrKeyStoreInvalidKeyID
 	}
 
@@ -365,6 +441,8 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 		if errors.Is(err, redis.Nil) {
 			status = "not_found"
 			errorType = "not_found"
+			span.RecordError(ErrKeyStoreKeyNotFound)
+			span.SetStatus(tracing.StatusError, ErrKeyStoreKeyNotFound.Error())
 			return nil, nil, ErrKeyStoreKeyNotFound
 		}
 		if r.logger != nil {
@@ -372,6 +450,8 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 				"keyID", keyID,
 				"error", err)
 		}
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
 		return nil, nil, fmt.Errorf("load key: %w", err)
 	}
 
@@ -382,6 +462,8 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 				"keyID", keyID,
 				"error", err)
 		}
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
 		return nil, nil, fmt.Errorf("parse key PEM: %w", err)
 	}
 
@@ -391,6 +473,8 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 		if errors.Is(err, redis.Nil) {
 			status = "not_found"
 			errorType = "not_found"
+			span.RecordError(ErrKeyStoreKeyNotFound)
+			span.SetStatus(tracing.StatusError, ErrKeyStoreKeyNotFound.Error())
 			return nil, nil, ErrKeyStoreKeyNotFound
 		}
 		if r.logger != nil {
@@ -398,6 +482,8 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 				"keyID", keyID,
 				"error", err)
 		}
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
 		return nil, nil, fmt.Errorf("load metadata: %w", err)
 	}
 
@@ -408,6 +494,8 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 				"keyID", keyID,
 				"error", err)
 		}
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
 		return nil, nil, fmt.Errorf("parse metadata: %w", err)
 	}
 
@@ -417,6 +505,7 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 	if r.logger != nil {
 		r.logger.Debug("loaded key from redis", ctx, "keyID", keyID)
 	}
+	span.SetStatus(tracing.StatusOK, "")
 	return privateKey, &meta, nil
 }
 
@@ -424,6 +513,10 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 // If the key does not exist, no error is returned — the call is idempotent.
 // Returns the context error if the context is cancelled.
 func (r *RedisKeyStore) Delete(ctx context.Context, keyID string) error {
+	ctx, span := r.startSpan(ctx, "Delete")
+	defer span.End()
+	span.SetAttribute("key_id", keyID)
+
 	start := time.Now()
 	status := "error"
 	errorType := "error"
@@ -446,6 +539,8 @@ func (r *RedisKeyStore) Delete(ctx context.Context, keyID string) error {
 	if err := ctx.Err(); err != nil {
 		status = "cancelled"
 		errorType = "cancelled"
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
 		return err
 	}
 
@@ -456,6 +551,8 @@ func (r *RedisKeyStore) Delete(ctx context.Context, keyID string) error {
 				"keyID", keyID,
 				"error", err)
 		}
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
 		return fmt.Errorf("delete key from redis: %w", err)
 	}
 
@@ -465,6 +562,7 @@ func (r *RedisKeyStore) Delete(ctx context.Context, keyID string) error {
 	if r.logger != nil {
 		r.logger.Info("deleted key from redis", ctx, "keyID", keyID)
 	}
+	span.SetStatus(tracing.StatusOK, "")
 	return nil
 }
 

--- a/pkg/keymanager/redis_test.go
+++ b/pkg/keymanager/redis_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/aetomala/jwtauth/internal/testutil"
 	"github.com/aetomala/jwtauth/pkg/keymanager"
+	"github.com/aetomala/jwtauth/pkg/tracing"
 )
 
 var _ = Describe("RedisKeyStore", func() {
@@ -34,7 +35,7 @@ var _ = Describe("RedisKeyStore", func() {
 			Addr: miniRedis.Addr(),
 		})
 
-		rs, err = keymanager.NewRedisKeyStore(client, nil, nil)
+		rs, err = keymanager.NewRedisKeyStore(keymanager.RedisKeyStoreConfig{Client: client})
 		Expect(err).NotTo(HaveOccurred())
 
 		ctx = context.Background()
@@ -51,22 +52,46 @@ var _ = Describe("RedisKeyStore", func() {
 	Describe("Phase 1: Constructor and Initialization", func() {
 		Context("with a valid client", func() {
 			It("should create a RedisKeyStore successfully", func() {
-				store, err := keymanager.NewRedisKeyStore(client, nil, nil)
+				store, err := keymanager.NewRedisKeyStore(keymanager.RedisKeyStoreConfig{Client: client})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(store).NotTo(BeNil())
 			})
 
 			It("should accept a logger and metrics without error", func() {
 				mockLogger := testutil.NewMockLogger()
-				store, err := keymanager.NewRedisKeyStore(client, mockLogger, nil)
+				store, err := keymanager.NewRedisKeyStore(keymanager.RedisKeyStoreConfig{Client: client, Logger: mockLogger})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(store).NotTo(BeNil())
+			})
+
+			It("should apply defaults from RedisKeyStoreConfigDefault when optional fields are nil", func() {
+				store, err := keymanager.NewRedisKeyStore(keymanager.RedisKeyStoreConfig{Client: client})
+				Expect(err).NotTo(HaveOccurred())
+				key := newTestKey()
+				Expect(store.Save(ctx, "defaults-key", key, keymanager.KeyMetadata{ID: "defaults-key", CreatedAt: time.Now()})).To(Succeed())
+				_, _, err = store.LoadKey(ctx, "defaults-key")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should accept an explicit Tracer without error", func() {
+				ctrl := gomock.NewController(GinkgoT())
+				defer ctrl.Finish()
+				mockTracer := testutil.NewMockTracer(ctrl)
+				mockSpan := testutil.NewMockSpan(ctrl)
+				mockTracer.EXPECT().Start(gomock.Any(), gomock.Any(), gomock.Any()).Return(ctx, mockSpan).AnyTimes()
+				mockSpan.EXPECT().End().AnyTimes()
+				mockSpan.EXPECT().SetAttribute(gomock.Any(), gomock.Any()).AnyTimes()
+				mockSpan.EXPECT().SetStatus(gomock.Any(), gomock.Any()).AnyTimes()
+				store, err := keymanager.NewRedisKeyStore(keymanager.RedisKeyStoreConfig{Client: client, Tracer: mockTracer})
+				Expect(err).NotTo(HaveOccurred())
+				key := newTestKey()
+				Expect(store.Save(ctx, "tracer-key", key, keymanager.KeyMetadata{ID: "tracer-key", CreatedAt: time.Now()})).To(Succeed())
 			})
 		})
 
 		Context("with a nil client", func() {
 			It("should return ErrNilRedisClient", func() {
-				_, err := keymanager.NewRedisKeyStore(nil, nil, nil)
+				_, err := keymanager.NewRedisKeyStore(keymanager.RedisKeyStoreConfig{})
 				Expect(err).To(MatchError(keymanager.ErrNilRedisClient))
 			})
 		})
@@ -430,7 +455,7 @@ var _ = Describe("RedisKeyStore", func() {
 		AfterEach(func() { ctrl.Finish() })
 
 		newMetricStore := func() *keymanager.RedisKeyStore {
-			store, err := keymanager.NewRedisKeyStore(client, nil, mockM)
+			store, err := keymanager.NewRedisKeyStore(keymanager.RedisKeyStoreConfig{Client: client, Metrics: mockM})
 			Expect(err).NotTo(HaveOccurred())
 			return store
 		}
@@ -526,6 +551,52 @@ var _ = Describe("RedisKeyStore", func() {
 					_ = rs.UpdateMetadata(ctx, "nil-metrics-key", keymanager.KeyMetadata{ID: "nil-metrics-key", CreatedAt: time.Now()})
 				}).NotTo(Panic())
 				Expect(func() { _ = rs.Delete(ctx, "nil-metrics-key") }).NotTo(Panic())
+			})
+		})
+	})
+
+	// ===== PHASE 10: Tracing =====
+	Describe("Phase 10: Tracing", func() {
+		var (
+			ctrl         *gomock.Controller
+			mockTracer   *testutil.MockTracer
+			mockSpan     *testutil.MockSpan
+			tracingStore *keymanager.RedisKeyStore
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			mockTracer = testutil.NewMockTracer(ctrl)
+			mockSpan = testutil.NewMockSpan(ctrl)
+			var err error
+			tracingStore, err = keymanager.NewRedisKeyStore(keymanager.RedisKeyStoreConfig{Client: client, Tracer: mockTracer})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() { ctrl.Finish() })
+
+		Context("Save — success path", func() {
+			It("should start a span named RedisKeyStore.Save with storage.backend, key_id and StatusOK", func() {
+				mockTracer.EXPECT().Start(gomock.Any(), "RedisKeyStore.Save", gomock.Any()).Return(ctx, mockSpan)
+				mockSpan.EXPECT().SetAttribute("key_id", "trace-save-key")
+				mockSpan.EXPECT().SetStatus(tracing.StatusOK, "")
+				mockSpan.EXPECT().End()
+
+				key := newTestKey()
+				Expect(tracingStore.Save(ctx, "trace-save-key", key, keymanager.KeyMetadata{ID: "trace-save-key", CreatedAt: time.Now()})).To(Succeed())
+			})
+		})
+
+		Context("LoadKey — error path", func() {
+			It("should call RecordError and StatusError when key is not found", func() {
+				mockTracer.EXPECT().Start(gomock.Any(), "RedisKeyStore.LoadKey", gomock.Any()).Return(ctx, mockSpan)
+				mockSpan.EXPECT().SetAttribute("key_id", "missing-trace-key")
+				mockSpan.EXPECT().RecordError(keymanager.ErrKeyStoreKeyNotFound)
+				mockSpan.EXPECT().SetStatus(tracing.StatusError, gomock.Any())
+				mockSpan.EXPECT().End()
+
+				_, _, err := tracingStore.LoadKey(ctx, "missing-trace-key")
+				Expect(err).To(MatchError(keymanager.ErrKeyStoreKeyNotFound))
 			})
 		})
 	})

--- a/pkg/tokens/integration/redis_test.go
+++ b/pkg/tokens/integration/redis_test.go
@@ -55,7 +55,7 @@ func init() {
 			// because both TokenManagers read from the same Redis refresh store.
 
 			// Instance A — own KeyManager, own TokenManager, shared Redis backend
-			ksA, err := keymanager.NewRedisKeyStore(client, nil, nil)
+			ksA, err := keymanager.NewRedisKeyStore(keymanager.RedisKeyStoreConfig{Client: client})
 			Expect(err).NotTo(HaveOccurred())
 
 			kmA, err := keymanager.NewManager(keymanager.ManagerConfig{
@@ -83,7 +83,7 @@ func init() {
 			})
 
 			// Instance B — own KeyManager (loads A's keys from Redis), own TokenManager, shared refresh store
-			ksB, err := keymanager.NewRedisKeyStore(client, nil, nil)
+			ksB, err := keymanager.NewRedisKeyStore(keymanager.RedisKeyStoreConfig{Client: client})
 			Expect(err).NotTo(HaveOccurred())
 
 			kmB, err := keymanager.NewManager(keymanager.ManagerConfig{
@@ -138,7 +138,7 @@ func init() {
 			// Instance B starts fresh (new Manager, same Redis key store) and must be able
 			// to validate tokens signed by both the pre- and post-rotation keys of instance A.
 
-			ksA, err := keymanager.NewRedisKeyStore(client, nil, nil)
+			ksA, err := keymanager.NewRedisKeyStore(keymanager.RedisKeyStoreConfig{Client: client})
 			Expect(err).NotTo(HaveOccurred())
 
 			kmA, err := keymanager.NewManager(keymanager.ManagerConfig{
@@ -179,7 +179,7 @@ func init() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Instance B starts with the same Redis key store — loads all keys on Start
-			ksB, err := keymanager.NewRedisKeyStore(client, nil, nil)
+			ksB, err := keymanager.NewRedisKeyStore(keymanager.RedisKeyStoreConfig{Client: client})
 			Expect(err).NotTo(HaveOccurred())
 
 			kmB, err := keymanager.NewManager(keymanager.ManagerConfig{
@@ -226,7 +226,7 @@ func redisFactory(cfg tokens.ManagerConfig) (*tokens.Manager, *keymanager.Manage
 
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 
-	ks, err := keymanager.NewRedisKeyStore(client, nil, nil)
+	ks, err := keymanager.NewRedisKeyStore(keymanager.RedisKeyStoreConfig{Client: client})
 	Expect(err).NotTo(HaveOccurred())
 
 	km, err := keymanager.NewManager(keymanager.ManagerConfig{


### PR DESCRIPTION
**Summary**

- Introduces RedisKeyStoreConfig / RedisKeyStoreConfigDefault() — same shape as DiskKeyStoreConfig; Logger, Metrics, and Tracer all default to NoOp implementations and are never nil after construction
- Replaces the positional NewRedisKeyStore(client, logger, metrics) constructor with NewRedisKeyStore(cfg RedisKeyStoreConfig)
- Adds startSpan helper; all 5 methods (LoadAll, Save, UpdateMetadata, LoadKey, Delete) instrumented with RedisKeyStore.<Method> span name, storage.backend + key_id attributes, StatusOK on success, RecordError+StatusError on error paths
- redis_test.go: all constructors updated to config-struct form; Phase 1 adds DefaultConfig and explicit-Tracer constructor tests; Phase 10 adds tracing tests (Save success path, LoadKey error path)
- integration/redis_test.go: all NewRedisKeyStore call sites updated

**Test plan**

- [x]  All 150 unit tests pass (pkg/keymanager — 150 specs)
- [x]  All 28 integration tests pass (pkg/tokens/integration)
- [x]  Remote CI lint (golangci-lint v2.11.4) passes