### PR TITLE
docs(tracing): document distributed tracing across all six components…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **`DiskKeyStore`, `RedisKeyStore`, `MemoryRefreshStore`, `RedisRefreshStore` constructors migrated to config-struct form** — positional parameter constructors removed; update call sites:
+  - `keymanager.NewDiskKeyStore(dir, keySize, logger, metrics)` → `keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: keySize, Logger: logger, Metrics: metrics})`
+  - `keymanager.NewRedisKeyStore(client, logger, metrics)` → `keymanager.NewRedisKeyStore(keymanager.RedisKeyStoreConfig{Client: client, Logger: logger, Metrics: metrics})`
+  - `storage.NewMemoryRefreshStore(logger, metrics)` → `storage.NewMemoryRefreshStore(storage.MemoryRefreshStoreConfig{Logger: logger, Metrics: metrics})`
+  - `storage.NewRedisRefreshStore(client, logger, metrics)` → `storage.NewRedisRefreshStore(storage.RedisRefreshStoreConfig{Client: client, Logger: logger, Metrics: metrics})`
+
 - **`tokens.Service` → `tokens.Manager`** — The core token lifecycle type is renamed. Update all call sites:
   - `tokens.NewService(tokens.ServiceConfig{...})` → `tokens.NewManager(tokens.ManagerConfig{...})`
   - `tokens.ConfigDefault()` → `tokens.DefaultManagerConfig()`
@@ -17,6 +23,14 @@ All notable changes to this project will be documented in this file.
 - **`AuthMiddleware` → `BearerMiddleware`** in all example middleware packages (`examples/gin-example/middleware`, `examples/chi-example/auth`, `examples/echo-example/middleware`). Rename call sites accordingly.
 
 ### Added
+
+- **Distributed tracing wired into all six components** via `pkg/tracing.Tracer` interface — every constructor accepts an optional `Tracer` field (defaults to `NoOpTracer`):
+  - `DiskKeyStore` — spans for Load, Save, Delete, UpdateMetadata; attributes: `storage.backend = "disk"`, `key_id`
+  - `RedisKeyStore` — same operations; `storage.backend = "redis"`
+  - `MemoryRefreshStore` — spans for Store, Retrieve, Revoke, RevokeAllForUser, Cleanup; attribute: `token_id`
+  - `RedisRefreshStore` — same operations; `storage.backend = "redis"`
+  - `KeyManager` — spans for Start, Shutdown, and all key operations; attribute: `key_id`
+  - `TokenManager` — spans for all 14 public methods; attributes: `user_id`, `token_id`, `active` (IntrospectToken), `deleted_count` (CleanupExpiredTokens)
 
 - **`KeyInfo` struct** — public metadata type in `pkg/keymanager` exposing `KeyID`, `CreatedAt`, `RotateAt` (estimated, current key only), `ExpiresAt`, `KeySizeBits`, `Algorithm`, `IsCurrent`, and `IsValid`. Contains no private key material — safe to serve from health check or admin endpoints.
 

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ You've already verified identity and need **production-grade token machinery** f
 
 ### 🚧 In Development (v0.4.0)
 
-- **OpenTelemetry / Distributed Tracing**: `pkg/tracing` interfaces (`Tracer`, `Span`) and `NoOpTracer` are scaffolded. Full wiring into KeyManager, TokenManager, and RefreshStore — with an OpenTelemetry adapter — is planned for v0.4.0.
+- **OpenTelemetry / Distributed Tracing**: Tracing is now wired into all six components (`DiskKeyStore`, `RedisKeyStore`, `MemoryRefreshStore`, `RedisRefreshStore`, `KeyManager`, `TokenManager`). Every constructor accepts an optional `Tracer` field — defaults to `NoOpTracer` for zero-config operation. `OtelTracer` is available for production use via `tracing.NewOtelTracer("scope")`. v0.4.0 is still in progress.
 
 ## Architecture Highlights
 
@@ -317,9 +317,13 @@ import (
     "github.com/aetomala/jwtauth/pkg/keymanager"
     "github.com/aetomala/jwtauth/pkg/logging"
     "github.com/aetomala/jwtauth/pkg/metrics"
+    "github.com/aetomala/jwtauth/pkg/tracing"
 )
 
-ks, _ := keymanager.NewDiskKeyStore("/var/keys", 2048, nil, nil)
+ks, _ := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{
+    Dir:    "/var/keys",
+    Logger: logging.NewJSONLogger(slog.LevelInfo),
+})
 config := keymanager.ManagerConfig{
     KeyStore:            ks,
     KeyRotationInterval: 30 * 24 * time.Hour, // 30 days
@@ -332,6 +336,9 @@ config := keymanager.ManagerConfig{
     Metrics: metrics.NewPrometheusMetrics(metrics.PrometheusConfig{
         Namespace: "myapp",
     }),
+
+    // Optional: Bring your own tracer (defaults to NoOpTracer)
+    Tracer: tracing.NewOtelTracer("jwtauth"),
 }
 ```
 
@@ -398,7 +405,7 @@ import (
 
 func main() {
     // Create DiskKeyStore for key persistence
-    ks, err := keymanager.NewDiskKeyStore("./keys", 2048, nil, nil)
+    ks, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: "./keys"})
     if err != nil {
         log.Fatal(err)
     }
@@ -479,7 +486,7 @@ func main() {
     logger := logging.NewJSONLogger(slog.LevelInfo)
     pm := metrics.NewPrometheusMetrics(metrics.PrometheusConfig{})
 
-    ks, err := keymanager.NewDiskKeyStore("./keys", 2048, logger, pm)
+    ks, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: "./keys", Logger: logger, Metrics: pm})
     if err != nil {
         log.Fatal(err)
     }
@@ -734,7 +741,10 @@ and your `RefreshStore` to handle the complete authentication flow.
 
 **Production (single-instance)**:
 ```go
-ks, _ := keymanager.NewDiskKeyStore("./keys", 2048, nil, nil)
+ks, _ := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{
+    Dir:    "./keys",
+    Logger: logging.NewJSONLogger(slog.LevelInfo),
+})
 config := keymanager.ManagerConfig{
     KeyStore:            ks,
     KeyRotationInterval: 30 * 24 * time.Hour,  // 30 days
@@ -746,7 +756,7 @@ config := keymanager.ManagerConfig{
 **Production (distributed / multi-instance)**:
 ```go
 client := redis.NewClient(&redis.Options{Addr: "redis:6379"})
-ks, _ := keymanager.NewRedisKeyStore(client, logger, nil)
+ks, _ := keymanager.NewRedisKeyStore(keymanager.RedisKeyStoreConfig{Client: client, Logger: logger})
 config := keymanager.ManagerConfig{
     KeyStore:            ks,
     KeyRotationInterval: 30 * 24 * time.Hour,
@@ -757,7 +767,10 @@ config := keymanager.ManagerConfig{
 
 **Development**:
 ```go
-ks, _ := keymanager.NewDiskKeyStore("./keys", 2048, nil, nil)
+ks, _ := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{
+    Dir:    "./keys",
+    Logger: logging.NewTextLogger(slog.LevelDebug),
+})
 config := keymanager.ManagerConfig{
     KeyStore:            ks,
     KeyRotationInterval: 24 * time.Hour,        // 1 day (faster testing)
@@ -914,9 +927,9 @@ pm := metrics.NewPrometheusMetrics(metrics.PrometheusConfig{
 http.Handle("/metrics", pm.Handler())
 
 // Pass pm to every constructor that accepts it
-ks, _ := keymanager.NewDiskKeyStore("./keys", 2048, logger, pm)
+ks, _ := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: "./keys", Logger: logger, Metrics: pm})
 km, _ := keymanager.NewManager(keymanager.ManagerConfig{KeyStore: ks, Metrics: pm})
-store := storage.NewMemoryRefreshStore(logger, pm)
+store := storage.NewMemoryRefreshStore(storage.MemoryRefreshStoreConfig{Logger: logger, Metrics: pm})
 mgr, _ := tokens.NewManager(tokens.ManagerConfig{
     KeyManager:   km,
     RefreshStore: store,
@@ -982,6 +995,54 @@ For the full operator reference including Grafana dashboard guidance and label c
 - StatsD (for Datadog, Graphite)
 - CloudWatch (for AWS environments)
 
+### Distributed Tracing
+
+Every component emits OpenTelemetry-compatible spans. Tracing is opt-in — all constructors default to `NoOpTracer` so existing code requires no changes.
+
+**Quick start**:
+
+```go
+import (
+    "go.opentelemetry.io/otel"
+    "github.com/aetomala/jwtauth/pkg/tracing"
+    "github.com/aetomala/jwtauth/pkg/keymanager"
+    "github.com/aetomala/jwtauth/pkg/storage"
+    "github.com/aetomala/jwtauth/pkg/tokens"
+)
+
+// Wire your OTel TracerProvider (OTLP, Jaeger, Tempo, etc.) then:
+tracer := tracing.NewOtelTracer("jwtauth")
+
+ks, _ := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{
+    Dir:    "./keys",
+    Tracer: tracer,
+})
+km, _ := keymanager.NewManager(keymanager.ManagerConfig{
+    KeyStore: ks,
+    Tracer:   tracer,
+})
+store := storage.NewMemoryRefreshStore(storage.MemoryRefreshStoreConfig{Tracer: tracer})
+mgr, _ := tokens.NewManager(tokens.ManagerConfig{
+    KeyManager:   km,
+    RefreshStore: store,
+    Tracer:       tracer,
+})
+```
+
+**Span naming**: `<TypeName>.<MethodName>` — e.g., `TokenManager.IssueAccessToken`, `DiskKeyStore.Save`.
+
+**Span attributes by component**:
+
+| Component | Attributes |
+|-----------|-----------|
+| `DiskKeyStore` / `RedisKeyStore` | `storage.backend` (`"disk"` / `"redis"`), `key_id` |
+| `MemoryRefreshStore` / `RedisRefreshStore` | `storage.backend` (`"memory"` / `"redis"`), `token_id` |
+| `KeyManager` | `key_id` |
+| `TokenManager` | `user_id`, `token_id`, `active` (IntrospectToken), `deleted_count` (CleanupExpiredTokens) |
+
+All spans set `StatusOK` on success and `RecordError` + `StatusError` on failure. For deployment setup and `TracerProvider` configuration, see [doc/DEPLOYMENT.md](doc/DEPLOYMENT.md).
+
+
 ## Project Structure
 
 ```
@@ -1007,8 +1068,8 @@ github.com/aetomala/jwtauth/
 │   │   ├── redis.go              # RedisKeyStore — Redis-backed KeyStore for distributed deployments
 │   │   ├── observability.go      # Metric name constants (KeyStore + Manager)
 │   │   ├── keymanager_test.go    # 9-phase Manager tests (52 specs, MockKeyStore)
-│   │   ├── disk_test.go          # 9-phase DiskKeyStore tests (38 specs)
-│   │   └── redis_test.go         # 9-phase RedisKeyStore tests (35 specs, miniredis)
+│   │   ├── disk_test.go          # 10-phase DiskKeyStore tests (42 specs)
+│   │   └── redis_test.go         # 10-phase RedisKeyStore tests (39 specs, miniredis)
 │   ├── tokens/                   # JWT operations (Beta) 🟡
 │   │   ├── manager.go            # TokenManager implementation
 │   │   ├── claims.go             # Claims management
@@ -1058,11 +1119,11 @@ github.com/aetomala/jwtauth/
   - RotateKeys: Save + UpdateMetadata calls, currentKeyID update
   - Shutdown: scheduler stop, idempotency, context timeout
   - Metrics recording: rotation counter/duration, signing/validation counters, active-versions gauge
-- **9-phase DiskKeyStore tests** (38 specs, real tmp directory):
+- **10-phase DiskKeyStore tests** (42 specs, real tmp directory):
   - Constructor, Save (0600 permissions, companion JSON), LoadAll
   - LoadKey (key size validation), UpdateMetadata, Delete (idempotent)
-  - Error handling, concurrency, metrics recording (storage_backend: "disk")
-- **9-phase RedisKeyStore tests** (35 specs, miniredis):
+  - Error handling, concurrency, metrics recording (storage_backend: "disk"), tracing
+- **10-phase RedisKeyStore tests** (39 specs, miniredis):
   - Constructor (nil client returns ErrNilRedisClient), Save round-trip, LoadAll (skip expired)
   - LoadKey, UpdateMetadata, Delete (idempotent)
   - Error handling: corrupt metadata, missing metadata entry, Redis unavailability via SetError
@@ -1171,12 +1232,13 @@ Tests follow **progressive phase-based development**:
 - ✅ Context cancellation guards in `GetJWKS` and `cleanupExpiredKeys`
 - ✅ Redis integration tests via miniredis covering distributed token operations end-to-end
 
-### v0.4.0 (Next)
+### v0.4.0 (In Progress)
 - ✅ `pkg/tracing` interfaces scaffolded — `Tracer`, `Span`, `SpanOption`, `StatusCode`, `SpanKind`
 - ✅ `NoOpTracer` / `NoOpSpan` implementations (36 tests, race-detection clean)
 - ✅ `MockTracer` / `MockSpan` generated for dependency injection in component tests
-- 🚧 Wire tracing into KeyManager, TokenManager, and RefreshStore
-- 🚧 OpenTelemetry adapter (`pkg/tracing/otel`) bridging `pkg/tracing.Tracer` to `go.opentelemetry.io/otel`
+- ✅ Tracing wired into all six components — `DiskKeyStore`, `RedisKeyStore`, `MemoryRefreshStore`, `RedisRefreshStore`, `KeyManager`, `TokenManager`
+- ✅ `OtelTracer` adapter (`pkg/tracing/otel`) bridging `pkg/tracing.Tracer` to `go.opentelemetry.io/otel`
+- 🚧 Additional v0.4.0 items in progress
 
 ### v1.0.0 (Stable)
 - API stability guarantee

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -198,7 +198,7 @@ github.com/aetomala/jwtauth/
 │     User's Observability Stack               │
 │  ┌─────────┐  ┌────────────┐  ┌──────────┐ │
 │  │  slog   │  │Prometheus  │  │   OTel   │ │
-│  │  Zap    │  │  StatsD    │  │  (Future)│ │
+│  │  Zap    │  │  StatsD    │  │  Jaeger  │ │
 │  │ Zerolog │  │CloudWatch  │  │          │ │
 │  └─────────┘  └────────────┘  └──────────┘ │
 └─────────────────────────────────────────────┘
@@ -380,6 +380,66 @@ func (m *Manager) RotateKeys(ctx context.Context) error {
             time.Since(start), map[string]string{"operation": "rotate"})
     }
     
+    return nil
+}
+```
+
+### Distributed Tracing
+
+**Interface**: `pkg/tracing/Tracer`
+
+**Design Decisions**:
+- **Thin abstraction** — `Tracer` and `Span` interfaces wrap OTel concepts without importing the OTel SDK in the core library
+- **Always non-nil** — every constructor applies `NoOpTracer` as default; no nil checks required in method bodies
+- **`startSpan` helper per component** — encapsulates span naming prefix so all spans follow `<TypeName>.<MethodName>` convention without repetition
+
+**Interface**:
+```go
+type Tracer interface {
+    Start(ctx context.Context, name string, opts ...SpanOption) (context.Context, Span)
+}
+
+type Span interface {
+    End()
+    SetAttribute(key string, value any)
+    SetStatus(code StatusCode, description string)
+    RecordError(err error)
+}
+```
+
+**Implementations**:
+- `NoOpTracer` / `NoOpSpan` — zero-allocation, race-detection clean; used as default in all constructors
+- `OtelTracer` — bridges `pkg/tracing.Tracer` to `go.opentelemetry.io/otel`; initialized with `tracing.NewOtelTracer("scope")`
+
+**Span naming convention**: `<TypeName>.<MethodName>` — e.g., `TokenManager.IssueAccessToken`, `DiskKeyStore.Save`
+
+**Span attributes by layer**:
+
+| Component | Attributes |
+|-----------|-----------|
+| `DiskKeyStore` / `RedisKeyStore` | `storage.backend` (`"disk"` / `"redis"`), `key_id` |
+| `MemoryRefreshStore` / `RedisRefreshStore` | `storage.backend` (`"memory"` / `"redis"`), `token_id` |
+| `KeyManager` | `key_id` |
+| `TokenManager` | `user_id`, `token_id`, `active` (IntrospectToken), `deleted_count` (CleanupExpiredTokens) |
+
+**Status conventions**: `StatusOK` on all success paths; `RecordError(err)` + `StatusError` on all error paths. Wrapped errors (via `fmt.Errorf("...: %w", err)`) are passed to `RecordError` so the full message propagates to the trace backend.
+
+**Integration Pattern** — every component follows the same shape:
+```go
+type DiskKeyStore struct {
+    tracer tracing.Tracer // never nil; defaults to NoOpTracer
+}
+
+func (d *DiskKeyStore) startSpan(ctx context.Context, op string, opts ...tracing.SpanOption) (context.Context, tracing.Span) {
+    return d.tracer.Start(ctx, "DiskKeyStore."+op, opts...)
+}
+
+func (d *DiskKeyStore) Save(ctx context.Context, key *KeyInfo) error {
+    ctx, span := d.startSpan(ctx, "Save")
+    defer span.End()
+    // ...
+    span.SetAttribute("key_id", key.ID)
+    span.SetStatus(tracing.StatusOK, "")
     return nil
 }
 ```
@@ -986,12 +1046,13 @@ Catches:
 - ✅ Context cancellation guards in `GetJWKS` and `cleanupExpiredKeys` with warning log on early return
 - ✅ Redis integration tests via miniredis (`pkg/tokens/integration`) covering distributed token operations end-to-end
 
-### Phase 6: Distributed Tracing (v0.4.0)
+### Phase 6: Distributed Tracing (v0.4.0 — In Progress)
 - ✅ `pkg/tracing` — `Tracer` and `Span` interfaces defined; `SpanOption` functional options; `StatusCode` and `SpanKind` enumerations
 - ✅ `NoOpTracer` / `NoOpSpan` — zero-allocation implementations; 36 tests, race-detection clean
 - ✅ `MockTracer` / `MockSpan` generated via gomock for dependency injection in component tests
-- ⏳ Wire tracing into KeyManager, TokenManager, and RefreshStore
-- ⏳ OpenTelemetry adapter (`pkg/tracing/otel`) bridging `pkg/tracing.Tracer` to `go.opentelemetry.io/otel`
+- ✅ Tracing wired into all six components — `DiskKeyStore`, `RedisKeyStore`, `MemoryRefreshStore`, `RedisRefreshStore`, `KeyManager`, `TokenManager`
+- ✅ `OtelTracer` adapter (`pkg/tracing/otel`) bridging `pkg/tracing.Tracer` to `go.opentelemetry.io/otel`
+- 🚧 Additional v0.4.0 items in progress
 
 ---
 
@@ -1090,4 +1151,4 @@ func (c *Component) Operation() error {
 
 **Last Updated**: April 14, 2026
 **Version**: 0.3.0-beta
-**Status**: Active Development (KeyManager + DiskKeyStore + RedisKeyStore + RefreshStore [Memory + Redis] + Metrics [Prometheus] + Logging [Correlation ID] stable and fully instrumented; Distributed Tracing interfaces scaffolded — full wiring planned for v0.4.0)
+**Status**: Active Development (KeyManager + DiskKeyStore + RedisKeyStore + RefreshStore [Memory + Redis] + Metrics [Prometheus] + Logging [Correlation ID] + Distributed Tracing stable and fully instrumented; v0.4.0 in progress)

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -159,6 +159,78 @@ For the complete metric reference — all 22 metrics with label values and PromQ
 
 ---
 
+## Distributed Tracing
+
+jwtauth emits OpenTelemetry-compatible spans via `pkg/tracing`. By default every component uses `NoOpTracer` — no setup required for local development. For production, initialize a `TracerProvider` and pass `tracing.NewOtelTracer("jwtauth")` into each config.
+
+### OTel SDK Setup
+
+```go
+import (
+    "go.opentelemetry.io/otel"
+    "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+    "go.opentelemetry.io/otel/sdk/trace"
+    "github.com/aetomala/jwtauth/pkg/tracing"
+    "github.com/aetomala/jwtauth/pkg/keymanager"
+    "github.com/aetomala/jwtauth/pkg/storage"
+    "github.com/aetomala/jwtauth/pkg/tokens"
+)
+
+// 1. Create an OTLP exporter (Jaeger, Tempo, or any OTLP-compatible backend)
+exporter, err := otlptracehttp.New(ctx,
+    otlptracehttp.WithEndpoint("http://localhost:4318"),
+)
+if err != nil {
+    log.Fatal(err)
+}
+
+// 2. Build a TracerProvider with your preferred sampler
+tp := trace.NewTracerProvider(
+    trace.WithBatcher(exporter),
+    trace.WithSampler(trace.AlwaysSample()), // adjust for production
+)
+otel.SetTracerProvider(tp)
+defer tp.Shutdown(ctx)
+
+// 3. Create a jwtauth tracer and pass it to every component
+tracer := tracing.NewOtelTracer("jwtauth")
+
+ks, _ := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{
+    Dir:    "./keys",
+    Tracer: tracer,
+})
+km, _ := keymanager.NewManager(keymanager.ManagerConfig{
+    KeyStore: ks,
+    Tracer:   tracer,
+})
+store := storage.NewMemoryRefreshStore(storage.MemoryRefreshStoreConfig{Tracer: tracer})
+mgr, _ := tokens.NewManager(tokens.ManagerConfig{
+    KeyManager:   km,
+    RefreshStore: store,
+    Tracer:       tracer,
+})
+```
+
+### Sampler Recommendations
+
+| Environment | Sampler | Rationale |
+|-------------|---------|-----------|
+| Development | `AlwaysSample` | Capture every span for debugging |
+| Staging | `TraceIDRatioBased(0.1)` | 10% sample — enough to verify instrumentation |
+| Production | `ParentBased(TraceIDRatioBased(0.01))` | 1% sample; respect upstream sampling decisions |
+
+Sampling is the caller's responsibility — jwtauth defers entirely to the OTel SDK.
+
+### Endpoint Environment Variables (OTLP)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4318` | OTLP HTTP exporter endpoint |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | — | Override for traces only |
+| `OTEL_SERVICE_NAME` | — | Service name tag applied to all spans |
+
+---
+
 ## Graceful Shutdown
 
 Shut down in reverse start order — `TokenManager` first, then `KeyManager`. Always use a deadline:

--- a/examples/README.md
+++ b/examples/README.md
@@ -134,7 +134,7 @@ km, _ := keymanager.NewManager(config)
 km.Start(ctx)
 
 // Create RefreshStore for token persistence
-store := storage.NewMemoryRefreshStore(logger)
+store := storage.NewMemoryRefreshStore(storage.MemoryRefreshStoreConfig{Logger: logger})
 
 // Create TokenManager for token operations
 mgr, _ := tokens.NewManager(config)

--- a/examples/chi-example/README.md
+++ b/examples/chi-example/README.md
@@ -312,7 +312,7 @@ Enable debug logging:
 ```go
 logger := logging.NewTextLogger(slog.LevelDebug)
 
-ks, _ := keymanager.NewDiskKeyStore("./keys", 2048, logger, nil)
+ks, _ := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: "./keys", Logger: logger})
 km, _ := keymanager.NewManager(keymanager.ManagerConfig{
     KeyStore: ks,
     Logger:   logger,

--- a/examples/echo-example/README.md
+++ b/examples/echo-example/README.md
@@ -278,7 +278,7 @@ Enable debug logging:
 ```go
 logger := logging.NewTextLogger(slog.LevelDebug)
 
-ks, _ := keymanager.NewDiskKeyStore("./keys", 2048, logger, nil)
+ks, _ := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: "./keys", Logger: logger})
 km, _ := keymanager.NewManager(keymanager.ManagerConfig{
     KeyStore: ks,
     Logger:   logger,

--- a/examples/gin-example/README.md
+++ b/examples/gin-example/README.md
@@ -265,7 +265,7 @@ Enable debug logging:
 ```go
 logger := logging.NewTextLogger(slog.LevelDebug)
 
-ks, _ := keymanager.NewDiskKeyStore("./keys", 2048, logger, nil)
+ks, _ := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: "./keys", Logger: logger})
 km, _ := keymanager.NewManager(keymanager.ManagerConfig{
     KeyStore: ks,
     Logger:   logger,


### PR DESCRIPTION
… (Phase 7)

- README: update In Development blurb (keep v0.4.0 in-progress status); add Distributed Tracing observability section with span naming convention, attribute table, and quick-start example; update v0.4.0 roadmap bullets to reflect wiring complete; fix all positional NewDiskKeyStore/NewRedisKeyStore/NewMemoryRefreshStore call sites to config-struct form; update DiskKeyStore/RedisKeyStore test phase counts (9→10) and spec counts (38→42 / 35→39)
- ARCHITECTURE: replace ⏳ tracing roadmap items with ✅; update status footer; add Tracing subsection to Cross-Cutting Concerns with interface, naming convention, attribute table, and integration pattern; update OTel diagram label (Future→Jaeger)
- DEPLOYMENT: add Distributed Tracing section with OTel SDK setup example, TracerProvider wiring, sampler recommendations table, and OTLP env var reference
- CHANGELOG: add config-struct constructor migration to ### Changed and distributed tracing wiring to ### Added under [Unreleased]
- examples/README, chi, echo, gin: update NewDiskKeyStore/NewMemoryRefreshStore snippets to config-struct form