### PR TITLE
feat(tokens): introduce CustomClaims type and rename WithMetadata to …

### DIFF
--- a/pkg/tokens/claims.go
+++ b/pkg/tokens/claims.go
@@ -122,6 +122,14 @@ type Claims struct {
 // 5. Scopes (OAuth2-style):
 //    "scope": "read:users write:posts"
 
+// CustomClaims holds application-defined key-value pairs embedded into a JWT
+// access token or stored alongside a refresh token. Reserved JWT field names
+// (sub, iss, aud, exp, nbf, iat, jti) are silently dropped at issuance time
+// to prevent caller-controlled claim injection. All methods are safe for
+// concurrent use when the map is not mutated after being passed to an issuance
+// method.
+type CustomClaims map[string]interface{}
+
 // ============================================================================
 // HELPER TYPES
 // ============================================================================

--- a/pkg/tokens/integration/integration_suite_test.go
+++ b/pkg/tokens/integration/integration_suite_test.go
@@ -275,12 +275,12 @@ func RunTokenManagerIntegrationTests(description string, factory ManagerFactory)
 
 			deviceRefreshTokens := make(map[string]string)
 			for deviceName, deviceID := range devices {
-				metadata := map[string]interface{}{
+				claims := tokens.CustomClaims{
 					"device_name": deviceName,
 					"device_id":   deviceID,
 					"ip_address":  "192.168.1.100",
 				}
-				token, err := mgr.IssueRefreshTokenWithMetadata(ctx, userID, metadata)
+				token, err := mgr.IssueRefreshTokenWithClaims(ctx, userID, claims)
 				Expect(err).NotTo(HaveOccurred())
 				deviceRefreshTokens[deviceName] = token
 			}

--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -572,11 +572,11 @@ func (m *Manager) IssueAccessToken(ctx context.Context, userID string) (string, 
 
 // IssueAccessTokenWithClaims creates a signed RS256 JWT access token with
 // additional custom claims merged into the payload. Reserved claims (sub, iss,
-// exp, iat, nbf, jti) cannot be overridden; any attempt is silently dropped
+// exp, iat, nbf, jti) cannot be overridden — any attempt is silently dropped
 // and logged as a warning.
 //
 // Returns the same errors as IssueAccessToken.
-func (m *Manager) IssueAccessTokenWithClaims(ctx context.Context, userID string, customClaims map[string]interface{}) (string, error) {
+func (m *Manager) IssueAccessTokenWithClaims(ctx context.Context, userID string, claims CustomClaims) (string, error) {
 	ctx, span := m.startSpan(ctx, "IssueAccessTokenWithClaims")
 	defer span.End()
 
@@ -672,7 +672,7 @@ func (m *Manager) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 	span.SetAttribute("token_id", tokenID)
 
 	// Create map claims to support both standard and custom claims
-	claims := jwt.MapClaims{
+	jwtClaims := jwt.MapClaims{
 		"sub": userID,
 		"iss": m.issuer,
 		"aud": m.audience,
@@ -682,17 +682,16 @@ func (m *Manager) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 		"jti": tokenID,
 	}
 
-	// Merge custom claims
-	// Custom claims can override standard claims except sub, iss, exp, iat, nbf, jti
+	// Merge custom claims — reserved keys are silently dropped.
 	reservedClaims := map[string]bool{
 		"sub": true, "iss": true, "exp": true,
 		"iat": true, "nbf": true, "jti": true,
 	}
 
 	customClaimsCount := 0
-	for key, value := range customClaims {
+	for key, value := range claims {
 		if !reservedClaims[key] {
-			claims[key] = value
+			jwtClaims[key] = value
 			customClaimsCount++
 		} else {
 			if m.logger != nil {
@@ -711,7 +710,7 @@ func (m *Manager) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 	}
 
 	// Sign token
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwtClaims)
 	token.Header["kid"] = keyID
 
 	signedToken, err := token.SignedString(privateKey)
@@ -740,7 +739,7 @@ func (m *Manager) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 			"userID", userID,
 			"tokenID", tokenID,
 			"keyID", keyID,
-			"customClaims", len(customClaims),
+			"customClaims", len(claims),
 			"expiresAt", expiresAt)
 	}
 	span.SetStatus(tracing.StatusOK, "")
@@ -855,7 +854,7 @@ func (m *Manager) IssueRefreshToken(ctx context.Context, userID string) (string,
 		refreshToken, // Token ID (the token itself is the ID)
 		userID,       // Who owns the token
 		expiresAt,    // When it expires
-		nil,          // No metadata (use IssueRefreshTokenWithMetadata for metadata)
+		nil,          // No claims (use IssueRefreshTokenWithClaims to attach claims)
 	)
 	if err != nil {
 		if m.logger != nil {
@@ -887,13 +886,13 @@ func (m *Manager) IssueRefreshToken(ctx context.Context, userID string) (string,
 	return refreshToken, nil
 }
 
-// IssueRefreshTokenWithMetadata behaves like IssueRefreshToken but stores
-// arbitrary metadata alongside the token (e.g. device ID, IP address, session
-// tags). The metadata is retrievable via IntrospectToken.
+// IssueRefreshTokenWithClaims behaves like IssueRefreshToken but stores
+// arbitrary claims alongside the token (e.g. device ID, IP address, session
+// tags). The claims are retrievable via IntrospectToken.
 //
 // Returns the same errors as IssueAccessToken.
-func (m *Manager) IssueRefreshTokenWithMetadata(ctx context.Context, userID string, metadata map[string]interface{}) (string, error) {
-	ctx, span := m.startSpan(ctx, "IssueRefreshTokenWithMetadata")
+func (m *Manager) IssueRefreshTokenWithClaims(ctx context.Context, userID string, claims CustomClaims) (string, error) {
+	ctx, span := m.startSpan(ctx, "IssueRefreshTokenWithClaims")
 	defer span.End()
 
 	start := time.Now()
@@ -954,7 +953,7 @@ func (m *Manager) IssueRefreshTokenWithMetadata(ctx context.Context, userID stri
 	}
 
 	if m.logger != nil {
-		m.logger.Debug("issuing refresh token with metadata", ctx, "userID", userID)
+		m.logger.Debug("issuing refresh token with claims", ctx, "userID", userID)
 	}
 
 	// ===== STEP 4: Generate Refresh Token =====
@@ -995,23 +994,23 @@ func (m *Manager) IssueRefreshTokenWithMetadata(ctx context.Context, userID stri
 		refreshToken, // Token ID (the token itself is the ID)
 		userID,       // Who owns the token
 		expiresAt,    // When it expires
-		metadata,     // Custom metadata
+		claims,       // Custom claims
 	)
 	if err != nil {
 		if m.logger != nil {
-			m.logger.Error("failed to store refresh token with metadata", ctx,
+			m.logger.Error("failed to store refresh token with claims", ctx,
 				"userID", userID,
 				"error", err)
 		}
-		wrapped := fmt.Errorf("failed to store refresh token with metadata: %w", err)
+		wrapped := fmt.Errorf("failed to store refresh token with claims: %w", err)
 		span.RecordError(wrapped)
 		span.SetStatus(tracing.StatusError, wrapped.Error())
 		return "", wrapped
 	}
 	if m.logger != nil {
-		m.logger.Debug("refresh token with metadata stored", ctx,
+		m.logger.Debug("refresh token with claims stored", ctx,
 			"userID", userID,
-			"metadataKeys", len(metadata),
+			"claimsKeys", len(claims),
 			"expiresAt", expiresAt)
 	}
 
@@ -1019,11 +1018,11 @@ func (m *Manager) IssueRefreshTokenWithMetadata(ctx context.Context, userID stri
 	status = "success"
 	errorType = ""
 	if m.logger != nil {
-		m.logger.Info("refresh token with metadata issued", ctx,
+		m.logger.Info("refresh token with claims issued", ctx,
 			"userID", userID,
 			"tokenID", refreshToken,
 			"expiresAt", expiresAt,
-			"metadataKeys", getMapKeys(metadata))
+			"claimsKeys", getMapKeys(claims))
 	}
 	span.SetStatus(tracing.StatusOK, "")
 	return refreshToken, nil
@@ -1198,7 +1197,7 @@ func (m *Manager) IssueTokenPair(ctx context.Context, userID string) (string, st
 		refreshToken, // Token ID (the token itself is the ID)
 		userID,       // Who owns the token
 		expiresAt,    // When it expires
-		nil,          // No metadata (use IssueRefreshTokenWithMetadata for metadata)
+		nil,          // No claims (use IssueRefreshTokenWithClaims to attach claims)
 	)
 	if err != nil {
 		if m.logger != nil {
@@ -2105,8 +2104,8 @@ func generateRefreshToken() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
-// getMapKeys returns the keys of a map (for logging).
-func getMapKeys(m map[string]interface{}) []string {
+// getMapKeys returns the keys of a CustomClaims map (for logging).
+func getMapKeys(m CustomClaims) []string {
 	if m == nil {
 		return nil
 	}

--- a/pkg/tokens/manager_test.go
+++ b/pkg/tokens/manager_test.go
@@ -275,7 +275,7 @@ var _ = Describe("TokenManager", func() {
 		It("should include custom claims issuance if provided", func() {
 			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
 
-			customClaims := map[string]interface{}{
+			customClaims := tokens.CustomClaims{
 				"role":   "admin",
 				"tenant": "org-123",
 			}
@@ -380,7 +380,7 @@ var _ = Describe("TokenManager", func() {
 
 			It("should not override reserved claim sub", func() {
 				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
-				customClaims := map[string]interface{}{"sub": "hacker", "role": "admin"}
+				customClaims := tokens.CustomClaims{"sub": "hacker", "role": "admin"}
 				tokenStr, err := service.IssueAccessTokenWithClaims(ctx, testUserID, customClaims)
 				Expect(err).NotTo(HaveOccurred())
 				parsed, _ := jwt.ParseWithClaims(tokenStr, &jwt.MapClaims{}, func(t *jwt.Token) (interface{}, error) {
@@ -441,18 +441,18 @@ var _ = Describe("TokenManager", func() {
 				}).Should(BeTrue())
 			})
 
-			It("should store metadata when provided", func() {
-				metadata := map[string]interface{}{
+			It("should store claims when provided", func() {
+				claims := tokens.CustomClaims{
 					"ip":        "192.168.1.1",
 					"userAgent": "Mozilla/5.0",
 				}
 
-				// Verify metadata is passed to Store
+				// Verify claims are passed to Store
 				mockStore.EXPECT().
-					Store(gomock.Any(), gomock.Any(), testUserID, gomock.Any(), metadata).
+					Store(gomock.Any(), gomock.Any(), testUserID, gomock.Any(), claims).
 					Return(nil)
 
-				service.IssueRefreshTokenWithMetadata(ctx, testUserID, metadata)
+				service.IssueRefreshTokenWithClaims(ctx, testUserID, claims)
 			})
 
 			It("should set correct expiration time", func() {
@@ -522,11 +522,11 @@ var _ = Describe("TokenManager", func() {
 			})
 		})
 
-		Context("IssueRefreshTokenWithMetadata guards", func() {
+		Context("IssueRefreshTokenWithClaims guards", func() {
 			It("should return error when service is not running", func() {
 				stoppedService := createService()
 
-				_, err := stoppedService.IssueRefreshTokenWithMetadata(ctx, testUserID, nil)
+				_, err := stoppedService.IssueRefreshTokenWithClaims(ctx, testUserID, nil)
 
 				Expect(err).To(MatchError(tokens.ErrManagerNotRunning))
 			})
@@ -535,7 +535,7 @@ var _ = Describe("TokenManager", func() {
 				cancelledCtx, cancel := context.WithCancel(ctx)
 				cancel()
 
-				_, err := service.IssueRefreshTokenWithMetadata(cancelledCtx, testUserID, nil)
+				_, err := service.IssueRefreshTokenWithClaims(cancelledCtx, testUserID, nil)
 
 				Expect(err).To(MatchError(context.Canceled))
 			})
@@ -544,7 +544,7 @@ var _ = Describe("TokenManager", func() {
 				mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(errors.New("storage failure"))
 
-				_, err := service.IssueRefreshTokenWithMetadata(ctx, testUserID, nil)
+				_, err := service.IssueRefreshTokenWithClaims(ctx, testUserID, nil)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -845,7 +845,7 @@ var _ = Describe("TokenManager", func() {
 			Context("with custom claims embedded at issuance", func() {
 				It("should return custom claims alongside registered claims", func() {
 					mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
-					customClaims := map[string]interface{}{
+					customClaims := tokens.CustomClaims{
 						"role":   "admin",
 						"tenant": "org-123",
 					}


### PR DESCRIPTION
…WithClaims

- Add CustomClaims (map[string]interface{}) named type to claims.go
- Update IssueAccessTokenWithClaims parameter from raw map to CustomClaims
- Rename IssueRefreshTokenWithMetadata → IssueRefreshTokenWithClaims with parameter renamed from metadata to claims (type CustomClaims)
- Update span name, log messages, and inline comments to match new name
- Update getMapKeys helper to accept CustomClaims
- Update all call sites in unit tests and integration tests

Phase 1 of claims API consistency pass (issue #76)