### PR TITLE
refactor(observability): eliminate nil logger/metrics guards in keyma…

### DIFF
--- a/pkg/keymanager/disk.go
+++ b/pkg/keymanager/disk.go
@@ -118,22 +118,20 @@ func (d *DiskKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 	errorType := "error"
 	var keyCount int
 	defer func() {
-		if d.metrics != nil {
-			d.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
-				"operation":       "load_all",
-				"status":          status,
-				"error_type":      errorType,
+		d.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
+			"operation":       "load_all",
+			"status":          status,
+			"error_type":      errorType,
+			"storage_backend": d.backend,
+		})
+		d.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
+			"operation":       "load_all",
+			"storage_backend": d.backend,
+		})
+		if status == "success" {
+			d.metrics.SetGauge(metricKeyStoreKeysCount, float64(keyCount), map[string]string{
 				"storage_backend": d.backend,
 			})
-			d.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
-				"operation":       "load_all",
-				"storage_backend": d.backend,
-			})
-			if status == "success" {
-				d.metrics.SetGauge(metricKeyStoreKeysCount, float64(keyCount), map[string]string{
-					"storage_backend": d.backend,
-				})
-			}
 		}
 	}()
 
@@ -150,9 +148,7 @@ func (d *DiskKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 	pattern := filepath.Join(d.dir, "*.pem")
 	matches, err := filepath.Glob(pattern)
 	if err != nil {
-		if d.logger != nil {
-			d.logger.Error("failed to glob key files", ctx, "error", err)
-		}
+		d.logger.Error("failed to glob key files", ctx, "error", err)
 		span.RecordError(err)
 		span.SetStatus(tracing.StatusError, "glob key files failed")
 		return nil, fmt.Errorf("glob key files: %w", err)
@@ -163,31 +159,25 @@ func (d *DiskKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 	for _, file := range matches {
 		privateKey, keyID, err := d.readKeyFile(file)
 		if err != nil {
-			if d.logger != nil {
-				d.logger.Warn("skipping key file: failed to load", ctx,
-					"file", filepath.Base(file),
-					"error", err)
-			}
+			d.logger.Warn("skipping key file: failed to load", ctx,
+				"file", filepath.Base(file),
+				"error", err)
 			continue
 		}
 
 		meta, err := d.readMetadata(keyID)
 		if err != nil {
-			if d.logger != nil {
-				d.logger.Warn("skipping key: failed to load metadata", ctx,
-					"keyID", keyID,
-					"error", err)
-			}
+			d.logger.Warn("skipping key: failed to load metadata", ctx,
+				"keyID", keyID,
+				"error", err)
 			continue
 		}
 
 		// Skip already-expired keys
 		if !meta.ExpiresAt.IsZero() && time.Now().After(meta.ExpiresAt) {
-			if d.logger != nil {
-				d.logger.Info("skipping expired key", ctx,
-					"keyID", keyID,
-					"expiredAt", meta.ExpiresAt.Format(time.RFC3339))
-			}
+			d.logger.Info("skipping expired key", ctx,
+				"keyID", keyID,
+				"expiredAt", meta.ExpiresAt.Format(time.RFC3339))
 			continue
 		}
 
@@ -197,18 +187,14 @@ func (d *DiskKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 			Metadata:   meta,
 		})
 
-		if d.logger != nil {
-			d.logger.Debug("loaded key from disk", ctx, "keyID", keyID)
-		}
+		d.logger.Debug("loaded key from disk", ctx, "keyID", keyID)
 	}
 
 	// ===== STEP 4: Log and Return =====
 	status = "success"
 	errorType = ""
 	keyCount = len(keys)
-	if d.logger != nil {
-		d.logger.Info("loaded keys from disk", ctx, "count", keyCount)
-	}
+	d.logger.Info("loaded keys from disk", ctx, "count", keyCount)
 	span.SetStatus(tracing.StatusOK, "")
 	return keys, nil
 }
@@ -225,18 +211,16 @@ func (d *DiskKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.P
 	status := "error"
 	errorType := "error"
 	defer func() {
-		if d.metrics != nil {
-			d.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
-				"operation":       "save",
-				"status":          status,
-				"error_type":      errorType,
-				"storage_backend": d.backend,
-			})
-			d.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
-				"operation":       "save",
-				"storage_backend": d.backend,
-			})
-		}
+		d.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
+			"operation":       "save",
+			"status":          status,
+			"error_type":      errorType,
+			"storage_backend": d.backend,
+		})
+		d.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
+			"operation":       "save",
+			"storage_backend": d.backend,
+		})
 	}()
 
 	// ===== STEP 1: Check Context =====
@@ -259,11 +243,9 @@ func (d *DiskKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.P
 	pemPath := filepath.Join(d.dir, keyID+".pem")
 	file, err := os.OpenFile(pemPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
-		if d.logger != nil {
-			d.logger.Error("failed to create key file", ctx,
-				"keyID", keyID,
-				"error", err)
-		}
+		d.logger.Error("failed to create key file", ctx,
+			"keyID", keyID,
+			"error", err)
 		span.RecordError(err)
 		span.SetStatus(tracing.StatusError, "create key file failed")
 		return fmt.Errorf("create key file: %w", err)
@@ -271,11 +253,9 @@ func (d *DiskKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.P
 	defer file.Close()
 
 	if err := pem.Encode(file, pemBlock); err != nil {
-		if d.logger != nil {
-			d.logger.Error("failed to write key file", ctx,
-				"keyID", keyID,
-				"error", err)
-		}
+		d.logger.Error("failed to write key file", ctx,
+			"keyID", keyID,
+			"error", err)
 		span.RecordError(err)
 		span.SetStatus(tracing.StatusError, "write key file failed")
 		return fmt.Errorf("write key file: %w", err)
@@ -285,11 +265,9 @@ func (d *DiskKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.P
 	if err := d.writeMetadata(keyID, meta); err != nil {
 		// Rollback: remove the PEM file to maintain consistency
 		os.Remove(pemPath)
-		if d.logger != nil {
-			d.logger.Warn("failed to save key metadata — rolling back PEM", ctx,
-				"keyID", keyID,
-				"error", err)
-		}
+		d.logger.Warn("failed to save key metadata — rolling back PEM", ctx,
+			"keyID", keyID,
+			"error", err)
 		span.RecordError(err)
 		span.SetStatus(tracing.StatusError, "save key metadata failed")
 		return fmt.Errorf("save key metadata: %w", err)
@@ -298,9 +276,7 @@ func (d *DiskKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.P
 	// ===== STEP 5: Log and Return =====
 	status = "success"
 	errorType = ""
-	if d.logger != nil {
-		d.logger.Info("saved key to disk", ctx, "keyID", keyID)
-	}
+	d.logger.Info("saved key to disk", ctx, "keyID", keyID)
 	span.SetStatus(tracing.StatusOK, "")
 	return nil
 }
@@ -318,18 +294,16 @@ func (d *DiskKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta Ke
 	status := "error"
 	errorType := "error"
 	defer func() {
-		if d.metrics != nil {
-			d.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
-				"operation":       "update_metadata",
-				"status":          status,
-				"error_type":      errorType,
-				"storage_backend": d.backend,
-			})
-			d.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
-				"operation":       "update_metadata",
-				"storage_backend": d.backend,
-			})
-		}
+		d.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
+			"operation":       "update_metadata",
+			"status":          status,
+			"error_type":      errorType,
+			"storage_backend": d.backend,
+		})
+		d.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
+			"operation":       "update_metadata",
+			"storage_backend": d.backend,
+		})
 	}()
 
 	// ===== STEP 1: Check Context =====
@@ -352,11 +326,9 @@ func (d *DiskKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta Ke
 
 	// ===== STEP 3: Write Updated Metadata =====
 	if err := d.writeMetadata(keyID, meta); err != nil {
-		if d.logger != nil {
-			d.logger.Error("failed to update metadata", ctx,
-				"keyID", keyID,
-				"error", err)
-		}
+		d.logger.Error("failed to update metadata", ctx,
+			"keyID", keyID,
+			"error", err)
 		span.RecordError(err)
 		span.SetStatus(tracing.StatusError, "update metadata failed")
 		return fmt.Errorf("update metadata: %w", err)
@@ -365,9 +337,7 @@ func (d *DiskKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta Ke
 	// ===== STEP 4: Log and Return =====
 	status = "success"
 	errorType = ""
-	if d.logger != nil {
-		d.logger.Info("updated key metadata", ctx, "keyID", keyID)
-	}
+	d.logger.Info("updated key metadata", ctx, "keyID", keyID)
 	span.SetStatus(tracing.StatusOK, "")
 	return nil
 }
@@ -384,18 +354,16 @@ func (d *DiskKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.PrivateK
 	status := "error"
 	errorType := "error"
 	defer func() {
-		if d.metrics != nil {
-			d.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
-				"operation":       "load_key",
-				"status":          status,
-				"error_type":      errorType,
-				"storage_backend": d.backend,
-			})
-			d.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
-				"operation":       "load_key",
-				"storage_backend": d.backend,
-			})
-		}
+		d.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
+			"operation":       "load_key",
+			"status":          status,
+			"error_type":      errorType,
+			"storage_backend": d.backend,
+		})
+		d.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
+			"operation":       "load_key",
+			"storage_backend": d.backend,
+		})
 	}()
 
 	// ===== STEP 1: Check Context =====
@@ -425,11 +393,9 @@ func (d *DiskKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.PrivateK
 			span.SetStatus(tracing.StatusError, "key not found")
 			return nil, nil, ErrKeyStoreKeyNotFound
 		}
-		if d.logger != nil {
-			d.logger.Error("failed to load key file", ctx,
-				"keyID", keyID,
-				"error", err)
-		}
+		d.logger.Error("failed to load key file", ctx,
+			"keyID", keyID,
+			"error", err)
 		span.RecordError(err)
 		span.SetStatus(tracing.StatusError, "load key file failed")
 		return nil, nil, fmt.Errorf("load key: %w", err)
@@ -438,11 +404,9 @@ func (d *DiskKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.PrivateK
 	// ===== STEP 4: Load Metadata =====
 	meta, err := d.readMetadata(keyID)
 	if err != nil {
-		if d.logger != nil {
-			d.logger.Error("failed to load key metadata", ctx,
-				"keyID", keyID,
-				"error", err)
-		}
+		d.logger.Error("failed to load key metadata", ctx,
+			"keyID", keyID,
+			"error", err)
 		span.RecordError(err)
 		span.SetStatus(tracing.StatusError, "load metadata failed")
 		return nil, nil, fmt.Errorf("load metadata: %w", err)
@@ -451,9 +415,7 @@ func (d *DiskKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.PrivateK
 	// ===== STEP 5: Log and Return =====
 	status = "success"
 	errorType = ""
-	if d.logger != nil {
-		d.logger.Debug("loaded key from disk", ctx, "keyID", keyID)
-	}
+	d.logger.Debug("loaded key from disk", ctx, "keyID", keyID)
 	span.SetStatus(tracing.StatusOK, "")
 	return privateKey, &meta, nil
 }
@@ -470,18 +432,16 @@ func (d *DiskKeyStore) Delete(ctx context.Context, keyID string) error {
 	status := "error"
 	errorType := "error"
 	defer func() {
-		if d.metrics != nil {
-			d.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
-				"operation":       "delete",
-				"status":          status,
-				"error_type":      errorType,
-				"storage_backend": d.backend,
-			})
-			d.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
-				"operation":       "delete",
-				"storage_backend": d.backend,
-			})
-		}
+		d.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
+			"operation":       "delete",
+			"status":          status,
+			"error_type":      errorType,
+			"storage_backend": d.backend,
+		})
+		d.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
+			"operation":       "delete",
+			"storage_backend": d.backend,
+		})
 	}()
 
 	// ===== STEP 1: Check Context =====
@@ -496,11 +456,9 @@ func (d *DiskKeyStore) Delete(ctx context.Context, keyID string) error {
 	// ===== STEP 2: Remove PEM File =====
 	pemPath := filepath.Join(d.dir, keyID+".pem")
 	if err := os.Remove(pemPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-		if d.logger != nil {
-			d.logger.Error("failed to delete key file", ctx,
-				"keyID", keyID,
-				"error", err)
-		}
+		d.logger.Error("failed to delete key file", ctx,
+			"keyID", keyID,
+			"error", err)
 		span.RecordError(err)
 		span.SetStatus(tracing.StatusError, "delete key file failed")
 		return fmt.Errorf("delete key file: %w", err)
@@ -509,11 +467,9 @@ func (d *DiskKeyStore) Delete(ctx context.Context, keyID string) error {
 	// ===== STEP 3: Remove Metadata File =====
 	metaPath := filepath.Join(d.dir, keyID+".json")
 	if err := os.Remove(metaPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-		if d.logger != nil {
-			d.logger.Error("failed to delete metadata file", ctx,
-				"keyID", keyID,
-				"error", err)
-		}
+		d.logger.Error("failed to delete metadata file", ctx,
+			"keyID", keyID,
+			"error", err)
 		span.RecordError(err)
 		span.SetStatus(tracing.StatusError, "delete metadata file failed")
 		return fmt.Errorf("delete metadata file: %w", err)
@@ -522,9 +478,7 @@ func (d *DiskKeyStore) Delete(ctx context.Context, keyID string) error {
 	// ===== STEP 4: Log and Return =====
 	status = "success"
 	errorType = ""
-	if d.logger != nil {
-		d.logger.Info("deleted key from disk", ctx, "keyID", keyID)
-	}
+	d.logger.Info("deleted key from disk", ctx, "keyID", keyID)
 	span.SetStatus(tracing.StatusOK, "")
 	return nil
 }

--- a/pkg/keymanager/keymanager.go
+++ b/pkg/keymanager/keymanager.go
@@ -127,7 +127,7 @@ type Manager struct {
 	currentKeyID string              // ID of the key currently used for signing
 
 	// ===== Observability =====
-	metrics metrics.Metrics // Optional; nil disables metrics
+	metrics metrics.Metrics // never nil; defaults to NoOpMetrics
 	tracer  tracing.Tracer  // never nil; defaults to NoOpTracer
 
 	// ===== Synchronization =====
@@ -144,10 +144,10 @@ type Manager struct {
 // ManagerConfig holds configuration settings for the Manager.
 // All fields should be set before passing to NewManager.
 type ManagerConfig struct {
-	Logger              logging.Logger  // Optional; nil disables logging
+	Logger              logging.Logger  // Optional; nil defaults to NoOpLogger.
 	KeyStore            KeyStore        // Required; the persistence backend for RSA key pairs
-	Metrics             metrics.Metrics // Optional; nil disables metrics
-	Tracer              tracing.Tracer  // Optional; nil defaults to NoOpTracer
+	Metrics             metrics.Metrics // Optional; nil defaults to NoOpMetrics.
+	Tracer              tracing.Tracer  // Optional; nil defaults to NoOpTracer.
 	KeyRotationInterval time.Duration   // How often to rotate to a new signing key
 	KeyOverlapDuration  time.Duration   // How long old keys remain valid after rotation
 	KeySize             int             // RSA key size in bits (minimum 2048)
@@ -161,6 +161,8 @@ func ConfigDefault() ManagerConfig {
 		KeySize:             2048,
 		KeyRotationInterval: 30 * 24 * time.Hour,
 		KeyOverlapDuration:  1 * time.Hour,
+		Logger:              &logging.NoOpLogger{},
+		Metrics:             metrics.NewNoOpMetrics(),
 		Tracer:              tracing.NewNoOpTracer(),
 	}
 }
@@ -282,6 +284,12 @@ func NewManager(config ManagerConfig) (*Manager, error) {
 	if config.KeyOverlapDuration == 0 {
 		config.KeyOverlapDuration = defaults.KeyOverlapDuration
 	}
+	if config.Logger == nil {
+		config.Logger = defaults.Logger
+	}
+	if config.Metrics == nil {
+		config.Metrics = defaults.Metrics
+	}
 	if config.Tracer == nil {
 		config.Tracer = defaults.Tracer
 	}
@@ -330,9 +338,7 @@ func (m *Manager) Start(ctx context.Context) error {
 	storedKeys, err := m.config.KeyStore.LoadAll(ctx)
 	if err != nil {
 		atomic.StoreInt32(&m.state, StateStopped)
-		if m.config.Logger != nil {
-			m.config.Logger.Error("failed to load keys from store", ctx, "error", err)
-		}
+		m.config.Logger.Error("failed to load keys from store", ctx, "error", err)
 		wrapped := fmt.Errorf("load keys: %w", err)
 		span.RecordError(wrapped)
 		span.SetStatus(tracing.StatusError, wrapped.Error())
@@ -362,22 +368,16 @@ func (m *Manager) Start(ctx context.Context) error {
 		keyCount := len(m.keys)
 		m.mu.Unlock()
 
-		if m.config.Logger != nil {
-			m.config.Logger.Info("loaded existing keys from store", ctx,
-				"keyID", m.currentKeyID,
-				"keyCount", len(storedKeys))
-		}
-		if m.metrics != nil {
-			m.metrics.SetGauge(metricKeyActiveVersionsCount, float64(keyCount), nil)
-		}
+		m.config.Logger.Info("loaded existing keys from store", ctx,
+			"keyID", m.currentKeyID,
+			"keyCount", len(storedKeys))
+		m.metrics.SetGauge(metricKeyActiveVersionsCount, float64(keyCount), nil)
 	} else {
 		// ===== STEP 4b: Generate Initial Key Pair =====
 		privateKey, err := rsa.GenerateKey(rand.Reader, m.config.KeySize)
 		if err != nil {
 			atomic.StoreInt32(&m.state, StateStopped)
-			if m.config.Logger != nil {
-				m.config.Logger.Error("failed to generate initial key", ctx, "error", err)
-			}
+			m.config.Logger.Error("failed to generate initial key", ctx, "error", err)
 			wrapped := fmt.Errorf("generate key: %w", err)
 			span.RecordError(wrapped)
 			span.SetStatus(tracing.StatusError, wrapped.Error())
@@ -403,23 +403,17 @@ func (m *Manager) Start(ctx context.Context) error {
 		meta := KeyMetadata{ID: keyID, CreatedAt: now}
 		if err := m.config.KeyStore.Save(ctx, keyID, privateKey, meta); err != nil {
 			atomic.StoreInt32(&m.state, StateStopped)
-			if m.config.Logger != nil {
-				m.config.Logger.Error("failed to save initial key", ctx, "error", err)
-			}
+			m.config.Logger.Error("failed to save initial key", ctx, "error", err)
 			wrapped := fmt.Errorf("save initial key: %w", err)
 			span.RecordError(wrapped)
 			span.SetStatus(tracing.StatusError, wrapped.Error())
 			return wrapped
 		}
 
-		if m.config.Logger != nil {
-			m.config.Logger.Info("generated new RSA key pair", ctx,
-				"keyID", keyID,
-				"keySize", m.config.KeySize)
-		}
-		if m.metrics != nil {
-			m.metrics.SetGauge(metricKeyActiveVersionsCount, float64(keyCount), nil)
-		}
+		m.config.Logger.Info("generated new RSA key pair", ctx,
+			"keyID", keyID,
+			"keySize", m.config.KeySize)
+		m.metrics.SetGauge(metricKeyActiveVersionsCount, float64(keyCount), nil)
 	}
 
 	// ===== STEP 5: Start Rotation Scheduler =====
@@ -427,11 +421,8 @@ func (m *Manager) Start(ctx context.Context) error {
 	m.rotationWG.Add(1)
 	go m.rotationSchedulerLoop(ctx)
 
-	if m.config.Logger != nil {
-		m.config.Logger.Info("key manager started", ctx,
-			"rotationInterval", m.config.KeyRotationInterval)
-	}
-
+	m.config.Logger.Info("key manager started", ctx,
+		"rotationInterval", m.config.KeyRotationInterval)
 	span.SetStatus(tracing.StatusOK, "")
 	return nil
 }
@@ -447,9 +438,7 @@ func (m *Manager) GetCurrentSigningKey(ctx context.Context) (*rsa.PrivateKey, st
 
 	// ===== STEP 1: Check Manager is Running =====
 	if !m.IsRunning() {
-		if m.metrics != nil {
-			m.metrics.IncrementCounter(metricKeySigningOpsTotal, map[string]string{"status": "error", "error_type": "error"})
-		}
+		m.metrics.IncrementCounter(metricKeySigningOpsTotal, map[string]string{"status": "error", "error_type": "error"})
 		span.RecordError(ErrManagerNotRunning)
 		span.SetStatus(tracing.StatusError, ErrManagerNotRunning.Error())
 		return nil, "", ErrManagerNotRunning
@@ -457,36 +446,28 @@ func (m *Manager) GetCurrentSigningKey(ctx context.Context) (*rsa.PrivateKey, st
 
 	// ===== STEP 2: Context Check =====
 	if err := ctx.Err(); err != nil {
-		if m.metrics != nil {
-			m.metrics.IncrementCounter(metricKeySigningOpsTotal, map[string]string{"status": "cancelled", "error_type": "cancelled"})
-		}
+		m.metrics.IncrementCounter(metricKeySigningOpsTotal, map[string]string{"status": "cancelled", "error_type": "cancelled"})
 		span.RecordError(err)
 		span.SetStatus(tracing.StatusError, err.Error())
 		return nil, "", err
 	}
 
 	// ===== STEP 3: Acquire Read Lock and Retrieve Key =====
-	if m.config.Logger != nil {
-		m.config.Logger.Debug("getting current signing key", ctx)
-	}
+	m.config.Logger.Debug("getting current signing key", ctx)
 
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	keyPair, found := m.keys[m.currentKeyID]
 
 	if !found {
-		if m.metrics != nil {
-			m.metrics.IncrementCounter(metricKeySigningOpsTotal, map[string]string{"status": "error", "error_type": "error"})
-		}
+		m.metrics.IncrementCounter(metricKeySigningOpsTotal, map[string]string{"status": "error", "error_type": "error"})
 		span.RecordError(ErrKeyNotFound)
 		span.SetStatus(tracing.StatusError, ErrKeyNotFound.Error())
 		return nil, "", ErrKeyNotFound
 	}
 
 	// ===== STEP 4: Return Key and ID =====
-	if m.metrics != nil {
-		m.metrics.IncrementCounter(metricKeySigningOpsTotal, map[string]string{"status": "success", "error_type": ""})
-	}
+	m.metrics.IncrementCounter(metricKeySigningOpsTotal, map[string]string{"status": "success", "error_type": ""})
 	span.SetAttribute("key_id", m.currentKeyID)
 	span.SetStatus(tracing.StatusOK, "")
 	return keyPair.PrivateKey, m.currentKeyID, nil
@@ -506,9 +487,7 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 		return nil
 	}
 
-	if m.config.Logger != nil {
-		m.config.Logger.Info("initiating graceful shutdown", ctx)
-	}
+	m.config.Logger.Info("initiating graceful shutdown", ctx)
 
 	// ===== STEP 2: Signal Rotation Scheduler to Stop =====
 	close(m.stopRotationCh)
@@ -532,10 +511,7 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 	// ===== STEP 4: Recreate Stop Channel for Potential Restart =====
 	m.stopRotationCh = make(chan struct{})
 
-	if m.config.Logger != nil {
-		m.config.Logger.Info("key manager stopped", ctx)
-	}
-
+	m.config.Logger.Info("key manager stopped", ctx)
 	span.SetStatus(tracing.StatusOK, "")
 	return nil
 }
@@ -558,9 +534,7 @@ func (m *Manager) GetPublicKey(ctx context.Context, keyID string) (*rsa.PublicKe
 	status := "error"
 	errorType := "error"
 	defer func() {
-		if m.metrics != nil {
-			m.metrics.IncrementCounter(metricKeyValidationOpsTotal, map[string]string{"status": status, "error_type": errorType})
-		}
+		m.metrics.IncrementCounter(metricKeyValidationOpsTotal, map[string]string{"status": status, "error_type": errorType})
 	}()
 
 	// ===== STEP 1: Validate Key ID =====
@@ -586,9 +560,7 @@ func (m *Manager) GetPublicKey(ctx context.Context, keyID string) (*rsa.PublicKe
 	m.mu.RLock()
 	if keyPair, exists := m.keys[keyID]; exists {
 		m.mu.RUnlock()
-		if m.config.Logger != nil {
-			m.config.Logger.Debug("public key cache hit", ctx, "keyID", keyID)
-		}
+		m.config.Logger.Debug("public key cache hit", ctx, "keyID", keyID)
 		status = "success"
 		errorType = ""
 		span.SetStatus(tracing.StatusOK, "")
@@ -597,9 +569,7 @@ func (m *Manager) GetPublicKey(ctx context.Context, keyID string) (*rsa.PublicKe
 	m.mu.RUnlock()
 
 	// ===== STEP 4: Load from KeyStore =====
-	if m.config.Logger != nil {
-		m.config.Logger.Debug("public key not in cache, loading from store", ctx, "keyID", keyID)
-	}
+	m.config.Logger.Debug("public key not in cache, loading from store", ctx, "keyID", keyID)
 	privateKey, meta, err := m.config.KeyStore.LoadKey(ctx, keyID)
 	if err != nil {
 		if errors.Is(err, ErrKeyStoreKeyNotFound) {
@@ -668,9 +638,7 @@ func (m *Manager) GetJWKS(ctx context.Context) (*JWKS, error) {
 		return nil, err
 	}
 
-	if m.config.Logger != nil {
-		m.config.Logger.Debug("getting JWKS", ctx)
-	}
+	m.config.Logger.Debug("getting JWKS", ctx)
 
 	// ===== STEP 3: Acquire Read Lock and Collect Keys =====
 	m.mu.RLock()
@@ -782,10 +750,8 @@ func (m *Manager) RotateKeys(ctx context.Context) error {
 	status := "error"
 	errorType := "error"
 	defer func() {
-		if m.metrics != nil {
-			m.metrics.IncrementCounter(metricKeyRotationsTotal, map[string]string{"status": status, "error_type": errorType})
-			m.metrics.RecordDuration(metricKeyOpDuration, time.Since(start), map[string]string{"operation": "rotate"})
-		}
+		m.metrics.IncrementCounter(metricKeyRotationsTotal, map[string]string{"status": status, "error_type": errorType})
+		m.metrics.RecordDuration(metricKeyOpDuration, time.Since(start), map[string]string{"operation": "rotate"})
 	}()
 
 	// ===== STEP 1: Check Context =====
@@ -793,9 +759,7 @@ func (m *Manager) RotateKeys(ctx context.Context) error {
 	case <-ctx.Done():
 		status = "cancelled"
 		errorType = "cancelled"
-		if m.config.Logger != nil {
-			m.config.Logger.Warn("key rotation cancelled", ctx)
-		}
+		m.config.Logger.Warn("key rotation cancelled", ctx)
 		span.RecordError(ctx.Err())
 		span.SetStatus(tracing.StatusError, ctx.Err().Error())
 		return ctx.Err()
@@ -816,9 +780,7 @@ func (m *Manager) RotateKeys(ctx context.Context) error {
 	// ===== STEP 4: Generate New RSA Key Pair =====
 	privateKey, err := rsa.GenerateKey(rand.Reader, m.config.KeySize)
 	if err != nil {
-		if m.config.Logger != nil {
-			m.config.Logger.Error("key rotation failed", ctx, "error", err)
-		}
+		m.config.Logger.Error("key rotation failed", ctx, "error", err)
 		wrapped := fmt.Errorf("generate key: %w", err)
 		span.RecordError(wrapped)
 		span.SetStatus(tracing.StatusError, wrapped.Error())
@@ -832,9 +794,7 @@ func (m *Manager) RotateKeys(ctx context.Context) error {
 	// ===== STEP 6: Save New Key to Store =====
 	newMeta := KeyMetadata{ID: keyID, CreatedAt: now}
 	if err := m.config.KeyStore.Save(ctx, keyID, privateKey, newMeta); err != nil {
-		if m.config.Logger != nil {
-			m.config.Logger.Error("key rotation failed: could not save new key", ctx, "error", err)
-		}
+		m.config.Logger.Error("key rotation failed: could not save new key", ctx, "error", err)
 		wrapped := fmt.Errorf("save new key: %w", err)
 		span.RecordError(wrapped)
 		span.SetStatus(tracing.StatusError, wrapped.Error())
@@ -853,17 +813,13 @@ func (m *Manager) RotateKeys(ctx context.Context) error {
 		}
 		if err := m.config.KeyStore.UpdateMetadata(ctx, oldKeyID, updatedMeta); err != nil {
 			// Log but continue — in-memory expiration is sufficient for correctness
-			if m.config.Logger != nil {
-				m.config.Logger.Warn("failed to persist expiration for old key", ctx,
-					"oldKeyID", oldKeyID,
-					"error", err)
-			}
+			m.config.Logger.Warn("failed to persist expiration for old key", ctx,
+				"oldKeyID", oldKeyID,
+				"error", err)
 		} else {
-			if m.config.Logger != nil {
-				m.config.Logger.Info("old key marked for expiration", ctx,
-					"keyID", oldKeyID,
-					"expiresAt", oldKey.ExpiresAt)
-			}
+			m.config.Logger.Info("old key marked for expiration", ctx,
+				"keyID", oldKeyID,
+				"expiresAt", oldKey.ExpiresAt)
 		}
 	}
 
@@ -880,16 +836,11 @@ func (m *Manager) RotateKeys(ctx context.Context) error {
 
 	status = "success"
 	errorType = ""
-	if m.metrics != nil {
-		m.metrics.SetGauge(metricKeyActiveVersionsCount, float64(len(m.keys)), nil)
-	}
-
-	if m.config.Logger != nil {
-		m.config.Logger.Info("key rotation successful", ctx,
-			"newKeyID", keyID,
-			"oldKeyID", oldKeyID,
-			"duration", time.Since(start))
-	}
+	m.metrics.SetGauge(metricKeyActiveVersionsCount, float64(len(m.keys)), nil)
+	m.config.Logger.Info("key rotation successful", ctx,
+		"newKeyID", keyID,
+		"oldKeyID", oldKeyID,
+		"duration", time.Since(start))
 
 	span.SetAttribute("key_id", keyID)
 	span.SetStatus(tracing.StatusOK, "")
@@ -922,20 +873,14 @@ func (m *Manager) rotationSchedulerLoop(ctx context.Context) {
 	for {
 		select {
 		case <-m.rotationTicker.C:
-			if m.config.Logger != nil {
-				m.config.Logger.Info("automatic rotation triggered", ctx)
-			}
+			m.config.Logger.Info("automatic rotation triggered", ctx)
 			if err := m.RotateKeys(ctx); err != nil {
-				if m.config.Logger != nil {
-					m.config.Logger.Error("rotation failed", ctx, "error", err)
-				}
+				m.config.Logger.Error("rotation failed", ctx, "error", err)
 			}
 			m.cleanupExpiredKeys(ctx)
 
 		case <-cleanupTicker.C:
-			if m.config.Logger != nil {
-				m.config.Logger.Debug("rotation cleanup tick fired", ctx)
-			}
+			m.config.Logger.Debug("rotation cleanup tick fired", ctx)
 			m.cleanupExpiredKeys(ctx)
 
 		case <-ctx.Done():
@@ -953,17 +898,13 @@ func (m *Manager) rotationSchedulerLoop(ctx context.Context) {
 func (m *Manager) cleanupExpiredKeys(ctx context.Context) {
 	// ===== STEP 1: Check Manager is Running =====
 	if !m.IsRunning() {
-		if m.config.Logger != nil {
-			m.config.Logger.Warn("cleanup aborted: manager is not running", ctx)
-		}
+		m.config.Logger.Warn("cleanup aborted: manager is not running", ctx)
 		return
 	}
 
 	// ===== STEP 2: Context Check =====
 	if err := ctx.Err(); err != nil {
-		if m.config.Logger != nil {
-			m.config.Logger.Warn("cleanup aborted: context cancelled", ctx, "reason", err)
-		}
+		m.config.Logger.Warn("cleanup aborted: context cancelled", ctx, "reason", err)
 		return
 	}
 
@@ -983,11 +924,9 @@ func (m *Manager) cleanupExpiredKeys(ctx context.Context) {
 		if !key.ExpiresAt.IsZero() && now.After(key.ExpiresAt) {
 			delete(m.keys, keyID)
 			if err := m.config.KeyStore.Delete(ctx, keyID); err != nil {
-				if m.config.Logger != nil {
-					m.config.Logger.Error("failed to delete expired key from store", ctx,
-						"keyID", keyID,
-						"error", err)
-				}
+				m.config.Logger.Error("failed to delete expired key from store", ctx,
+					"keyID", keyID,
+					"error", err)
 			} else {
 				count++
 				deletedKeys = append(deletedKeys, keyID)
@@ -996,19 +935,17 @@ func (m *Manager) cleanupExpiredKeys(ctx context.Context) {
 	}
 
 	// ===== STEP 5: Log Results =====
-	if m.config.Logger != nil {
-		if count == 0 {
-			m.config.Logger.Debug("no expired keys found during cleanup", ctx)
-		} else {
-			m.config.Logger.Info("expired key cleanup executed", ctx, "deletedCount", count)
-			for _, key := range deletedKeys {
-				m.config.Logger.Info("deleted expired key", ctx, "keyID", key)
-			}
+	if count == 0 {
+		m.config.Logger.Debug("no expired keys found during cleanup", ctx)
+	} else {
+		m.config.Logger.Info("expired key cleanup executed", ctx, "deletedCount", count)
+		for _, key := range deletedKeys {
+			m.config.Logger.Info("deleted expired key", ctx, "keyID", key)
 		}
 	}
 
-	// ===== STEP 5: Update Active Keys Gauge (only when keys were removed) =====
-	if count > 0 && m.metrics != nil {
+	// ===== STEP 6: Update Active Keys Gauge (only when keys were removed) =====
+	if count > 0 {
 		m.metrics.SetGauge(metricKeyActiveVersionsCount, float64(len(m.keys)), nil)
 	}
 }

--- a/pkg/keymanager/redis.go
+++ b/pkg/keymanager/redis.go
@@ -104,22 +104,20 @@ func (r *RedisKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 	errorType := "error"
 	var keyCount int
 	defer func() {
-		if r.metrics != nil {
-			r.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
-				"operation":       "load_all",
-				"status":          status,
-				"error_type":      errorType,
+		r.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
+			"operation":       "load_all",
+			"status":          status,
+			"error_type":      errorType,
+			"storage_backend": r.backend,
+		})
+		r.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
+			"operation":       "load_all",
+			"storage_backend": r.backend,
+		})
+		if status == "success" {
+			r.metrics.SetGauge(metricKeyStoreKeysCount, float64(keyCount), map[string]string{
 				"storage_backend": r.backend,
 			})
-			r.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
-				"operation":       "load_all",
-				"storage_backend": r.backend,
-			})
-			if status == "success" {
-				r.metrics.SetGauge(metricKeyStoreKeysCount, float64(keyCount), map[string]string{
-					"storage_backend": r.backend,
-				})
-			}
 		}
 	}()
 
@@ -143,52 +141,42 @@ func (r *RedisKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 		// ===== STEP 3: Load PEM =====
 		pemStr, err := r.client.Get(ctx, redisKey).Result()
 		if err != nil {
-			if r.logger != nil {
-				r.logger.Warn("skipping key: failed to load PEM", ctx,
-					"keyID", keyID,
-					"error", err)
-			}
+			r.logger.Warn("skipping key: failed to load PEM", ctx,
+				"keyID", keyID,
+				"error", err)
 			continue
 		}
 
 		privateKey, err := decodePEM(pemStr)
 		if err != nil {
-			if r.logger != nil {
-				r.logger.Warn("skipping key: failed to parse PEM", ctx,
-					"keyID", keyID,
-					"error", err)
-			}
+			r.logger.Warn("skipping key: failed to parse PEM", ctx,
+				"keyID", keyID,
+				"error", err)
 			continue
 		}
 
 		// ===== STEP 4: Load Metadata =====
 		metaStr, err := r.client.Get(ctx, keyMetaPrefix+keyID).Result()
 		if err != nil {
-			if r.logger != nil {
-				r.logger.Warn("skipping key: failed to load metadata", ctx,
-					"keyID", keyID,
-					"error", err)
-			}
+			r.logger.Warn("skipping key: failed to load metadata", ctx,
+				"keyID", keyID,
+				"error", err)
 			continue
 		}
 
 		var meta KeyMetadata
 		if err := json.Unmarshal([]byte(metaStr), &meta); err != nil {
-			if r.logger != nil {
-				r.logger.Warn("skipping key: failed to parse metadata", ctx,
-					"keyID", keyID,
-					"error", err)
-			}
+			r.logger.Warn("skipping key: failed to parse metadata", ctx,
+				"keyID", keyID,
+				"error", err)
 			continue
 		}
 
 		// ===== STEP 5: Skip Expired Keys =====
 		if !meta.ExpiresAt.IsZero() && time.Now().After(meta.ExpiresAt) {
-			if r.logger != nil {
-				r.logger.Info("skipping expired key", ctx,
-					"keyID", keyID,
-					"expiredAt", meta.ExpiresAt.Format(time.RFC3339))
-			}
+			r.logger.Info("skipping expired key", ctx,
+				"keyID", keyID,
+				"expiredAt", meta.ExpiresAt.Format(time.RFC3339))
 			continue
 		}
 
@@ -198,15 +186,11 @@ func (r *RedisKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 			Metadata:   meta,
 		})
 
-		if r.logger != nil {
-			r.logger.Debug("loaded key from redis", ctx, "keyID", keyID)
-		}
+		r.logger.Debug("loaded key from redis", ctx, "keyID", keyID)
 	}
 
 	if err := iter.Err(); err != nil {
-		if r.logger != nil {
-			r.logger.Error("failed to scan redis keys", ctx, "error", err)
-		}
+		r.logger.Error("failed to scan redis keys", ctx, "error", err)
 		span.RecordError(err)
 		span.SetStatus(tracing.StatusError, err.Error())
 		return nil, fmt.Errorf("scan redis keys: %w", err)
@@ -216,9 +200,7 @@ func (r *RedisKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 	status = "success"
 	errorType = ""
 	keyCount = len(keys)
-	if r.logger != nil {
-		r.logger.Info("loaded keys from redis", ctx, "count", keyCount)
-	}
+	r.logger.Info("loaded keys from redis", ctx, "count", keyCount)
 	span.SetStatus(tracing.StatusOK, "")
 	return keys, nil
 }
@@ -235,18 +217,16 @@ func (r *RedisKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.
 	status := "error"
 	errorType := "error"
 	defer func() {
-		if r.metrics != nil {
-			r.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
-				"operation":       "save",
-				"status":          status,
-				"error_type":      errorType,
-				"storage_backend": r.backend,
-			})
-			r.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
-				"operation":       "save",
-				"storage_backend": r.backend,
-			})
-		}
+		r.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
+			"operation":       "save",
+			"status":          status,
+			"error_type":      errorType,
+			"storage_backend": r.backend,
+		})
+		r.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
+			"operation":       "save",
+			"storage_backend": r.backend,
+		})
 	}()
 
 	// ===== STEP 1: Check Context =====
@@ -264,11 +244,9 @@ func (r *RedisKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.
 	// ===== STEP 3: Marshal Metadata =====
 	metaBytes, err := json.Marshal(meta)
 	if err != nil {
-		if r.logger != nil {
-			r.logger.Error("failed to marshal key metadata", ctx,
-				"keyID", keyID,
-				"error", err)
-		}
+		r.logger.Error("failed to marshal key metadata", ctx,
+			"keyID", keyID,
+			"error", err)
 		span.RecordError(err)
 		span.SetStatus(tracing.StatusError, err.Error())
 		return fmt.Errorf("marshal key metadata: %w", err)
@@ -280,11 +258,9 @@ func (r *RedisKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.
 	pipe.Set(ctx, keyMetaPrefix+keyID, string(metaBytes), 0)
 
 	if _, err := pipe.Exec(ctx); err != nil {
-		if r.logger != nil {
-			r.logger.Error("failed to save key to redis", ctx,
-				"keyID", keyID,
-				"error", err)
-		}
+		r.logger.Error("failed to save key to redis", ctx,
+			"keyID", keyID,
+			"error", err)
 		span.RecordError(err)
 		span.SetStatus(tracing.StatusError, err.Error())
 		return fmt.Errorf("save key to redis: %w", err)
@@ -293,9 +269,7 @@ func (r *RedisKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.
 	// ===== STEP 5: Log and Return =====
 	status = "success"
 	errorType = ""
-	if r.logger != nil {
-		r.logger.Info("saved key to redis", ctx, "keyID", keyID)
-	}
+	r.logger.Info("saved key to redis", ctx, "keyID", keyID)
 	span.SetStatus(tracing.StatusOK, "")
 	return nil
 }
@@ -313,18 +287,16 @@ func (r *RedisKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta K
 	status := "error"
 	errorType := "error"
 	defer func() {
-		if r.metrics != nil {
-			r.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
-				"operation":       "update_metadata",
-				"status":          status,
-				"error_type":      errorType,
-				"storage_backend": r.backend,
-			})
-			r.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
-				"operation":       "update_metadata",
-				"storage_backend": r.backend,
-			})
-		}
+		r.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
+			"operation":       "update_metadata",
+			"status":          status,
+			"error_type":      errorType,
+			"storage_backend": r.backend,
+		})
+		r.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
+			"operation":       "update_metadata",
+			"storage_backend": r.backend,
+		})
 	}()
 
 	// ===== STEP 1: Check Context =====
@@ -339,11 +311,9 @@ func (r *RedisKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta K
 	// ===== STEP 2: Verify Key Exists =====
 	exists, err := r.client.Exists(ctx, keyPEMPrefix+keyID).Result()
 	if err != nil {
-		if r.logger != nil {
-			r.logger.Error("failed to check key existence", ctx,
-				"keyID", keyID,
-				"error", err)
-		}
+		r.logger.Error("failed to check key existence", ctx,
+			"keyID", keyID,
+			"error", err)
 		span.RecordError(err)
 		span.SetStatus(tracing.StatusError, err.Error())
 		return fmt.Errorf("check key existence: %w", err)
@@ -359,22 +329,18 @@ func (r *RedisKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta K
 	// ===== STEP 3: Marshal and Write Updated Metadata =====
 	metaBytes, err := json.Marshal(meta)
 	if err != nil {
-		if r.logger != nil {
-			r.logger.Error("failed to marshal key metadata", ctx,
-				"keyID", keyID,
-				"error", err)
-		}
+		r.logger.Error("failed to marshal key metadata", ctx,
+			"keyID", keyID,
+			"error", err)
 		span.RecordError(err)
 		span.SetStatus(tracing.StatusError, err.Error())
 		return fmt.Errorf("marshal key metadata: %w", err)
 	}
 
 	if err := r.client.Set(ctx, keyMetaPrefix+keyID, string(metaBytes), 0).Err(); err != nil {
-		if r.logger != nil {
-			r.logger.Error("failed to update metadata in redis", ctx,
-				"keyID", keyID,
-				"error", err)
-		}
+		r.logger.Error("failed to update metadata in redis", ctx,
+			"keyID", keyID,
+			"error", err)
 		span.RecordError(err)
 		span.SetStatus(tracing.StatusError, err.Error())
 		return fmt.Errorf("update metadata: %w", err)
@@ -383,9 +349,7 @@ func (r *RedisKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta K
 	// ===== STEP 4: Log and Return =====
 	status = "success"
 	errorType = ""
-	if r.logger != nil {
-		r.logger.Info("updated key metadata", ctx, "keyID", keyID)
-	}
+	r.logger.Info("updated key metadata", ctx, "keyID", keyID)
 	span.SetStatus(tracing.StatusOK, "")
 	return nil
 }
@@ -403,18 +367,16 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 	status := "error"
 	errorType := "error"
 	defer func() {
-		if r.metrics != nil {
-			r.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
-				"operation":       "load_key",
-				"status":          status,
-				"error_type":      errorType,
-				"storage_backend": r.backend,
-			})
-			r.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
-				"operation":       "load_key",
-				"storage_backend": r.backend,
-			})
-		}
+		r.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
+			"operation":       "load_key",
+			"status":          status,
+			"error_type":      errorType,
+			"storage_backend": r.backend,
+		})
+		r.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
+			"operation":       "load_key",
+			"storage_backend": r.backend,
+		})
 	}()
 
 	// ===== STEP 1: Check Context =====
@@ -445,11 +407,9 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 			span.SetStatus(tracing.StatusError, ErrKeyStoreKeyNotFound.Error())
 			return nil, nil, ErrKeyStoreKeyNotFound
 		}
-		if r.logger != nil {
-			r.logger.Error("failed to load key from redis", ctx,
-				"keyID", keyID,
-				"error", err)
-		}
+		r.logger.Error("failed to load key from redis", ctx,
+			"keyID", keyID,
+			"error", err)
 		span.RecordError(err)
 		span.SetStatus(tracing.StatusError, err.Error())
 		return nil, nil, fmt.Errorf("load key: %w", err)
@@ -457,11 +417,9 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 
 	privateKey, err := decodePEM(pemStr)
 	if err != nil {
-		if r.logger != nil {
-			r.logger.Error("failed to parse PEM for key", ctx,
-				"keyID", keyID,
-				"error", err)
-		}
+		r.logger.Error("failed to parse PEM for key", ctx,
+			"keyID", keyID,
+			"error", err)
 		span.RecordError(err)
 		span.SetStatus(tracing.StatusError, err.Error())
 		return nil, nil, fmt.Errorf("parse key PEM: %w", err)
@@ -477,11 +435,9 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 			span.SetStatus(tracing.StatusError, ErrKeyStoreKeyNotFound.Error())
 			return nil, nil, ErrKeyStoreKeyNotFound
 		}
-		if r.logger != nil {
-			r.logger.Error("failed to load key metadata from redis", ctx,
-				"keyID", keyID,
-				"error", err)
-		}
+		r.logger.Error("failed to load key metadata from redis", ctx,
+			"keyID", keyID,
+			"error", err)
 		span.RecordError(err)
 		span.SetStatus(tracing.StatusError, err.Error())
 		return nil, nil, fmt.Errorf("load metadata: %w", err)
@@ -489,11 +445,9 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 
 	var meta KeyMetadata
 	if err := json.Unmarshal([]byte(metaStr), &meta); err != nil {
-		if r.logger != nil {
-			r.logger.Error("failed to parse key metadata", ctx,
-				"keyID", keyID,
-				"error", err)
-		}
+		r.logger.Error("failed to parse key metadata", ctx,
+			"keyID", keyID,
+			"error", err)
 		span.RecordError(err)
 		span.SetStatus(tracing.StatusError, err.Error())
 		return nil, nil, fmt.Errorf("parse metadata: %w", err)
@@ -502,9 +456,7 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 	// ===== STEP 5: Log and Return =====
 	status = "success"
 	errorType = ""
-	if r.logger != nil {
-		r.logger.Debug("loaded key from redis", ctx, "keyID", keyID)
-	}
+	r.logger.Debug("loaded key from redis", ctx, "keyID", keyID)
 	span.SetStatus(tracing.StatusOK, "")
 	return privateKey, &meta, nil
 }
@@ -521,18 +473,16 @@ func (r *RedisKeyStore) Delete(ctx context.Context, keyID string) error {
 	status := "error"
 	errorType := "error"
 	defer func() {
-		if r.metrics != nil {
-			r.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
-				"operation":       "delete",
-				"status":          status,
-				"error_type":      errorType,
-				"storage_backend": r.backend,
-			})
-			r.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
-				"operation":       "delete",
-				"storage_backend": r.backend,
-			})
-		}
+		r.metrics.IncrementCounter(metricKeyStoreOpsTotal, map[string]string{
+			"operation":       "delete",
+			"status":          status,
+			"error_type":      errorType,
+			"storage_backend": r.backend,
+		})
+		r.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
+			"operation":       "delete",
+			"storage_backend": r.backend,
+		})
 	}()
 
 	// ===== STEP 1: Check Context =====
@@ -546,11 +496,9 @@ func (r *RedisKeyStore) Delete(ctx context.Context, keyID string) error {
 
 	// ===== STEP 2: Delete Both Keys =====
 	if err := r.client.Del(ctx, keyPEMPrefix+keyID, keyMetaPrefix+keyID).Err(); err != nil {
-		if r.logger != nil {
-			r.logger.Error("failed to delete key from redis", ctx,
-				"keyID", keyID,
-				"error", err)
-		}
+		r.logger.Error("failed to delete key from redis", ctx,
+			"keyID", keyID,
+			"error", err)
 		span.RecordError(err)
 		span.SetStatus(tracing.StatusError, err.Error())
 		return fmt.Errorf("delete key from redis: %w", err)
@@ -559,9 +507,7 @@ func (r *RedisKeyStore) Delete(ctx context.Context, keyID string) error {
 	// ===== STEP 3: Log and Return =====
 	status = "success"
 	errorType = ""
-	if r.logger != nil {
-		r.logger.Info("deleted key from redis", ctx, "keyID", keyID)
-	}
+	r.logger.Info("deleted key from redis", ctx, "keyID", keyID)
 	span.SetStatus(tracing.StatusOK, "")
 	return nil
 }

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -17,7 +17,7 @@ import (
 type PrometheusMetrics struct {
 	// ===== Observability =====
 	registry *prometheus.Registry
-	logger   logging.Logger // Optional; nil disables logging
+	logger   logging.Logger // never nil; defaults to NoOpLogger
 
 	// ===== Counters =====
 	counters   map[string]*prometheus.CounterVec
@@ -35,9 +35,9 @@ type PrometheusMetrics struct {
 // PrometheusConfig holds configuration for a PrometheusMetrics instance.
 // All fields have sensible defaults and may be left at their zero values.
 type PrometheusConfig struct {
-	Namespace string             // Prepended to all metric names. Defaults to "jwtauth".
+	Namespace string               // Prepended to all metric names. Defaults to "jwtauth".
 	Registry  *prometheus.Registry // Registry to register metrics into. If nil, a new isolated registry is created.
-	Logger    logging.Logger     // Optional; nil disables logging.
+	Logger    logging.Logger       // Optional; nil defaults to NoOpLogger.
 }
 
 // NewPrometheusMetrics returns a new PrometheusMetrics with all metrics
@@ -49,9 +49,11 @@ func NewPrometheusMetrics(config PrometheusConfig) *PrometheusMetrics {
 	if config.Namespace == "" {
 		config.Namespace = "jwtauth"
 	}
-
 	if config.Registry == nil {
 		config.Registry = prometheus.NewRegistry()
+	}
+	if config.Logger == nil {
+		config.Logger = &logging.NoOpLogger{}
 	}
 
 	// ===== STEP 2: Construct =====
@@ -241,18 +243,14 @@ func (pm *PrometheusMetrics) AddCounter(name string, value float64, labels map[s
 	pm.countersMu.RUnlock()
 
 	if !exists {
-		if pm.logger != nil {
-			pm.logger.Warn("counter metric not registered - skipping", "metric", name, "value", value)
-		}
+		pm.logger.Warn("counter metric not registered - skipping", "metric", name, "value", value)
 		return
 	}
 
 	// ===== STEP 2: Resolve Label Set =====
 	c, err := counter.GetMetricWith(labels)
 	if err != nil {
-		if pm.logger != nil {
-			pm.logger.Warn("invalid labels for counter - skipping", "metric", name, "error", err)
-		}
+		pm.logger.Warn("invalid labels for counter - skipping", "metric", name, "error", err)
 		return
 	}
 
@@ -271,18 +269,14 @@ func (pm *PrometheusMetrics) SetGauge(name string, value float64, labels map[str
 	pm.gaugesMu.RUnlock()
 
 	if !exists {
-		if pm.logger != nil {
-			pm.logger.Warn("gauge metric not registered - skipping", "metric", name)
-		}
+		pm.logger.Warn("gauge metric not registered - skipping", "metric", name)
 		return
 	}
 
 	// ===== STEP 2: Resolve Label Set =====
 	g, err := gauge.GetMetricWith(labels)
 	if err != nil {
-		if pm.logger != nil {
-			pm.logger.Warn("invalid labels for gauge - skipping", "metric", name, "error", err)
-		}
+		pm.logger.Warn("invalid labels for gauge - skipping", "metric", name, "error", err)
 		return
 	}
 
@@ -302,18 +296,14 @@ func (pm *PrometheusMetrics) RecordHistogram(name string, value float64, labels 
 	pm.histogramsMu.RUnlock()
 
 	if !exists {
-		if pm.logger != nil {
-			pm.logger.Warn("histogram metric not registered - skipping", "metric", name)
-		}
+		pm.logger.Warn("histogram metric not registered - skipping", "metric", name)
 		return
 	}
 
 	// ===== STEP 2: Resolve Label Set =====
 	h, err := histogram.GetMetricWith(labels)
 	if err != nil {
-		if pm.logger != nil {
-			pm.logger.Warn("invalid labels for histogram - skipping", "metric", name, "error", err)
-		}
+		pm.logger.Warn("invalid labels for histogram - skipping", "metric", name, "error", err)
 		return
 	}
 


### PR DESCRIPTION
…nager and prometheus

Replace 81 scattered `if x.logger != nil` / `if x.metrics != nil` call-site guards with no-op assignment at construction time, bringing DiskKeyStore, RedisKeyStore, Manager, and PrometheusMetrics in line with the Pattern B already used by the storage components.

- NewManager now defaults Logger → &logging.NoOpLogger{} and Metrics → metrics.NewNoOpMetrics() when nil; ConfigDefault updated to match
- PrometheusMetrics.NewPrometheusMetrics defaults Logger → &logging.NoOpLogger{} when nil
- All four structs now document logger/metrics fields as "never nil"
- Struct field and ManagerConfig field comments updated to reflect new nil-defaulting semantics