### PR TITLE
docs: correct nil-guard patterns, project structure, tracing status, …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable changes to this project will be documented in this file.
 
 - **`AuthMiddleware` → `BearerMiddleware`** in all example middleware packages (`examples/gin-example/middleware`, `examples/chi-example/auth`, `examples/echo-example/middleware`). Rename call sites accordingly.
 
+- **Nil logger/metrics guards eliminated** across all five components — `Logger` and `Metrics` fields are now assigned `&logging.NoOpLogger{}` / `metrics.NewNoOpMetrics()` at construction when `nil` is passed; every call site in `pkg/keymanager/`, `pkg/metrics/prometheus.go`, and `pkg/tokens/` invokes `m.logger` and `m.metrics` unconditionally. Passing `nil` continues to work — it silently activates the no-op. Previously 217 call-site guards were scattered across five files.
+
 ### Added
 
 - **`CustomClaims` named type** (`map[string]interface{}`) in `pkg/tokens` — canonical type for caller-supplied custom claims across all `WithClaims` methods; reserved JWT field names (`sub`, `iss`, `aud`, `exp`, `nbf`, `iat`, `jti`) are silently dropped at issuance time to prevent caller-controlled claim injection.

--- a/README.md
+++ b/README.md
@@ -719,8 +719,8 @@ and your `RefreshStore` to handle the complete authentication flow.
 | `KeyStore` | `KeyStore` | Yes | - | Key persistence backend — use `NewDiskKeyStore` for single-instance or a custom implementation for distributed deployments |
 | `KeyRotationInterval` | `time.Duration` | Yes | - | How often to rotate keys (e.g., 30 days) |
 | `KeyOverlapDuration` | `time.Duration` | Yes | - | Overlap period for zero-downtime rotation |
-| `Logger` | `logging.Logger` | No | `nil` | Optional structured logger |
-| `Metrics` | `metrics.Metrics` | No | `nil` | Optional metrics collector |
+| `Logger` | `logging.Logger` | No | `NoOpLogger` | Structured logger; defaults to no-op if nil |
+| `Metrics` | `metrics.Metrics` | No | `NoOpMetrics` | Metrics collector; defaults to no-op if nil |
 
 ### ManagerConfig
 
@@ -728,8 +728,8 @@ and your `RefreshStore` to handle the complete authentication flow.
 |-------|------|----------|---------|-------------|
 | `KeyManager` | `keymanager.KeyManager` | Yes | — | Signs and validates tokens |
 | `RefreshStore` | `storage.RefreshStore` | Yes | — | Persists refresh tokens |
-| `Logger` | `logging.Logger` | No | `nil` | Optional structured logger |
-| `Metrics` | `metrics.Metrics` | No | `nil` | Optional metrics collector |
+| `Logger` | `logging.Logger` | No | `NoOpLogger` | Structured logger; defaults to no-op if nil |
+| `Metrics` | `metrics.Metrics` | No | `NoOpMetrics` | Metrics collector; defaults to no-op if nil |
 | `AccessTokenDuration` | `time.Duration` | No | `15m` | Access token TTL |
 | `RefreshTokenDuration` | `time.Duration` | No | `30d` | Refresh token TTL |
 | `CleanupInterval` | `time.Duration` | No | `1h` | How often expired tokens are purged |
@@ -1052,14 +1052,21 @@ github.com/aetomala/jwtauth/
 │   │   ├── logger.go             # Logger interface (4 methods: Debug, Info, Warn, Error)
 │   │   ├── slog_adapter.go       # Standard library adapter
 │   │   ├── noop.go               # NoOp implementation
-│   │   └── logger_test.go        # Logging tests (76 specs)
+│   │   ├── logger_test.go        # Logging tests (76 specs)
+│   │   └── README.md             # Usage documentation
 │   ├── metrics/                  # Metrics abstraction and implementations
 │   │   ├── interface.go          # Metrics interface
 │   │   ├── noop.go               # NoOp implementation
 │   │   ├── prometheus.go         # Prometheus implementation
 │   │   ├── metrics_suite_test.go # Ginkgo bootstrap
-│   │   ├── prometheus_test.go    # 9-phase Prometheus test suite
+│   │   ├── prometheus_test.go    # 9-phase Prometheus test suite (66 specs)
 │   │   └── noop_test.go          # NoOp tests
+│   ├── tracing/                  # Distributed tracing abstraction ✅
+│   │   ├── interface.go          # Tracer and Span interfaces
+│   │   ├── noop.go               # NoOpTracer / NoOpSpan implementations
+│   │   ├── noop_test.go          # NoOp tests (36 specs)
+│   │   ├── otel.go               # OtelTracer adapter (go.opentelemetry.io/otel)
+│   │   └── otel_test.go          # OtelTracer tests
 │   ├── keymanager/               # Key rotation and management ✅
 │   │   ├── keymanager.go         # Manager: lifecycle, rotation, JWKS generation
 │   │   ├── interface.go          # Manager interface
@@ -1094,14 +1101,26 @@ github.com/aetomala/jwtauth/
 │       ├── mock_keystore.go      # gomock-generated MockKeyStore
 │       ├── mock_logger.go        # Reusable MockLogger
 │       ├── mock_metrics.go       # gomock-generated MockMetrics
-│       └── mock_refreshstore.go  # gomock-generated MockRefreshStore
+│       ├── mock_refreshstore.go  # gomock-generated MockRefreshStore
+│       └── mock_tracing.go       # gomock-generated MockTracer / MockSpan
 ├── doc/                          # Documentation
 │   ├── ARCHITECTURE.md           # Design decisions and patterns
-│   └── DEPLOYMENT.md             # Deployment guide
+│   ├── DEPLOYMENT.md             # Deployment guide
+│   ├── METRICS.md                # Metrics reference
+│   ├── MIGRATION.md              # Migration guides from golang-jwt, gin-jwt, jwx
+│   └── adr/                      # Architecture Decision Records
+│       ├── README.md             # ADR index
+│       ├── 001-no-rate-limiting.md
+│       ├── 002-stateful-refresh-tokens.md
+│       └── 003-rs256-only.md
 ├── examples/                     # Framework usage examples
+│   ├── README.md                 # Examples overview
 │   ├── gin-example/              # Gin HTTP framework
 │   ├── echo-example/             # Echo HTTP framework
-│   └── chi-example/              # Chi HTTP router
+│   ├── chi-example/              # Chi HTTP router
+│   ├── correlation-example/      # End-to-end correlation ID with stdlib net/http
+│   ├── health-check/             # Health check endpoint with KeyInfo
+│   └── prometheus-metrics/       # Prometheus metrics endpoint wiring
 └── jwtauth_suite_test.go         # Root Ginkgo suite bootstrap
 ```
 
@@ -1260,6 +1279,14 @@ This library follows SOLID principles and clean architecture patterns. For detai
 - Strategy Pattern (swap implementations via interfaces)
 - Template Method (consistent patterns across components)
 
+**Architecture Decision Records** — major design decisions are captured in [`doc/adr/`](doc/adr/):
+
+| ADR | Decision | Date |
+|-----|----------|------|
+| [ADR-001](doc/adr/001-no-rate-limiting.md) | No rate limiting — belongs at API Gateway / infrastructure layer | 2026-03-11 |
+| [ADR-002](doc/adr/002-stateful-refresh-tokens.md) | Stateful refresh tokens — opaque UUIDs for instant revocation | 2026-03-18 |
+| [ADR-003](doc/adr/003-rs256-only.md) | RS256 only — prevents algorithm confusion attacks | 2026-04-01 |
+
 ## Rate Limiting
 
 `jwtauth` does not provide rate limiting. Rate limiting is a deployment concern — the right layer depends on your environment, scale, and infrastructure.
@@ -1334,8 +1361,8 @@ Built by a Senior Platform Engineer with 28 years of experience in distributed s
 
 ---
 
-**Status**: Beta (Active Development)
-**Version**: 0.3.0-beta
-**Components**: KeyManager ✅ | TokenManager (Beta) 🟡 | RefreshStore (Memory + Redis) ✅ | Metrics (Prometheus) ✅ | Logging (Correlation ID) ✅ | Tracing (scaffold) 🚧
+**Status**: Beta (Active Development — v0.4.0 in progress)
+**Version**: v0.4.0-dev
+**Components**: KeyManager ✅ | TokenManager (Beta) 🟡 | RefreshStore (Memory + Redis) ✅ | Metrics (Prometheus) ✅ | Logging (Correlation ID) ✅ | Tracing ✅
 **Test Coverage**: 605 tests (KeyManager ~90%, TokenManager ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%), all passing, race-detection enabled
-**Last Updated**: April 14, 2026
+**Last Updated**: April 18, 2026

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -57,6 +57,7 @@ Each package has one clear responsibility:
 - `pkg/keymanager` - RSA key generation, rotation, and management
 - `pkg/logging` - Logging abstraction and adapters
 - `pkg/metrics` - Metrics abstraction and implementations
+- `pkg/tracing` - Distributed tracing abstraction and OTel adapter
 - `pkg/tokens` - JWT token creation, validation, and lifecycle management
 - `pkg/storage` - Refresh token persistence (memory, Redis, extensible)
 
@@ -101,6 +102,12 @@ github.com/aetomala/jwtauth/
 │   │   ├── metrics_suite_test.go  # Ginkgo bootstrap
 │   │   ├── prometheus_test.go     # 9-phase Prometheus test suite (66 specs)
 │   │   └── noop_test.go           # NoOp tests
+│   ├── tracing/                   # Distributed tracing abstraction ✅
+│   │   ├── interface.go           # Tracer and Span interfaces
+│   │   ├── noop.go                # NoOpTracer / NoOpSpan implementations
+│   │   ├── noop_test.go           # NoOp tests (36 specs)
+│   │   ├── otel.go                # OtelTracer adapter (go.opentelemetry.io/otel)
+│   │   └── otel_test.go           # OtelTracer tests
 │   ├── keymanager/                # Key rotation and management ✅
 │   │   ├── keymanager.go          # Manager: lifecycle, rotation, JWKS generation
 │   │   ├── interface.go           # Manager interface
@@ -109,9 +116,9 @@ github.com/aetomala/jwtauth/
 │   │   ├── redis.go               # RedisKeyStore — Redis-backed KeyStore for distributed deployments
 │   │   ├── observability.go       # Metric name constants (KeyStore + Manager)
 │   │   ├── keymanager_test.go     # 9-phase Manager tests (52 specs, MockKeyStore)
-│   │   ├── disk_test.go           # 9-phase DiskKeyStore tests (38 specs)
-│   │   └── redis_test.go          # 9-phase RedisKeyStore tests (35 specs, miniredis)
-│   ├── tokens/                    # JWT token operations (Beta)
+│   │   ├── disk_test.go           # 10-phase DiskKeyStore tests (42 specs)
+│   │   └── redis_test.go          # 10-phase RedisKeyStore tests (39 specs, miniredis)
+│   ├── tokens/                    # JWT token operations (Beta) 🟡
 │   │   ├── manager.go             # TokenManager implementation
 │   │   ├── claims.go              # Claims management
 │   │   ├── manager_test.go        # Token operations tests
@@ -135,15 +142,27 @@ github.com/aetomala/jwtauth/
 │       ├── mock_keystore.go       # gomock-generated MockKeyStore
 │       ├── mock_logger.go         # Reusable MockLogger
 │       ├── mock_metrics.go        # gomock-generated MockMetrics
-│       └── mock_refreshstore.go   # gomock-generated MockRefreshStore
+│       ├── mock_refreshstore.go   # gomock-generated MockRefreshStore
+│       ├── mock_tracing.go        # gomock-generated MockTracer / MockSpan
+│       └── README.md              # Testutil usage guide
 ├── doc/                           # Documentation
 │   ├── ARCHITECTURE.md            # This file
-│   └── DEPLOYMENT.md              # Deployment guide
+│   ├── DEPLOYMENT.md              # Deployment guide
+│   ├── METRICS.md                 # Metrics reference
+│   ├── MIGRATION.md               # Migration guides from golang-jwt, gin-jwt, jwx
+│   └── adr/                       # Architecture Decision Records
+│       ├── README.md              # ADR index
+│       ├── 001-no-rate-limiting.md
+│       ├── 002-stateful-refresh-tokens.md
+│       └── 003-rs256-only.md
 ├── examples/                      # Framework usage examples
+│   ├── README.md                  # Examples overview
 │   ├── gin-example/               # Gin HTTP framework
 │   ├── echo-example/              # Echo HTTP framework
 │   ├── chi-example/               # Chi HTTP router
-│   └── correlation-example/       # End-to-end correlation ID with stdlib net/http
+│   ├── correlation-example/       # End-to-end correlation ID with stdlib net/http
+│   ├── health-check/              # Health check endpoint with KeyInfo
+│   └── prometheus-metrics/        # Prometheus metrics endpoint wiring
 └── jwtauth_suite_test.go          # Root Ginkgo suite bootstrap
 ```
 
@@ -185,7 +204,7 @@ github.com/aetomala/jwtauth/
 ├─────────────────────────────────────────────┤
 │  ┌──────────┐  ┌──────────┐  ┌──────────┐  │
 │  │ Logging  │  │ Metrics  │  │ Tracing  │  │
-│  │Interface │  │Interface │  │(Future)  │  │
+│  │Interface │  │Interface │  │Interface │  │
 │  └──────────┘  └──────────┘  └──────────┘  │
 ├─────────────────────────────────────────────┤
 │         Component Layer                      │
@@ -211,7 +230,7 @@ github.com/aetomala/jwtauth/
 **Design Decisions**:
 - **4 levels** (Debug, Info, Warn, Error) - stratified by use case
 - **Structured** (key-value pairs) - machine-readable
-- **Optional** (nil-safe) - works without logger
+- **Optional** — pass `nil` to default to `NoOpLogger`; call sites invoke unconditionally
 - **stdlib adapter** (slog) - no external dependencies
 
 **Log Levels by Purpose**:
@@ -226,21 +245,15 @@ github.com/aetomala/jwtauth/
 **Debug Usage Pattern**:
 ```go
 // High-frequency read operations (cache lookups, token validation entry)
-if m.config.Logger != nil {
-    m.config.Logger.Debug("public key cache hit", "keyID", keyID)
-}
+m.config.Logger.Debug("public key cache hit", "keyID", keyID)
 
 // Intermediate steps in loops (per-token operations)
-if m.logger != nil {
-    m.logger.Debug("revoking token for user",
-        "tokenID", tokenID,
-        "userID", userID)
-}
+m.logger.Debug("revoking token for user",
+    "tokenID", tokenID,
+    "userID", userID)
 
 // No-op outcomes (nothing to do during cleanup)
-if m.logger != nil {
-    m.logger.Debug("no expired keys found during cleanup")
-}
+m.logger.Debug("no expired keys found during cleanup")
 ```
 
 **Flow**:
@@ -294,7 +307,7 @@ See `examples/correlation-example/` for a complete working demonstration.
 
 **Design Decisions**:
 - **Generic primitives** (counters, gauges, histograms, durations) with label maps — backend-agnostic
-- **Optional** (nil-safe) — works without metrics
+- **Optional** — pass `nil` to default to `NoOpMetrics`; call sites invoke unconditionally
 - **Pre-registration at construction** — naming conflicts caught early, not at observation time
 - **Graceful label handling** — wrong or missing labels log a warning and skip rather than panic
 
@@ -674,8 +687,8 @@ type MemoryRefreshStore struct {
     mu         sync.RWMutex             // Thread safety
     tokens     map[string]*RefreshToken // tokenID → token
     userTokens map[string][]string      // userID → []tokenID (for bulk ops)
-    logger     logging.Logger           // Optional; nil disables logging
-    metrics    metrics.Metrics          // Optional; nil disables metrics
+    logger     logging.Logger           // never nil; defaults to NoOpLogger
+    metrics    metrics.Metrics          // never nil; defaults to NoOpMetrics
     backend    string                   // storage_backend label value; always "memory"
 }
 ```
@@ -698,8 +711,8 @@ type MemoryRefreshStore struct {
 ```go
 type RedisRefreshStore struct {
     client  *redis.Client   // go-redis/v9 client (internally thread-safe)
-    logger  logging.Logger  // Optional; nil disables logging
-    metrics metrics.Metrics // Optional; nil disables metrics
+    logger  logging.Logger  // never nil; defaults to NoOpLogger
+    metrics metrics.Metrics // never nil; defaults to NoOpMetrics
     backend string          // storage_backend label value; always "redis"
 }
 ```
@@ -777,12 +790,10 @@ func (m *MemoryRefreshStore) Store(ctx context.Context, ...) error {
     start := time.Now()
     status := "error"          // default; overwritten at each return point
     defer func() {
-        if m.metrics != nil {
-            m.metrics.IncrementCounter(metricStorageOpsTotal, map[string]string{
-                "operation": "store", "status": status, "storage_backend": m.backend,
-            })
-            m.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), ...)
-        }
+        m.metrics.IncrementCounter(metricStorageOpsTotal, map[string]string{
+            "operation": "store", "status": status, "storage_backend": m.backend,
+        })
+        m.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), ...)
     }()
     // ...
     status = "validation_error"
@@ -1046,7 +1057,7 @@ Catches:
 - ✅ Context cancellation guards in `GetJWKS` and `cleanupExpiredKeys` with warning log on early return
 - ✅ Redis integration tests via miniredis (`pkg/tokens/integration`) covering distributed token operations end-to-end
 
-### Phase 6: Distributed Tracing (v0.4.0 — In Progress)
+### Phase 6: Distributed Tracing (v0.4.0)
 - ✅ `pkg/tracing` — `Tracer` and `Span` interfaces defined; `SpanOption` functional options; `StatusCode` and `SpanKind` enumerations
 - ✅ `NoOpTracer` / `NoOpSpan` — zero-allocation implementations; 36 tests, race-detection clean
 - ✅ `MockTracer` / `MockSpan` generated via gomock for dependency injection in component tests
@@ -1102,8 +1113,8 @@ func (c *Component) Operation() error {
     // 1. Check state
     // 2. Acquire lock
     // 3. Do work
-    // 4. Log result (if logger present)
-    // 5. Record metric (if metrics present)
+    // 4. Log result (unconditional — no-op assigned at construction)
+    // 5. Record metric (unconditional — no-op assigned at construction)
 }
 ```
 
@@ -1124,8 +1135,8 @@ func (c *Component) Operation() error {
 ### Adding Observability
 
 1. Identify what to log/measure
-2. Add calls at appropriate points
-3. Always check for nil (optional feature)
+2. Assign `NoOpLogger` / `NoOpMetrics` / `NoOpTracer` at construction when caller passes `nil`
+3. Add unconditional calls at appropriate points — no nil guards at call sites
 4. Write tests verifying logs/metrics
 5. Update documentation
 
@@ -1139,6 +1150,18 @@ func (c *Component) Operation() error {
 
 ---
 
+## Architecture Decision Records
+
+Key design decisions are captured in `doc/adr/`. Each ADR documents the context, the decision made, and the consequences.
+
+| ADR | Title | Date |
+|-----|-------|------|
+| [001](adr/001-no-rate-limiting.md) | No Rate Limiting in Library | 2026-03-11 |
+| [002](adr/002-stateful-refresh-tokens.md) | Stateful Refresh Tokens | 2026-03-18 |
+| [003](adr/003-rs256-only.md) | RS256 Only (No Algorithm Flexibility) | 2026-04-01 |
+
+---
+
 ## References
 
 - [SOLID Principles](https://en.wikipedia.org/wiki/SOLID)
@@ -1149,6 +1172,6 @@ func (c *Component) Operation() error {
 
 ---
 
-**Last Updated**: April 14, 2026
-**Version**: 0.3.0-beta
-**Status**: Active Development (KeyManager + DiskKeyStore + RedisKeyStore + RefreshStore [Memory + Redis] + Metrics [Prometheus] + Logging [Correlation ID] + Distributed Tracing stable and fully instrumented; v0.4.0 in progress)
+**Last Updated**: April 18, 2026
+**Version**: v0.4.0 (in progress)
+**Status**: Active Development (KeyManager + DiskKeyStore + RedisKeyStore + RefreshStore [Memory + Redis] + Metrics [Prometheus] + Logging [Correlation ID] + Distributed Tracing — all stable and fully instrumented; TokenManager in beta)

--- a/doc/adr/001-no-rate-limiting.md
+++ b/doc/adr/001-no-rate-limiting.md
@@ -1,7 +1,7 @@
 # ADR-001: No Rate Limiting in Library
 
 **Status**: Accepted  
-**Date**: 2024-04-01  
+**Date**: 2026-03-11  
 **Deciders**: Architecture Team
 
 ## Context

--- a/doc/adr/002-stateful-refresh-tokens.md
+++ b/doc/adr/002-stateful-refresh-tokens.md
@@ -1,7 +1,7 @@
 # ADR-002: Stateful Refresh Tokens
 
 **Status**: Accepted  
-**Date**: 2024-04-01  
+**Date**: 2026-03-18  
 **Deciders**: Architecture Team
 
 ## Context

--- a/doc/adr/003-rs256-only.md
+++ b/doc/adr/003-rs256-only.md
@@ -1,7 +1,7 @@
 # ADR-003: RS256 Only (No Algorithm Flexibility)
 
 **Status**: Accepted  
-**Date**: 2024-04-01  
+**Date**: 2026-04-01  
 **Deciders**: Architecture Team
 
 ## Context

--- a/pkg/logging/README.md
+++ b/pkg/logging/README.md
@@ -11,7 +11,7 @@ The `logging` package provides a simple, structured logging interface that all c
 - **Simple**: Only 4 log levels (Debug, Info, Warn, Error)
 - **Structured**: Key-value pairs for machine-readable logs
 - **Flexible**: Works with any logging library via adapters
-- **Optional**: Components work without a logger (nil-safe)
+- **Optional**: Pass `nil` to default to `NoOpLogger` — components call unconditionally
 
 ## Quick Start
 
@@ -420,12 +420,14 @@ func TestMyComponent(t *testing.T) {
 - **Include context** in every log (IDs, durations, errors)
 - **Log at appropriate levels** (Info for success, Warn for issues, Error for failures)
 - **Use JSON in production** for log aggregators
-- **Make logger optional** (handle nil gracefully)
+- **Assign no-op at construction** — default to `&logging.NoOpLogger{}` when caller passes `nil`; call sites are then unconditional
 
 ```go
-if m.config.Logger != nil {
-    m.config.Logger.Info("operation complete", "duration", elapsed)
+if config.Logger == nil {
+    config.Logger = &logging.NoOpLogger{}
 }
+// Now call unconditionally everywhere:
+m.logger.Info("operation complete", ctx, "duration", elapsed)
 ```
 
 ### DON'T ❌
@@ -433,7 +435,7 @@ if m.config.Logger != nil {
 - **Don't log sensitive data** (passwords, tokens, PII)
 - **Don't use string formatting in messages** (use key-value pairs instead)
 - **Don't log excessively** (avoid noisy logs)
-- **Don't assume logger is not nil** (always check or use helper)
+- **Don't guard every call site** — assign `NoOpLogger` at construction instead of repeating `if m.logger != nil` throughout method bodies
 
 ## Future: OpenTelemetry
 


### PR DESCRIPTION
…and ADR housekeeping

- CHANGELOG: add nil-guards-eliminated bullet to v0.4.0 Changed section
- README + ARCHITECTURE: add pkg/tracing to project structure; add doc/METRICS.md, doc/MIGRATION.md, doc/adr/, examples (correlation, health-check, prometheus-metrics), mock_tracing.go, testutil README
- ARCHITECTURE: remove (Future) label from Tracing in observability diagram; add pkg/tracing to Single Responsibility list; mark Phase 6 complete; update Contributing/Adding Observability to no-op pattern; add ADR table section; update footer to v0.4.0-dev
- README: add ADR table under Architecture section; fix footer Tracing status from scaffold/🚧 to ✅
- pkg/logging/README: replace nil-guard DO/DON'T examples with no-op-at-construction pattern
- doc/adr: set distinct March–April 2026 dates (were all 2024-04-01)