### PR TITLE
docs(keys): update all markdown references from pkg/keymanager to pkg…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ All notable changes to this project will be documented in this file.
 - **`IssueRefreshTokenWithMetadata` renamed to `IssueRefreshTokenWithClaims`** — parameter renamed from `metadata` to `claims` with type `CustomClaims`; span name updated to match. Update all call sites.
 
 - **`DiskKeyStore`, `RedisKeyStore`, `MemoryRefreshStore`, `RedisRefreshStore` constructors migrated to config-struct form** — positional parameter constructors removed; update call sites:
-  - `keymanager.NewDiskKeyStore(dir, keySize, logger, metrics)` → `keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: dir, KeySize: keySize, Logger: logger, Metrics: metrics})`
-  - `keymanager.NewRedisKeyStore(client, logger, metrics)` → `keymanager.NewRedisKeyStore(keymanager.RedisKeyStoreConfig{Client: client, Logger: logger, Metrics: metrics})`
+  - `keys.NewDiskKeyStore(dir, keySize, logger, metrics)` → `keys.NewDiskKeyStore(keys.DiskKeyStoreConfig{Dir: dir, KeySize: keySize, Logger: logger, Metrics: metrics})`
+  - `keys.NewRedisKeyStore(client, logger, metrics)` → `keys.NewRedisKeyStore(keys.RedisKeyStoreConfig{Client: client, Logger: logger, Metrics: metrics})`
   - `storage.NewMemoryRefreshStore(logger, metrics)` → `storage.NewMemoryRefreshStore(storage.MemoryRefreshStoreConfig{Logger: logger, Metrics: metrics})`
   - `storage.NewRedisRefreshStore(client, logger, metrics)` → `storage.NewRedisRefreshStore(storage.RedisRefreshStoreConfig{Client: client, Logger: logger, Metrics: metrics})`
 
@@ -26,7 +26,7 @@ All notable changes to this project will be documented in this file.
 
 - **`AuthMiddleware` → `BearerMiddleware`** in all example middleware packages (`examples/gin-example/middleware`, `examples/chi-example/auth`, `examples/echo-example/middleware`). Rename call sites accordingly.
 
-- **Nil logger/metrics guards eliminated** across all five components — `Logger` and `Metrics` fields are now assigned `&logging.NoOpLogger{}` / `metrics.NewNoOpMetrics()` at construction when `nil` is passed; every call site in `pkg/keymanager/`, `pkg/metrics/prometheus.go`, and `pkg/tokens/` invokes `m.logger` and `m.metrics` unconditionally. Passing `nil` continues to work — it silently activates the no-op. Previously 217 call-site guards were scattered across five files.
+- **Nil logger/metrics guards eliminated** across all five components — `Logger` and `Metrics` fields are now assigned `&logging.NoOpLogger{}` / `metrics.NewNoOpMetrics()` at construction when `nil` is passed; every call site in `pkg/keys/`, `pkg/metrics/prometheus.go`, and `pkg/tokens/` invokes `m.logger` and `m.metrics` unconditionally. Passing `nil` continues to work — it silently activates the no-op. Previously 217 call-site guards were scattered across five files.
 
 ### Added
 
@@ -44,19 +44,19 @@ All notable changes to this project will be documented in this file.
   - `KeyManager` — spans for Start, Shutdown, and all key operations; attribute: `key_id`
   - `TokenManager` — spans for all 14 public methods; attributes: `user_id`, `token_id`, `active` (IntrospectToken), `deleted_count` (CleanupExpiredTokens)
 
-- **`KeyInfo` struct** — public metadata type in `pkg/keymanager` exposing `KeyID`, `CreatedAt`, `RotateAt` (estimated, current key only), `ExpiresAt`, `KeySizeBits`, `Algorithm`, `IsCurrent`, and `IsValid`. Contains no private key material — safe to serve from health check or admin endpoints.
+- **`KeyInfo` struct** — public metadata type in `pkg/keys` exposing `KeyID`, `CreatedAt`, `RotateAt` (estimated, current key only), `ExpiresAt`, `KeySizeBits`, `Algorithm`, `IsCurrent`, and `IsValid`. Contains no private key material — safe to serve from health check or admin endpoints.
 
-- **`GetKeyInfo(ctx, keyID)`** on `keymanager.Manager` — returns `*KeyInfo` for a specific key by ID. Pass an empty string to resolve the current signing key. Respects context cancellation. Returns `ErrManagerNotRunning` or `ErrKeyNotFound` as appropriate. `KeySizeBits` reflects the actual RSA modulus bit length of the key on disk, not the configured `KeySize`.
+- **`GetKeyInfo(ctx, keyID)`** on `keys.Manager` — returns `*KeyInfo` for a specific key by ID. Pass an empty string to resolve the current signing key. Respects context cancellation. Returns `ErrManagerNotRunning` or `ErrKeyNotFound` as appropriate. `KeySizeBits` reflects the actual RSA modulus bit length of the key on disk, not the configured `KeySize`.
 
-- **`GetCurrentKeyInfo(ctx)`** on `keymanager.Manager` — convenience wrapper around `GetKeyInfo(ctx, "")` for the common case of inspecting the active signing key.
+- **`GetCurrentKeyInfo(ctx)`** on `keys.Manager` — convenience wrapper around `GetKeyInfo(ctx, "")` for the common case of inspecting the active signing key.
 
-- **`GetKeyInfo` and `GetCurrentKeyInfo` on `keymanager.KeyManager` interface** — both methods are now part of the `KeyManager` interface, enabling dependency injection and test doubles for any code that inspects key metadata. `internal/testutil/mock_keymanager.go` has been regenerated with corresponding stubs (`MockKeyManager.GetKeyInfo`, `MockKeyManager.GetCurrentKeyInfo`).
+- **`GetKeyInfo` and `GetCurrentKeyInfo` on `keys.KeyManager` interface** — both methods are now part of the `KeyManager` interface, enabling dependency injection and test doubles for any code that inspects key metadata. `internal/testutil/mock_keys.go` has been regenerated with corresponding stubs (`MockKeyManager.GetKeyInfo`, `MockKeyManager.GetCurrentKeyInfo`).
 
 - **Integration tests for `GetCurrentKeyInfo` and `GetKeyInfo`** — three new cases added to `RunTokenManagerIntegrationTests` and run against all storage backends (DiskKeyStore+MemoryRefreshStore, RedisKeyStore+RedisRefreshStore): verifies accurate field values after `Start()`; verifies that `GetCurrentKeyInfo` reflects the new key after `RotateKeys()` while the old key remains accessible via `GetKeyInfo`; verifies that 20 concurrent `GetCurrentKeyInfo` calls during an active `RotateKeys()` produce no data races (real `Manager.mu` lock path exercised under `-race`).
 
 ### Fixed
 
-- **`KeyInfo.KeySizeBits` now reports actual key size** — previously sourced from `ManagerConfig.KeySize` (caller-supplied), which could silently diverge from the actual RSA key on disk if the `DiskKeyStore` or `RedisKeyStore` was configured with a different key size. Now derived from `keyPair.PrivateKey.N.BitLen()` so the reported value always matches the real key material.
+- **`KeyInfo.KeySizeBits` now reports actual key size** — previously sourced from `KeyManagerConfig.KeySize` (caller-supplied), which could silently diverge from the actual RSA key on disk if the `DiskKeyStore` or `RedisKeyStore` was configured with a different key size. Now derived from `keyPair.PrivateKey.N.BitLen()` so the reported value always matches the real key material.
 
 - **`pkg/tracing` package** — `Tracer` and `Span` interfaces defining the distributed tracing contract. `SpanOption` functional options pattern for span configuration. `StatusCode` (`Unset`, `Error`, `OK`) and `SpanKind` (`Internal`, `Server`, `Client`, `Producer`, `Consumer`) enumerations with `String()` methods. `WithAttributes` and `WithSpanKind` option constructors.
 
@@ -83,7 +83,7 @@ All notable changes to this project will be documented in this file.
 
 - **`pkg/tokens` — package doc comment** — added `// Package tokens ...` comment with key capability list (access token issuance, refresh token rotation, instant revocation, distributed cleanup) and canonical usage example covering the full token lifecycle.
 
-- **`pkg/keymanager` — package doc comment** — added `// Package keymanager ...` comment with rotation timeline ASCII diagram (Day 0 → Day 30 → Day 30+1h) and storage backend summary.
+- **`pkg/keys` — package doc comment** — added `// Package keys ...` comment with rotation timeline ASCII diagram (Day 0 → Day 30 → Day 30+1h) and storage backend summary.
 
 - **`README.md` — "Why This Library?" rewrite** — new positioning statement (authz layer, not authn), comparison vs. `golang-jwt/jwt` (build-vs-buy table), vs. framework JWT middleware (`gin-jwt`, `echo-jwt`) — previously missing entirely, vs. `lestrrat-go/jwx` / `go-jose/go-jose` JOSE toolkits, concrete security guarantees block (algorithm confusion, reserved claim protection, 10 sentinel errors, instant revocation), horizontal scale path table (`DiskKeyStore`+`MemoryRefreshStore` → `RedisKeyStore`+`RedisRefreshStore`), and "What jwtauth is not" closing paragraph.
 
@@ -115,7 +115,7 @@ All notable changes to this project will be documented in this file.
 
 - **Correlation ID logging** — `logging.WithCorrelationID(ctx, id)` and `logging.GetCorrelationID(ctx)` context helpers with an unexported key type that prevents collisions with external packages. `CorrelationIDHandler` wraps any `slog.Handler` and injects a `correlation_id` field into every log record when a correlation ID is present in the context. `SlogAdapter` now routes to slog's `*Context()` methods when `context.Context` is passed as the first variadic arg. `NewCorrelationJSONLogger` and `NewCorrelationTextLogger` convenience constructors pre-wire the handler. `examples/correlation-example/main.go` demonstrates end-to-end HTTP middleware usage.
 
-- **All internal logging call sites pass `ctx`** — every `logger.Info/Debug/Warn/Error` call in `pkg/keymanager`, `pkg/tokens`, and `pkg/storage` now forwards the in-scope `context.Context` as the first variadic arg, enabling correlation ID injection at all component boundaries without any Logger interface changes.
+- **All internal logging call sites pass `ctx`** — every `logger.Info/Debug/Warn/Error` call in `pkg/keys`, `pkg/tokens`, and `pkg/storage` now forwards the in-scope `context.Context` as the first variadic arg, enabling correlation ID injection at all component boundaries without any Logger interface changes.
 
 - **Context cancellation guard in `GetJWKS`** — returns the context error immediately after the running check, before acquiring the read lock.
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ During the **overlap period** (configurable, default 1 hour):
 
 Configuration:
 ```go
-km, _ := keymanager.NewManager(keymanager.ManagerConfig{
+km, _ := keys.NewManager(keys.KeyManagerConfig{
     KeyRotationInterval: 30 * 24 * time.Hour,  // Rotate every 30 days
     KeyOverlapDuration:  1 * time.Hour,        // Keep old key valid for 1 hour
 })
@@ -314,17 +314,17 @@ Every component accepts optional logging and metrics interfaces:
 
 ```go
 import (
-    "github.com/aetomala/jwtauth/pkg/keymanager"
+    "github.com/aetomala/jwtauth/pkg/keys"
     "github.com/aetomala/jwtauth/pkg/logging"
     "github.com/aetomala/jwtauth/pkg/metrics"
     "github.com/aetomala/jwtauth/pkg/tracing"
 )
 
-ks, _ := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{
+ks, _ := keys.NewDiskKeyStore(keys.DiskKeyStoreConfig{
     Dir:    "/var/keys",
     Logger: logging.NewJSONLogger(slog.LevelInfo),
 })
-config := keymanager.ManagerConfig{
+config := keys.KeyManagerConfig{
     KeyStore:            ks,
     KeyRotationInterval: 30 * 24 * time.Hour, // 30 days
     KeyOverlapDuration:  1 * time.Hour,        // 1 hour overlap
@@ -360,7 +360,7 @@ Components depend on abstractions, not concrete implementations:
 
 ```go
 // ✅ KeyManager depends on interfaces
-type ManagerConfig struct {
+type KeyManagerConfig struct {
     KeyStore KeyStore         // Interface, not *DiskKeyStore
     Logger   logging.Logger  // Interface, not *slog.Logger
     Metrics  metrics.Metrics // Interface, not *PrometheusMetrics
@@ -400,18 +400,18 @@ import (
     "log"
     "time"
     
-    "github.com/aetomala/jwtauth/pkg/keymanager"
+    "github.com/aetomala/jwtauth/pkg/keys"
 )
 
 func main() {
     // Create DiskKeyStore for key persistence
-    ks, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: "./keys"})
+    ks, err := keys.NewDiskKeyStore(keys.DiskKeyStoreConfig{Dir: "./keys"})
     if err != nil {
         log.Fatal(err)
     }
 
     // Create KeyManager
-    manager, err := keymanager.NewManager(keymanager.ManagerConfig{
+    manager, err := keys.NewManager(keys.KeyManagerConfig{
         KeyStore:            ks,
         KeyRotationInterval: 30 * 24 * time.Hour,
         KeyOverlapDuration:  1 * time.Hour,
@@ -477,7 +477,7 @@ import (
     "log/slog"
     "os"
     
-    "github.com/aetomala/jwtauth/pkg/keymanager"
+    "github.com/aetomala/jwtauth/pkg/keys"
     "github.com/aetomala/jwtauth/pkg/logging"
 )
 
@@ -486,12 +486,12 @@ func main() {
     logger := logging.NewJSONLogger(slog.LevelInfo)
     pm := metrics.NewPrometheusMetrics(metrics.PrometheusConfig{})
 
-    ks, err := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: "./keys", Logger: logger, Metrics: pm})
+    ks, err := keys.NewDiskKeyStore(keys.DiskKeyStoreConfig{Dir: "./keys", Logger: logger, Metrics: pm})
     if err != nil {
         log.Fatal(err)
     }
 
-    manager, err := keymanager.NewManager(keymanager.ManagerConfig{
+    manager, err := keys.NewManager(keys.KeyManagerConfig{
         KeyStore:            ks,
         KeyRotationInterval: 30 * 24 * time.Hour,
         KeyOverlapDuration:  1 * time.Hour,
@@ -601,9 +601,9 @@ graph TB
     end
 
     subgraph "Application Layer (Stateless)"
-        API1[API Instance 1<br/>tokens.Manager<br/>keymanager.Manager]
-        API2[API Instance 2<br/>tokens.Manager<br/>keymanager.Manager]
-        API3[API Instance 3<br/>tokens.Manager<br/>keymanager.Manager]
+        API1[API Instance 1<br/>tokens.Manager<br/>keys.Manager]
+        API2[API Instance 2<br/>tokens.Manager<br/>keys.Manager]
+        API3[API Instance 3<br/>tokens.Manager<br/>keys.Manager]
     end
 
     subgraph "Shared Storage Layer"
@@ -656,7 +656,7 @@ sequenceDiagram
     participant Client
     participant API
     participant Manager as tokens.Manager
-    participant KeyMgr as keymanager.Manager
+    participant KeyMgr as keys.Manager
     participant Redis as RefreshStore (Redis)
 
     Note over Client,Redis: Login & Token Issuance
@@ -707,12 +707,12 @@ sequenceDiagram
     API-->>Client: 200 OK
 ```
 
-The sequence shows how `tokens.Manager` coordinates with `keymanager.Manager` 
+The sequence shows how `tokens.Manager` coordinates with `keys.Manager` 
 and your `RefreshStore` to handle the complete authentication flow.
 
 ## Configuration
 
-### ManagerConfig
+### KeyManagerConfig
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
@@ -726,7 +726,7 @@ and your `RefreshStore` to handle the complete authentication flow.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `KeyManager` | `keymanager.KeyManager` | Yes | — | Signs and validates tokens |
+| `KeyManager` | `keys.KeyManager` | Yes | — | Signs and validates tokens |
 | `RefreshStore` | `storage.RefreshStore` | Yes | — | Persists refresh tokens |
 | `Logger` | `logging.Logger` | No | `NoOpLogger` | Structured logger; defaults to no-op if nil |
 | `Metrics` | `metrics.Metrics` | No | `NoOpMetrics` | Metrics collector; defaults to no-op if nil |
@@ -741,11 +741,11 @@ and your `RefreshStore` to handle the complete authentication flow.
 
 **Production (single-instance)**:
 ```go
-ks, _ := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{
+ks, _ := keys.NewDiskKeyStore(keys.DiskKeyStoreConfig{
     Dir:    "./keys",
     Logger: logging.NewJSONLogger(slog.LevelInfo),
 })
-config := keymanager.ManagerConfig{
+config := keys.KeyManagerConfig{
     KeyStore:            ks,
     KeyRotationInterval: 30 * 24 * time.Hour,  // 30 days
     KeyOverlapDuration:  1 * time.Hour,         // 1 hour
@@ -756,8 +756,8 @@ config := keymanager.ManagerConfig{
 **Production (distributed / multi-instance)**:
 ```go
 client := redis.NewClient(&redis.Options{Addr: "redis:6379"})
-ks, _ := keymanager.NewRedisKeyStore(keymanager.RedisKeyStoreConfig{Client: client, Logger: logger})
-config := keymanager.ManagerConfig{
+ks, _ := keys.NewRedisKeyStore(keys.RedisKeyStoreConfig{Client: client, Logger: logger})
+config := keys.KeyManagerConfig{
     KeyStore:            ks,
     KeyRotationInterval: 30 * 24 * time.Hour,
     KeyOverlapDuration:  1 * time.Hour,
@@ -767,11 +767,11 @@ config := keymanager.ManagerConfig{
 
 **Development**:
 ```go
-ks, _ := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{
+ks, _ := keys.NewDiskKeyStore(keys.DiskKeyStoreConfig{
     Dir:    "./keys",
     Logger: logging.NewTextLogger(slog.LevelDebug),
 })
-config := keymanager.ManagerConfig{
+config := keys.KeyManagerConfig{
     KeyStore:            ks,
     KeyRotationInterval: 24 * time.Hour,        // 1 day (faster testing)
     KeyOverlapDuration:  5 * time.Minute,        // 5 minutes
@@ -927,8 +927,8 @@ pm := metrics.NewPrometheusMetrics(metrics.PrometheusConfig{
 http.Handle("/metrics", pm.Handler())
 
 // Pass pm to every constructor that accepts it
-ks, _ := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: "./keys", Logger: logger, Metrics: pm})
-km, _ := keymanager.NewManager(keymanager.ManagerConfig{KeyStore: ks, Metrics: pm})
+ks, _ := keys.NewDiskKeyStore(keys.DiskKeyStoreConfig{Dir: "./keys", Logger: logger, Metrics: pm})
+km, _ := keys.NewManager(keys.KeyManagerConfig{KeyStore: ks, Metrics: pm})
 store := storage.NewMemoryRefreshStore(storage.MemoryRefreshStoreConfig{Logger: logger, Metrics: pm})
 mgr, _ := tokens.NewManager(tokens.ManagerConfig{
     KeyManager:   km,
@@ -1005,7 +1005,7 @@ Every component emits OpenTelemetry-compatible spans. Tracing is opt-in — all 
 import (
     "go.opentelemetry.io/otel"
     "github.com/aetomala/jwtauth/pkg/tracing"
-    "github.com/aetomala/jwtauth/pkg/keymanager"
+    "github.com/aetomala/jwtauth/pkg/keys"
     "github.com/aetomala/jwtauth/pkg/storage"
     "github.com/aetomala/jwtauth/pkg/tokens"
 )
@@ -1013,11 +1013,11 @@ import (
 // Wire your OTel TracerProvider (OTLP, Jaeger, Tempo, etc.) then:
 tracer := tracing.NewOtelTracer("jwtauth")
 
-ks, _ := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{
+ks, _ := keys.NewDiskKeyStore(keys.DiskKeyStoreConfig{
     Dir:    "./keys",
     Tracer: tracer,
 })
-km, _ := keymanager.NewManager(keymanager.ManagerConfig{
+km, _ := keys.NewManager(keys.KeyManagerConfig{
     KeyStore: ks,
     Tracer:   tracer,
 })
@@ -1067,14 +1067,14 @@ github.com/aetomala/jwtauth/
 │   │   ├── noop_test.go          # NoOp tests (36 specs)
 │   │   ├── otel.go               # OtelTracer adapter (go.opentelemetry.io/otel)
 │   │   └── otel_test.go          # OtelTracer tests
-│   ├── keymanager/               # Key rotation and management ✅
-│   │   ├── keymanager.go         # Manager: lifecycle, rotation, JWKS generation
+│   ├── keys/               # Key rotation and management ✅
+│   │   ├── manager.go         # Manager: lifecycle, rotation, JWKS generation
 │   │   ├── interface.go          # Manager interface
 │   │   ├── keystore.go           # KeyStore interface, StoredKey type, sentinel errors
 │   │   ├── disk.go               # DiskKeyStore — filesystem-backed KeyStore
 │   │   ├── redis.go              # RedisKeyStore — Redis-backed KeyStore for distributed deployments
 │   │   ├── observability.go      # Metric name constants (KeyStore + Manager)
-│   │   ├── keymanager_test.go    # 9-phase Manager tests (52 specs, MockKeyStore)
+│   │   ├── manager_test.go    # 9-phase Manager tests (52 specs, MockKeyStore)
 │   │   ├── disk_test.go          # 10-phase DiskKeyStore tests (42 specs)
 │   │   └── redis_test.go         # 10-phase RedisKeyStore tests (39 specs, miniredis)
 │   ├── tokens/                   # JWT operations (Beta) 🟡
@@ -1097,7 +1097,7 @@ github.com/aetomala/jwtauth/
 ├── internal/                     # Private packages
 │   └── testutil/                 # Shared test utilities
 │       ├── errors.go             # Shared test error helpers
-│       ├── mock_keymanager.go    # gomock-generated MockKeyManager
+│       ├── mock_keys.go    # gomock-generated MockKeyManager
 │       ├── mock_keystore.go      # gomock-generated MockKeyStore
 │       ├── mock_logger.go        # Reusable MockLogger
 │       ├── mock_metrics.go       # gomock-generated MockMetrics
@@ -1205,7 +1205,7 @@ go install github.com/onsi/ginkgo/v2/ginkgo@latest
 ginkgo -v -race ./...
 
 # Specific package
-go test -v -race ./pkg/keymanager
+go test -v -race ./pkg/keys
 ```
 
 ### Test Philosophy

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -45,7 +45,7 @@ jwtauth is designed as a production-ready, highly observable, and testable **sta
 **Example**:
 ```go
 // KeyManager depends on abstractions, not concrete implementations
-type ManagerConfig struct {
+type KeyManagerConfig struct {
     Logger  logging.Logger   // Interface, not *slog.Logger
     Metrics metrics.Metrics  // Interface, not *PrometheusMetrics
 }
@@ -54,7 +54,7 @@ type ManagerConfig struct {
 ### 2. Single Responsibility Principle
 
 Each package has one clear responsibility:
-- `pkg/keymanager` - RSA key generation, rotation, and management
+- `pkg/keys` - RSA key generation, rotation, and management
 - `pkg/logging` - Logging abstraction and adapters
 - `pkg/metrics` - Metrics abstraction and implementations
 - `pkg/tracing` - Distributed tracing abstraction and OTel adapter
@@ -108,14 +108,14 @@ github.com/aetomala/jwtauth/
 │   │   ├── noop_test.go           # NoOp tests (36 specs)
 │   │   ├── otel.go                # OtelTracer adapter (go.opentelemetry.io/otel)
 │   │   └── otel_test.go           # OtelTracer tests
-│   ├── keymanager/                # Key rotation and management ✅
-│   │   ├── keymanager.go          # Manager: lifecycle, rotation, JWKS generation
+│   ├── keys/                # Key rotation and management ✅
+│   │   ├── manager.go          # Manager: lifecycle, rotation, JWKS generation
 │   │   ├── interface.go           # Manager interface
 │   │   ├── keystore.go            # KeyStore interface, StoredKey type, sentinel errors
 │   │   ├── disk.go                # DiskKeyStore — filesystem-backed KeyStore
 │   │   ├── redis.go               # RedisKeyStore — Redis-backed KeyStore for distributed deployments
 │   │   ├── observability.go       # Metric name constants (KeyStore + Manager)
-│   │   ├── keymanager_test.go     # 9-phase Manager tests (52 specs, MockKeyStore)
+│   │   ├── manager_test.go     # 9-phase Manager tests (52 specs, MockKeyStore)
 │   │   ├── disk_test.go           # 10-phase DiskKeyStore tests (42 specs)
 │   │   └── redis_test.go          # 10-phase RedisKeyStore tests (39 specs, miniredis)
 │   ├── tokens/                    # JWT token operations (Beta) 🟡
@@ -138,7 +138,7 @@ github.com/aetomala/jwtauth/
 ├── internal/                      # Private packages
 │   └── testutil/                  # Shared test utilities
 │       ├── errors.go              # Shared test error helpers
-│       ├── mock_keymanager.go     # gomock-generated MockKeyManager
+│       ├── mock_keys.go     # gomock-generated MockKeyManager
 │       ├── mock_keystore.go       # gomock-generated MockKeyStore
 │       ├── mock_logger.go         # Reusable MockLogger
 │       ├── mock_metrics.go        # gomock-generated MockMetrics
@@ -360,7 +360,7 @@ type Metrics interface {
 Every component accepts optional observability:
 
 ```go
-type ManagerConfig struct {
+type KeyManagerConfig struct {
     // Core configuration
     KeyStore            KeyStore        // Required: injected key persistence backend
     KeyRotationInterval time.Duration
@@ -564,8 +564,8 @@ This enables:
 **DiskKeyStore**:
 
 ```go
-ks, err := keymanager.NewDiskKeyStore("./keys", 2048, logger, metrics)
-km, err := keymanager.NewManager(keymanager.ManagerConfig{
+ks, err := keys.NewDiskKeyStore("./keys", 2048, logger, metrics)
+km, err := keys.NewManager(keys.KeyManagerConfig{
     KeyStore: ks,
     Logger:   logger,
 })
@@ -581,8 +581,8 @@ File format:
 
 ```go
 client := redis.NewClient(&redis.Options{Addr: "redis:6379"})
-ks, err := keymanager.NewRedisKeyStore(client, logger, metrics)
-km, err := keymanager.NewManager(keymanager.ManagerConfig{
+ks, err := keys.NewRedisKeyStore(client, logger, metrics)
+km, err := keys.NewManager(keys.KeyManagerConfig{
     KeyStore: ks,
     Logger:   logger,
 })
@@ -966,9 +966,9 @@ ctrl      := gomock.NewController(GinkgoT())
 mockLogger := testutil.NewMockLogger()
 mockKS     := testutil.NewMockKeyStore(ctrl)
 
-mockKS.EXPECT().LoadAll(gomock.Any()).Return([]*keymanager.StoredKey{}, nil)
+mockKS.EXPECT().LoadAll(gomock.Any()).Return([]*keys.StoredKey{}, nil)
 
-manager, _ := keymanager.NewManager(keymanager.ManagerConfig{
+manager, _ := keys.NewManager(keys.KeyManagerConfig{
     KeyStore: mockKS,
     Logger:   mockLogger,
 })
@@ -1072,7 +1072,7 @@ Catches:
 ### 1. Dependency Injection
 Configuration structs accept interfaces:
 ```go
-type ManagerConfig struct {
+type KeyManagerConfig struct {
     Logger logging.Logger  // Injected
 }
 ```

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -25,7 +25,7 @@ if err := redisClient.Ping(ctx).Err(); err != nil {
     log.Fatalf("Redis unavailable: %v", err)
 }
 
-ks, _ := keymanager.NewRedisKeyStore(redisClient, logger, pm)
+ks, _ := keys.NewRedisKeyStore(redisClient, logger, pm)
 store := storage.NewRedisRefreshStore(redisClient, logger, pm)
 ```
 
@@ -50,7 +50,7 @@ Expose a health endpoint that reflects actual service state — not just HTTP li
 
 ```go
 // Health check handler — checks both manager and key availability
-func healthHandler(mgr *tokens.Manager, km keymanager.KeyManager) http.HandlerFunc {
+func healthHandler(mgr *tokens.Manager, km keys.KeyManager) http.HandlerFunc {
     return func(w http.ResponseWriter, r *http.Request) {
         if !mgr.IsRunning() {
             w.WriteHeader(http.StatusServiceUnavailable)
@@ -104,8 +104,8 @@ pm := metrics.NewPrometheusMetrics(metrics.PrometheusConfig{
     Namespace: "myapp",  // prefix for all metric names; defaults to "jwtauth"
 })
 
-ks, _   := keymanager.NewDiskKeyStore("./keys", 2048, logger, pm)
-km, _   := keymanager.NewManager(keymanager.ManagerConfig{KeyStore: ks, Metrics: pm})
+ks, _   := keys.NewDiskKeyStore("./keys", 2048, logger, pm)
+km, _   := keys.NewManager(keys.KeyManagerConfig{KeyStore: ks, Metrics: pm})
 store   := storage.NewMemoryRefreshStore(logger, pm)
 mgr, _  := tokens.NewManager(tokens.ManagerConfig{
     KeyManager:   km,
@@ -171,7 +171,7 @@ import (
     "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
     "go.opentelemetry.io/otel/sdk/trace"
     "github.com/aetomala/jwtauth/pkg/tracing"
-    "github.com/aetomala/jwtauth/pkg/keymanager"
+    "github.com/aetomala/jwtauth/pkg/keys"
     "github.com/aetomala/jwtauth/pkg/storage"
     "github.com/aetomala/jwtauth/pkg/tokens"
 )
@@ -195,11 +195,11 @@ defer tp.Shutdown(ctx)
 // 3. Create a jwtauth tracer and pass it to every component
 tracer := tracing.NewOtelTracer("jwtauth")
 
-ks, _ := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{
+ks, _ := keys.NewDiskKeyStore(keys.DiskKeyStoreConfig{
     Dir:    "./keys",
     Tracer: tracer,
 })
-km, _ := keymanager.NewManager(keymanager.ManagerConfig{
+km, _ := keys.NewManager(keys.KeyManagerConfig{
     KeyStore: ks,
     Tracer:   tracer,
 })

--- a/doc/METRICS.md
+++ b/doc/METRICS.md
@@ -177,7 +177,7 @@ The built-in metrics above cover rotation counts and operation latency. For time
 
 ```go
 import (
-    "github.com/aetomala/jwtauth/pkg/keymanager"
+    "github.com/aetomala/jwtauth/pkg/keys"
     "github.com/prometheus/client_golang/prometheus"
 )
 
@@ -196,7 +196,7 @@ var (
     })
 )
 
-func collectKeyMetrics(ctx context.Context, km *keymanager.Manager) {
+func collectKeyMetrics(ctx context.Context, km *keys.Manager) {
     info, err := km.GetCurrentKeyInfo(ctx)
     if err != nil {
         return

--- a/doc/MIGRATION.md
+++ b/doc/MIGRATION.md
@@ -39,14 +39,14 @@ parsed, _ := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) 
 
 ```go
 import (
-    "github.com/aetomala/jwtauth/pkg/keymanager"
+    "github.com/aetomala/jwtauth/pkg/keys"
     "github.com/aetomala/jwtauth/pkg/storage"
     "github.com/aetomala/jwtauth/pkg/tokens"
 )
 
 // Step 1: Create KeyManager (handles keys + rotation)
-ks, _ := keymanager.NewDiskKeyStore("./keys", 2048, nil, nil)
-km, _ := keymanager.NewManager(keymanager.ManagerConfig{
+ks, _ := keys.NewDiskKeyStore("./keys", 2048, nil, nil)
+km, _ := keys.NewManager(keys.KeyManagerConfig{
     KeyStore:            ks,
     KeyRotationInterval: 30 * 24 * time.Hour,
     KeyOverlapDuration:  1 * time.Hour,
@@ -281,7 +281,7 @@ mgr.RevokeAllUserTokens(ctx, userID)
 
 **After (zero-downtime):**
 ```go
-km, _ := keymanager.NewManager(keymanager.ManagerConfig{
+km, _ := keys.NewManager(keys.KeyManagerConfig{
     KeyStore:            ks,
     KeyRotationInterval: 30 * 24 * time.Hour, // Auto-rotate every 30 days
     KeyOverlapDuration:  1 * time.Hour,        // Old key valid for 1 hour
@@ -302,7 +302,7 @@ km, _ := keymanager.NewManager(keymanager.ManagerConfig{
 **Development/Single-Instance:**
 ```go
 // Use in-memory storage
-ks, _ := keymanager.NewDiskKeyStore("./keys", 2048, nil, nil)
+ks, _ := keys.NewDiskKeyStore("./keys", 2048, nil, nil)
 refreshStore := storage.NewMemoryRefreshStore(nil, nil)
 ```
 
@@ -314,7 +314,7 @@ import "github.com/redis/go-redis/v9"
 client := redis.NewClient(&redis.Options{Addr: "redis:6379"})
 
 // Shared key storage
-ks, _ := keymanager.NewRedisKeyStore(client, logger, metrics)
+ks, _ := keys.NewRedisKeyStore(client, logger, metrics)
 
 // Shared refresh token storage
 refreshStore := storage.NewRedisRefreshStore(client, logger, metrics)

--- a/examples/README.md
+++ b/examples/README.md
@@ -130,7 +130,7 @@ The `health-check` and `prometheus-metrics` examples focus exclusively on the **
 
 ```go
 // Create KeyManager for key rotation
-km, _ := keymanager.NewManager(config)
+km, _ := keys.NewManager(config)
 km.Start(ctx)
 
 // Create RefreshStore for token persistence

--- a/examples/chi-example/README.md
+++ b/examples/chi-example/README.md
@@ -312,8 +312,8 @@ Enable debug logging:
 ```go
 logger := logging.NewTextLogger(slog.LevelDebug)
 
-ks, _ := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: "./keys", Logger: logger})
-km, _ := keymanager.NewManager(keymanager.ManagerConfig{
+ks, _ := keys.NewDiskKeyStore(keys.DiskKeyStoreConfig{Dir: "./keys", Logger: logger})
+km, _ := keys.NewManager(keys.KeyManagerConfig{
     KeyStore: ks,
     Logger:   logger,
 })

--- a/examples/echo-example/README.md
+++ b/examples/echo-example/README.md
@@ -278,8 +278,8 @@ Enable debug logging:
 ```go
 logger := logging.NewTextLogger(slog.LevelDebug)
 
-ks, _ := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: "./keys", Logger: logger})
-km, _ := keymanager.NewManager(keymanager.ManagerConfig{
+ks, _ := keys.NewDiskKeyStore(keys.DiskKeyStoreConfig{Dir: "./keys", Logger: logger})
+km, _ := keys.NewManager(keys.KeyManagerConfig{
     KeyStore: ks,
     Logger:   logger,
 })

--- a/examples/gin-example/README.md
+++ b/examples/gin-example/README.md
@@ -265,8 +265,8 @@ Enable debug logging:
 ```go
 logger := logging.NewTextLogger(slog.LevelDebug)
 
-ks, _ := keymanager.NewDiskKeyStore(keymanager.DiskKeyStoreConfig{Dir: "./keys", Logger: logger})
-km, _ := keymanager.NewManager(keymanager.ManagerConfig{
+ks, _ := keys.NewDiskKeyStore(keys.DiskKeyStoreConfig{Dir: "./keys", Logger: logger})
+km, _ := keys.NewManager(keys.KeyManagerConfig{
     KeyStore: ks,
     Logger:   logger,
 })

--- a/internal/testutil/README.md
+++ b/internal/testutil/README.md
@@ -6,8 +6,8 @@ Mock implementations for testing components that depend on external interfaces. 
 
 | Mock | Source interface | File | Generation |
 |------|-----------------|------|------------|
-| **MockKeyManager** | `keymanager.KeyManager` | mock_keymanager.go | Auto-generated (mockgen) |
-| **MockKeyStore** | `keymanager.KeyStore` | mock_keystore.go | Auto-generated (mockgen) |
+| **MockKeyManager** | `keys.KeyManager` | mock_keys.go | Auto-generated (mockgen) |
+| **MockKeyStore** | `keys.KeyStore` | mock_keystore.go | Auto-generated (mockgen) |
 | **MockRefreshStore** | `storage.RefreshStore` | mock_refreshstore.go | Auto-generated (mockgen) |
 | **MockMetrics** | `metrics.Metrics` | mock_metrics.go | Auto-generated (mockgen) |
 | **MockLogger** | `logging.Logger` | mock_logger.go | Custom implementation |
@@ -75,7 +75,7 @@ mockM.EXPECT().RecordDuration("jwtauth_operation_duration_seconds", gomock.Any()
 ctrl := gomock.NewController(GinkgoT())
 mockKS := testutil.NewMockKeyStore(ctrl)
 
-mockKS.EXPECT().LoadAll(gomock.Any()).Return([]*keymanager.StoredKey{}, nil)
+mockKS.EXPECT().LoadAll(gomock.Any()).Return([]*keys.StoredKey{}, nil)
 mockKS.EXPECT().Save(gomock.Any(), "key-1", gomock.Any(), gomock.Any()).Return(nil)
 ```
 
@@ -114,7 +114,7 @@ Each mock file contains the exact `mockgen` command used to generate it in its h
 
 ## Files
 
-- **[mock_keymanager.go](./mock_keymanager.go)** — `KeyManager` interface (key signing, rotation, lifecycle)
+- **[mock_keys.go](./mock_keys.go)** — `KeyManager` interface (key signing, rotation, lifecycle)
 - **[mock_keystore.go](./mock_keystore.go)** — `KeyStore` interface (key persistence: LoadAll, Save, UpdateMetadata, LoadKey, Delete)
 - **[mock_refreshstore.go](./mock_refreshstore.go)** — `RefreshStore` interface (token persistence: Store, Retrieve, Revoke, Cleanup)
 - **[mock_metrics.go](./mock_metrics.go)** — `Metrics` interface (counters, gauges, histograms, durations)

--- a/pkg/logging/README.md
+++ b/pkg/logging/README.md
@@ -21,7 +21,7 @@ The `logging` package provides a simple, structured logging interface that all c
 import (
     "log/slog"
     "github.com/aetomala/jwtauth/pkg/logging"
-    "github.com/aetomala/jwtauth/pkg/keymanager"
+    "github.com/aetomala/jwtauth/pkg/keys"
 )
 
 func main() {
@@ -34,8 +34,8 @@ func main() {
     // logger := logging.NewJSONLogger(slog.LevelInfo)
 
     // Use with KeyManager
-    ks, _ := keymanager.NewDiskKeyStore("/keys", 2048, logger, nil)
-    manager, _ := keymanager.NewManager(keymanager.ManagerConfig{
+    ks, _ := keys.NewDiskKeyStore("/keys", 2048, logger, nil)
+    manager, _ := keys.NewManager(keys.KeyManagerConfig{
         KeyStore: ks,
         Logger:   logger,
     })
@@ -66,12 +66,12 @@ logger := logging.NewSlogAdapter(slog.New(handler))
 
 ```go
 // Option 1: Use NoOpLogger
-config := keymanager.ManagerConfig{
+config := keys.KeyManagerConfig{
     Logger: &logging.NoOpLogger{},
 }
 
 // Option 2: Use nil (components handle nil gracefully)
-config := keymanager.ManagerConfig{
+config := keys.KeyManagerConfig{
     Logger: nil,
 }
 ```
@@ -445,4 +445,4 @@ The Logger interface is designed to be compatible with OpenTelemetry for unified
 
 - [Metrics Package](../metrics/README.md) - For metrics/monitoring
 - [Architecture Docs](../../doc/ARCHITECTURE.md) - Overall design decisions
-- [KeyManager Example](../../examples/keymanager/) - Complete usage examples
+- [Examples](../../examples/README.md) - Complete usage examples


### PR DESCRIPTION
…/keys

- Replace all `keymanager.` qualifiers with `keys.` in code samples
- Update import paths from `pkg/keymanager` to `pkg/keys`
- Rename `keymanager.ManagerConfig` → `keys.KeyManagerConfig` throughout
- Rename `keymanager.ConfigDefault()` → `keys.DefaultKeyManagerConfig()`
- Update directory tree entries: keymanager/ → keys/, keymanager.go → manager.go, keymanager_test.go → manager_test.go
- Update unqualified `type ManagerConfig struct` in keys-context code blocks to `type KeyManagerConfig struct`
- Fix pkg/logging README broken example link (examples/keymanager/ → examples/README.md)
- CHANGELOG: correct package doc comment reference (Package keymanager → Package keys)