### PR TITLE
refactor(tokens): document storage→tokens error translation contract

### DIFF
--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -1591,7 +1591,9 @@ func (m *Manager) RefreshAccessToken(ctx context.Context, refreshToken string) (
 	if err != nil {
 		m.logger.Warn("refresh token not found in store", ctx,
 			"error", err)
-		// Propagate specific errors, default to invalid token for generic errors
+		// storage.ErrTokenRevoked is translated to tokens.ErrTokenRevoked so that
+		// callers only ever see tokens-package sentinels and have no dependency on
+		// the storage package. All other storage errors map to ErrInvalidRefreshToken.
 		if errors.Is(err, storage.ErrTokenRevoked) {
 			status = "revoked"
 			errorType = "revoked"
@@ -1724,7 +1726,9 @@ func (m *Manager) RefreshAccessTokenWithClaims(ctx context.Context, refreshToken
 	if err != nil {
 		m.logger.Warn("refresh token not found in store", ctx,
 			"error", err)
-		// Propagate specific errors, default to invalid token for generic errors
+		// storage.ErrTokenRevoked is translated to tokens.ErrTokenRevoked so that
+		// callers only ever see tokens-package sentinels and have no dependency on
+		// the storage package. All other storage errors map to ErrInvalidRefreshToken.
 		if errors.Is(err, storage.ErrTokenRevoked) {
 			status = "revoked"
 			errorType = "revoked"
@@ -1915,6 +1919,8 @@ func (m *Manager) RevokeAllUserTokens(ctx context.Context, userID string) error 
 	span.SetAttribute("user_id", userID)
 
 	// ===== STEP 4: Revoke All Tokens For User =====
+	// storage.ErrInvalidUserID cannot surface here — userID is validated above
+	// before this call, so storage never receives an empty value.
 	err := m.refreshStore.RevokeAllForUser(ctx, userID)
 	if err != nil {
 		m.logger.Error("failed to revoke all user tokens", ctx,


### PR DESCRIPTION
## Summary

- Added contract comment at both `refreshStore.Retrieve` catch sites where `storage.ErrTokenRevoked` is translated to `tokens.ErrTokenRevoked`
- Added confirming comment at `refreshStore.RevokeAllForUser` documenting why `storage.ErrInvalidUserID` cannot surface there

## Context

Phase 6 of the consistency cleanup audit — formalizing the error ownership boundary between the `storage` and `tokens` packages.

**`storage.ErrTokenRevoked`**: Two `Retrieve` call sites catch this sentinel and re-emit `tokens.ErrTokenRevoked`. The translation is intentional — callers never need to import the `storage` package to handle revocation errors. Both sites now have a comment stating this contract explicitly.

**`storage.ErrInvalidUserID`**: Cannot reach any caller. `tokens.Manager` validates every userID before passing it to a storage method, so storage never receives an empty value. The one `%w`-wrapped path (`RevokeAllForUser`) now documents this guarantee explicitly.

No logic changes — documentation only.

## Verification

- `go build ./...` passes
- `go test ./...` passes
- `grep` for `storage.Err` in `pkg/tokens/` confirms no sentinel appears in any caller-facing return path