### PR TITLE
docs: add ADR-004 and ADR-005 to README and ARCHITECTURE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ All notable changes to this project will be documented in this file.
 
 - **`doc/ARCHITECTURE.md` — terminology and positioning** — updated title and overview to reflect stateful JWT authorization engine positioning; replaced all "TokenManager" occurrences with "TokenService" / `Manager`.
 
+- **ADR-004 and ADR-005 cross-referenced in `README.md` and `doc/ARCHITECTURE.md`** — `004-kid-validation.md` and `005-security-boundaries.md` added to the `doc/adr/` directory tree and the Architecture Decision Records table in both files.
+
 - **`doc/MIGRATION.md`** — new file; step-by-step migration guides from `golang-jwt/jwt` (manual token management → jwtauth), `gin-jwt` (framework lock-in → framework-agnostic middleware), and `lestrrat-go/jwx` (JOSE toolkit → focused engine). Covers common patterns (adding refresh tokens, adding revocation, zero-downtime key rotation), single-instance-to-distributed upgrade path, and a 10-item migration checklist.
 
 - **`doc/adr/`** — new directory; three Architecture Decision Records:

--- a/README.md
+++ b/README.md
@@ -1112,7 +1112,9 @@ github.com/aetomala/jwtauth/
 │       ├── README.md             # ADR index
 │       ├── 001-no-rate-limiting.md
 │       ├── 002-stateful-refresh-tokens.md
-│       └── 003-rs256-only.md
+│       ├── 003-rs256-only.md
+│       ├── 004-kid-validation.md
+│       └── 005-security-boundaries.md
 ├── examples/                     # Framework usage examples
 │   ├── README.md                 # Examples overview
 │   ├── gin-example/              # Gin HTTP framework
@@ -1286,6 +1288,8 @@ This library follows SOLID principles and clean architecture patterns. For detai
 | [ADR-001](doc/adr/001-no-rate-limiting.md) | No rate limiting — belongs at API Gateway / infrastructure layer | 2026-03-11 |
 | [ADR-002](doc/adr/002-stateful-refresh-tokens.md) | Stateful refresh tokens — opaque UUIDs for instant revocation | 2026-03-18 |
 | [ADR-003](doc/adr/003-rs256-only.md) | RS256 only — prevents algorithm confusion attacks | 2026-04-01 |
+| [ADR-004](doc/adr/004-kid-validation.md) | `kid` UUID validation at every `KeyStore` boundary — path traversal prevention | 2026-04-21 |
+| [ADR-005](doc/adr/005-security-boundaries.md) | Security boundaries — explicit validation gate for every attacker-controlled token field | 2026-04-21 |
 
 ## Rate Limiting
 

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -154,7 +154,9 @@ github.com/aetomala/jwtauth/
 │       ├── README.md              # ADR index
 │       ├── 001-no-rate-limiting.md
 │       ├── 002-stateful-refresh-tokens.md
-│       └── 003-rs256-only.md
+│       ├── 003-rs256-only.md
+│       ├── 004-kid-validation.md
+│       └── 005-security-boundaries.md
 ├── examples/                      # Framework usage examples
 │   ├── README.md                  # Examples overview
 │   ├── gin-example/               # Gin HTTP framework
@@ -1159,6 +1161,8 @@ Key design decisions are captured in `doc/adr/`. Each ADR documents the context,
 | [001](adr/001-no-rate-limiting.md) | No Rate Limiting in Library | 2026-03-11 |
 | [002](adr/002-stateful-refresh-tokens.md) | Stateful Refresh Tokens | 2026-03-18 |
 | [003](adr/003-rs256-only.md) | RS256 Only (No Algorithm Flexibility) | 2026-04-01 |
+| [004](adr/004-kid-validation.md) | `kid` UUID Validation at KeyStore Boundary | 2026-04-21 |
+| [005](adr/005-security-boundaries.md) | Security Boundaries — Attacker-Controlled Token Fields | 2026-04-21 |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `004-kid-validation.md` and `005-security-boundaries.md` to the `doc/adr/` directory tree in both `README.md` and `doc/ARCHITECTURE.md`
- Add ADR-004 and ADR-005 rows to the Architecture Decision Records table in both files
- Add CHANGELOG entry under `### Documentation`

## Test plan

- [ ] Verify directory trees in both files list all five ADR files
- [ ] Verify ADR table links resolve correctly against the files on `security/kid-validation` (merges before this)