### PR TITLE
docs: ADR-006 — KeyPrefix namespace isolation in Redis backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -1208,6 +1208,7 @@ This library follows SOLID principles and clean architecture patterns. For detai
 | [ADR-003](doc/adr/003-rs256-only.md) | RS256 only — prevents algorithm confusion attacks | 2026-04-01 |
 | [ADR-004](doc/adr/004-kid-validation.md) | `kid` UUID validation at every `KeyStore` boundary — path traversal prevention | 2026-04-21 |
 | [ADR-005](doc/adr/005-security-boundaries.md) | Security boundaries — explicit validation gate for every attacker-controlled token field | 2026-04-21 |
+| [ADR-006](doc/adr/006-keyprefix-namespace-isolation.md) | `KeyPrefix` — optional namespace isolation for Redis backends; opaque separator for any multi-instance deployment | 2026-04-27 |
 
 ## Rate Limiting
 

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -493,11 +493,11 @@ km, err := keys.NewManager(keys.KeyManagerConfig{
 
 Redis data layout:
 ```
-ks:pem:<keyID>   — PKCS#1 PEM-encoded RSA private key (string)
-ks:meta:<keyID>  — JSON-encoded KeyMetadata (string)
+[KeyPrefix]ks:pem:<keyID>   — PKCS#1 PEM-encoded RSA private key (string)
+[KeyPrefix]ks:meta:<keyID>  — JSON-encoded KeyMetadata (string)
 ```
 
-Keys carry no TTL — Manager owns the lifecycle and calls `Delete` explicitly via `cleanupExpiredKeys`. `LoadAll` uses `SCAN ks:pem:*` to enumerate all stored keys. `Save` writes both entries via a Redis Pipeline, so either both succeed or both fail — no partial state and no rollback code needed.
+Keys are optionally prefixed by `RedisKeyStoreConfig.KeyPrefix` (defaults to empty string — preserves current layout). Keys carry no TTL — Manager owns the lifecycle and calls `Delete` explicitly via `cleanupExpiredKeys`. `LoadAll` uses `SCAN {KeyPrefix}ks:pem:*` to enumerate all stored keys, scoping enumeration to the configured namespace. `Save` writes both entries via a Redis Pipeline, so either both succeed or both fail — no partial state and no rollback code needed.
 
 `ErrNilRedisClient` is returned by the constructor if client is nil. All other sentinel errors (`ErrKeyStoreKeyNotFound`, `ErrKeyStoreInvalidKeyID`) are shared with `DiskKeyStore` and defined in `keystore.go`.
 
@@ -622,9 +622,11 @@ type RedisRefreshStore struct {
 
 **Redis Data Structure**:
 ```
-tokens:{tokenID}        → Hash with fields: userID, expiresAt, createdAt, revoked, metadata
-user_tokens:{userID}    → Set of tokenIDs for that user
+[KeyPrefix]tokens:{tokenID}        → Hash with fields: userID, expiresAt, createdAt, revoked, metadata
+[KeyPrefix]user_tokens:{userID}    → Set of tokenIDs for that user
 ```
+
+Keys are optionally prefixed by `RedisRefreshStoreConfig.KeyPrefix`. `Cleanup` scans only `{KeyPrefix}tokens:*` — expired tokens from other namespaces are not affected.
 
 **Key Features**:
 - **Distributed**: Works across multiple instances (Redis is the shared backend)

--- a/doc/adr/006-keyprefix-namespace-isolation.md
+++ b/doc/adr/006-keyprefix-namespace-isolation.md
@@ -1,0 +1,24 @@
+# ADR-006: KeyPrefix — Namespace Isolation in Redis Backends
+
+**Date**: 2026-04-27  
+**Status**: Accepted
+
+## Context
+
+Both Redis store implementations (`RedisKeyStore`, `RedisRefreshStore`) used hardcoded key prefixes with no configuration surface. Any consumer that runs multiple Manager instances against a shared Redis instance — whether for multi-tenancy, environment separation, test isolation, or any other reason — has no way to prevent keyspace collision without resorting to separate Redis clients or separate Redis databases. Neither option is cost-effective at scale.
+
+## Decision
+
+Add an optional `KeyPrefix string` field to `RedisKeyStoreConfig` and `RedisRefreshStoreConfig`. The prefix is prepended to all internally constructed Redis keys. Empty string preserves current behavior exactly — fully backward compatible. The prefix is computed once at construction time into struct-level fields; no call-site concatenation with the raw constant occurs outside the constructor.
+
+The library treats the prefix as an **opaque namespace separator**. It enforces that every Redis operation within a store instance uses the configured prefix consistently — it does not interpret what the prefix means, does not validate its format, and does not prescribe any particular deployment model. What the prefix represents is entirely the consumer's decision.
+
+The other two implementations are out of scope for distinct reasons. `DiskKeyStore` uses a directory path as its natural namespace — two stores with different directories are structurally isolated at the filesystem level with no shared keyspace concern. `MemoryRefreshStore` is designed for development use only; multi-instance namespace isolation is a production deployment concern that does not apply to a development-only implementation.
+
+## Consequences
+
+- Multiple Manager instances can safely share a single Redis instance by using distinct prefixes
+- `DiskKeyStore` is unaffected — the directory path already provides structural filesystem-level isolation
+- `MemoryRefreshStore` is unaffected — it is designed for development use only; the shared-Redis multi-instance namespace problem is a production concern that does not apply
+- Consumers using the empty default need no migration
+- `SCAN`-based operations (`LoadAll`, `Cleanup`) now scan only within the configured namespace — operations in one namespace do not observe or affect keys in another

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -21,3 +21,4 @@ Each ADR includes:
 - [ADR-003: RS256 Only](003-rs256-only.md)
 - [ADR-004: Key ID (kid) Validation at the KeyStore Boundary](004-kid-validation.md)
 - [ADR-005: Security Boundaries — Attacker-Controlled Token Fields](005-security-boundaries.md)
+- [ADR-006: KeyPrefix — Namespace Isolation in Redis Backends](006-keyprefix-namespace-isolation.md)


### PR DESCRIPTION
## What

Documents the `KeyPrefix` design decision for Issue #104.

- **`doc/adr/006-keyprefix-namespace-isolation.md`** — new ADR capturing context, decision, and consequences; prefix is framed as an opaque namespace separator applicable to any consumer deployment model
- **`doc/adr/README.md`** — ADR-006 index entry added
- **`README.md`** — ADR-006 row added to the ADR table
- **`doc/ARCHITECTURE.md`** — both Redis data layout sections updated with `[KeyPrefix]` notation and SCAN scoping note

## Why separate PR

Documentation describes the design, not the merged code. This branch was cut off `dev` independently of PR #110 (Phase 1 implementation) so both can be reviewed and squash-merged in any order.

## No code changes

CI passes (748 specs, race-clean). No Go files modified.