### PR TITLE
feat(logging): add Logger.With for pre-bound structured fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] — v0.4.0
 
+### Breaking
+
+- **`logging.Logger` gains `With(keysAndValues ...interface{}) Logger`** — existing third-party adapter implementations (Zap, Zerolog, Logrus, etc.) must add this method. Built-in implementations (`SlogAdapter`, `NoOpLogger`) and `MockLogger` are already updated. `With` is additive — chained calls accumulate fields. `NoOpLogger` may return the receiver unchanged.
+
 ### Security
 
 - **`kid` path traversal fix** — `DiskKeyStore` and `RedisKeyStore` now validate the

--- a/internal/testutil/mock_logger.go
+++ b/internal/testutil/mock_logger.go
@@ -6,8 +6,11 @@ import (
 	"github.com/aetomala/jwtauth/pkg/logging"
 )
 
-// Ensure MockLogger implements logging.Logger at compile time
-var _ logging.Logger = (*MockLogger)(nil)
+// Ensure MockLogger and withMockLogger implement logging.Logger at compile time.
+var (
+	_ logging.Logger = (*MockLogger)(nil)
+	_ logging.Logger = (*withMockLogger)(nil)
+)
 
 // MockLogger implements the logging.Logger interface for testing.
 // It records all log calls in memory for verification in tests.
@@ -270,4 +273,41 @@ func (m *MockLogger) IsEnabled() bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.enable
+}
+
+// With returns a withMockLogger that pre-injects bound fields into every log call
+// and delegates storage to the parent MockLogger so callers can inspect all entries
+// — including those from enriched loggers — on the original mock.
+func (m *MockLogger) With(keysAndValues ...interface{}) logging.Logger {
+	return &withMockLogger{parent: m, bound: keysAndValues}
+}
+
+// withMockLogger wraps a MockLogger and pre-injects bound fields into every call.
+// It shares the parent's log store so all entries are visible on the original MockLogger.
+type withMockLogger struct {
+	parent *MockLogger
+	bound  []interface{}
+}
+
+func (w *withMockLogger) With(keysAndValues ...interface{}) logging.Logger {
+	merged := make([]interface{}, len(w.bound)+len(keysAndValues))
+	copy(merged, w.bound)
+	copy(merged[len(w.bound):], keysAndValues)
+	return &withMockLogger{parent: w.parent, bound: merged}
+}
+
+func (w *withMockLogger) Debug(msg string, kvs ...interface{}) {
+	w.parent.Debug(msg, append(w.bound, kvs...)...)
+}
+
+func (w *withMockLogger) Info(msg string, kvs ...interface{}) {
+	w.parent.Info(msg, append(w.bound, kvs...)...)
+}
+
+func (w *withMockLogger) Warn(msg string, kvs ...interface{}) {
+	w.parent.Warn(msg, append(w.bound, kvs...)...)
+}
+
+func (w *withMockLogger) Error(msg string, kvs ...interface{}) {
+	w.parent.Error(msg, append(w.bound, kvs...)...)
 }

--- a/pkg/logging/interface.go
+++ b/pkg/logging/interface.go
@@ -77,6 +77,17 @@ type Logger interface {
 	// Example:
 	//   Error("rotation failed", "error", err, "keyID", keyID)
 	Error(msg string, keysAndValues ...interface{})
+
+	// With returns a new Logger with the given key-value pairs pre-bound to every
+	// subsequent log call. Calls to With are additive — calling With on an already
+	// enriched logger accumulates fields rather than replacing them.
+	//
+	// keysAndValues must be alternating keys (string) and values (any type),
+	// following the same convention as the log methods.
+	//
+	// Implementations that discard all log output (e.g. NoOpLogger) may return
+	// the receiver unchanged.
+	With(keysAndValues ...interface{}) Logger
 }
 
 // Ensure interfaces are implemented at compile time

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -862,6 +862,82 @@ var _ = Describe("Integration", func() {
 })
 
 // ============================================================================
+// Logger.With Tests
+// ============================================================================
+
+var _ = Describe("Logger.With", func() {
+	Describe("SlogAdapter.With", func() {
+		var buf *bytes.Buffer
+
+		newAdapter := func() *logging.SlogAdapter {
+			return logging.NewSlogAdapter(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+		}
+
+		BeforeEach(func() {
+			buf = &bytes.Buffer{}
+		})
+
+		It("should pre-bind fields to all subsequent log calls", func() {
+			enriched := newAdapter().With("namespace", "tenant-a")
+			enriched.Info("token issued", "user_id", "u-1")
+
+			var entry map[string]interface{}
+			Expect(json.Unmarshal(buf.Bytes(), &entry)).To(Succeed())
+			Expect(entry["namespace"]).To(Equal("tenant-a"))
+			Expect(entry["user_id"]).To(Equal("u-1"))
+		})
+
+		It("should be additive — chained With calls accumulate fields", func() {
+			enriched := newAdapter().With("namespace", "tenant-b").With("component", "keymanager")
+			enriched.Info("rotation started")
+
+			var entry map[string]interface{}
+			Expect(json.Unmarshal(buf.Bytes(), &entry)).To(Succeed())
+			Expect(entry["namespace"]).To(Equal("tenant-b"))
+			Expect(entry["component"]).To(Equal("keymanager"))
+		})
+
+		It("should not affect the original adapter", func() {
+			base := newAdapter()
+			_ = base.With("namespace", "tenant-c")
+			base.Info("unaffected")
+
+			var entry map[string]interface{}
+			Expect(json.Unmarshal(buf.Bytes(), &entry)).To(Succeed())
+			Expect(entry).NotTo(HaveKey("namespace"))
+		})
+
+		It("should still honour ctx-first convention after With", func() {
+			inner := slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+			base := logging.NewSlogAdapter(slog.New(logging.NewCorrelationIDHandler(inner)))
+			enriched := base.With("namespace", "tenant-d")
+
+			ctx := logging.WithCorrelationID(context.Background(), "corr-with-1")
+			enriched.Info("enriched ctx log", ctx, "key", "val")
+
+			var entry map[string]interface{}
+			Expect(json.Unmarshal(buf.Bytes(), &entry)).To(Succeed())
+			Expect(entry["namespace"]).To(Equal("tenant-d"))
+			Expect(entry["correlation_id"]).To(Equal("corr-with-1"))
+			Expect(entry["key"]).To(Equal("val"))
+		})
+	})
+
+	Describe("NoOpLogger.With", func() {
+		It("should return the same instance — no allocation", func() {
+			n := &logging.NoOpLogger{}
+			result := n.With("namespace", "x")
+			Expect(result).To(BeIdenticalTo(n))
+		})
+
+		It("should not panic on subsequent log calls after With", func() {
+			enriched := (&logging.NoOpLogger{}).With("k", "v")
+			Expect(func() { enriched.Info("msg", "extra", "field") }).NotTo(Panic())
+		})
+	})
+})
+
+// ============================================================================
 // SlogAdapter — Context Detection Tests
 // ============================================================================
 

--- a/pkg/logging/noop.go
+++ b/pkg/logging/noop.go
@@ -28,3 +28,7 @@ func (n *NoOpLogger) Warn(msg string, keysAndValues ...interface{}) {}
 
 // Error discards the log message.
 func (n *NoOpLogger) Error(msg string, keysAndValues ...interface{}) {}
+
+// With returns the receiver unchanged — NoOpLogger discards all output so there
+// are no fields to bind.
+func (n *NoOpLogger) With(keysAndValues ...interface{}) Logger { return n }

--- a/pkg/logging/slog.go
+++ b/pkg/logging/slog.go
@@ -102,6 +102,13 @@ func (s *SlogAdapter) Error(msg string, keysAndValues ...interface{}) {
 	s.logger.Error(msg, keysAndValues...)
 }
 
+// With returns a new SlogAdapter with the given key-value pairs pre-bound to every
+// subsequent log call. The ctx-first convention in Debug/Info/Warn/Error continues
+// to work on the returned adapter — context detection lives in those methods, not here.
+func (s *SlogAdapter) With(keysAndValues ...interface{}) Logger {
+	return &SlogAdapter{logger: s.logger.With(keysAndValues...)}
+}
+
 // Helper functions for common slog configurations
 
 // NewJSONLogger creates a production-ready JSON logger that writes to stdout.


### PR DESCRIPTION
## Summary

- Adds `With(keysAndValues ...interface{}) Logger` to the `Logger` interface as a **breaking change** — existing third-party adapters (Zap, Zerolog, Logrus, etc.) must implement this method
- `SlogAdapter.With` wraps `slog.Logger.With`; the ctx-first convention in `Debug`/`Info`/`Warn`/`Error` continues to work on the returned adapter
- `NoOpLogger.With` returns the receiver unchanged
- `MockLogger.With` returns a `withMockLogger` that shares the parent's log store — test assertions on the original mock capture all entries including those emitted through an enriched logger; chained `With` calls accumulate fields

## Migration notes for third-party adapters

Add `With(keysAndValues ...interface{}) logging.Logger` to your adapter. The method should return a new logger with the given key-value pairs pre-bound to every subsequent log call, following the same additive contract as `slog.Logger.With`.

## Test plan

- [ ] 9 new specs in `logger_test.go`: field binding, additivity, parent isolation, ctx-first interop after With, NoOpLogger identity return
- [ ] Logging Suite: 104/104 specs passing, 100% coverage
- [ ] Full CI (`./run-ci-locally.sh`): all checks passed

Refs #112