### PR TITLE
feat(keys,storage): add Namespace() to KeyStore and RefreshStore interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 
 - **`logging.Logger` gains `With(keysAndValues ...interface{}) Logger`** — existing third-party adapter implementations (Zap, Zerolog, Logrus, etc.) must add this method. Built-in implementations (`SlogAdapter`, `NoOpLogger`) and `MockLogger` are already updated. `With` is additive — chained calls accumulate fields. `NoOpLogger` may return the receiver unchanged.
 
+- **`keys.KeyStore` gains `Namespace() string`** — existing implementations must add this method. `RedisKeyStore` returns the configured `KeyPrefix`; `DiskKeyStore` returns `""`. `MockKeyStore` regenerated.
+
+- **`storage.RefreshStore` gains `Namespace() string`** — existing implementations must add this method. `RedisRefreshStore` returns the configured `KeyPrefix`; `MemoryRefreshStore` returns `""`. `MockRefreshStore` regenerated.
+
 ### Security
 
 - **`kid` path traversal fix** — `DiskKeyStore` and `RedisKeyStore` now validate the

--- a/internal/testutil/mock_keystore.go
+++ b/internal/testutil/mock_keystore.go
@@ -87,6 +87,20 @@ func (mr *MockKeyStoreMockRecorder) LoadKey(ctx, keyID any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadKey", reflect.TypeOf((*MockKeyStore)(nil).LoadKey), ctx, keyID)
 }
 
+// Namespace mocks base method.
+func (m *MockKeyStore) Namespace() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Namespace")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Namespace indicates an expected call of Namespace.
+func (mr *MockKeyStoreMockRecorder) Namespace() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Namespace", reflect.TypeOf((*MockKeyStore)(nil).Namespace))
+}
+
 // Save mocks base method.
 func (m *MockKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.PrivateKey, meta keys.KeyMetadata) error {
 	m.ctrl.T.Helper()

--- a/internal/testutil/mock_refreshstore.go
+++ b/internal/testutil/mock_refreshstore.go
@@ -57,6 +57,20 @@ func (mr *MockRefreshStoreMockRecorder) Cleanup(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cleanup", reflect.TypeOf((*MockRefreshStore)(nil).Cleanup), ctx)
 }
 
+// Namespace mocks base method.
+func (m *MockRefreshStore) Namespace() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Namespace")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Namespace indicates an expected call of Namespace.
+func (mr *MockRefreshStoreMockRecorder) Namespace() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Namespace", reflect.TypeOf((*MockRefreshStore)(nil).Namespace))
+}
+
 // Retrieve mocks base method.
 func (m *MockRefreshStore) Retrieve(ctx context.Context, tokenID string) (*storage.RefreshToken, error) {
 	m.ctrl.T.Helper()

--- a/pkg/keys/disk.go
+++ b/pkg/keys/disk.go
@@ -96,6 +96,10 @@ func NewDiskKeyStore(cfg DiskKeyStoreConfig) (*DiskKeyStore, error) {
 	}, nil
 }
 
+// Namespace returns empty string — DiskKeyStore uses directory-level isolation
+// and does not support the namespace concept.
+func (d *DiskKeyStore) Namespace() string { return "" }
+
 // startSpan begins a new tracing span with storage.backend pre-set to "disk".
 func (d *DiskKeyStore) startSpan(ctx context.Context, operation string) (context.Context, tracing.Span) {
 	return d.tracer.Start(ctx, "DiskKeyStore."+operation,

--- a/pkg/keys/keystore.go
+++ b/pkg/keys/keystore.go
@@ -53,6 +53,11 @@ type KeyStore interface {
 	// Manager.cleanupExpiredKeys. If the key does not exist, no error is returned.
 	// Returns ErrKeyStoreInvalidKeyID if keyID is not a valid UUID v4 string.
 	Delete(ctx context.Context, keyID string) error
+
+	// Namespace returns the namespace this store is operating in. For Redis-backed
+	// stores this matches the configured KeyPrefix. Implementations that do not
+	// support namespacing return empty string.
+	Namespace() string
 }
 
 // Sentinel errors for KeyStore operations.

--- a/pkg/keys/redis.go
+++ b/pkg/keys/redis.go
@@ -48,6 +48,7 @@ type RedisKeyStore struct {
 	client *redis.Client // Thread-safe Redis client
 
 	// ===== Key Prefixes =====
+	namespace  string // = cfg.KeyPrefix; returned by Namespace()
 	pemPrefix  string // = cfg.KeyPrefix + keyPEMPrefix;  applied to all PEM keys
 	metaPrefix string // = cfg.KeyPrefix + keyMetaPrefix; applied to all metadata keys
 
@@ -81,6 +82,7 @@ func NewRedisKeyStore(cfg RedisKeyStoreConfig) (*RedisKeyStore, error) {
 	// ===== STEP 3: Return Initialized Store =====
 	return &RedisKeyStore{
 		client:     cfg.Client,
+		namespace:  cfg.KeyPrefix,
 		pemPrefix:  cfg.KeyPrefix + keyPEMPrefix,
 		metaPrefix: cfg.KeyPrefix + keyMetaPrefix,
 		logger:     cfg.Logger,
@@ -89,6 +91,10 @@ func NewRedisKeyStore(cfg RedisKeyStoreConfig) (*RedisKeyStore, error) {
 		backend:    "redis",
 	}, nil
 }
+
+// Namespace returns the KeyPrefix this store was configured with. An empty
+// string indicates an unscoped (single-tenant) deployment.
+func (r *RedisKeyStore) Namespace() string { return r.namespace }
 
 // startSpan starts a new span for the given operation name, pre-seeded with
 // the storage.backend attribute.

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -99,6 +99,11 @@ type RefreshStore interface {
 	//   - count: Number of tokens deleted
 	//   - error: If cleanup fails
 	Cleanup(ctx context.Context) (int, error)
+
+	// Namespace returns the namespace this store is operating in. For Redis-backed
+	// stores this matches the configured KeyPrefix. Implementations that do not
+	// support namespacing return empty string.
+	Namespace() string
 }
 
 // RefreshToken represents a stored refresh token.

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -76,6 +76,10 @@ func NewMemoryRefreshStore(cfg MemoryRefreshStoreConfig) *MemoryRefreshStore {
 	}
 }
 
+// Namespace returns empty string — MemoryRefreshStore is development-only and
+// does not support multi-tenant namespace isolation.
+func (m *MemoryRefreshStore) Namespace() string { return "" }
+
 // startSpan starts a new span for the given operation name, pre-seeded with
 // the storage.backend attribute.
 func (m *MemoryRefreshStore) startSpan(ctx context.Context, operation string) (context.Context, tracing.Span) {

--- a/pkg/storage/redis.go
+++ b/pkg/storage/redis.go
@@ -47,6 +47,7 @@ type RedisRefreshStore struct {
 	client *redis.Client // Redis client; internally thread-safe
 
 	// ===== Key Prefixes =====
+	namespace     string // = cfg.KeyPrefix; returned by Namespace()
 	tokenPrefix   string // = cfg.KeyPrefix + tokenKeyPrefix;   applied to all token hash keys
 	userSetPrefix string // = cfg.KeyPrefix + userSetKeyPrefix; applied to all user-set keys
 
@@ -79,6 +80,7 @@ func NewRedisRefreshStore(cfg RedisRefreshStoreConfig) (*RedisRefreshStore, erro
 
 	return &RedisRefreshStore{
 		client:        cfg.Client,
+		namespace:     cfg.KeyPrefix,
 		tokenPrefix:   cfg.KeyPrefix + tokenKeyPrefix,
 		userSetPrefix: cfg.KeyPrefix + userSetKeyPrefix,
 		logger:        cfg.Logger,
@@ -87,6 +89,10 @@ func NewRedisRefreshStore(cfg RedisRefreshStoreConfig) (*RedisRefreshStore, erro
 		backend:       "redis",
 	}, nil
 }
+
+// Namespace returns the KeyPrefix this store was configured with. An empty
+// string indicates an unscoped (single-tenant) deployment.
+func (r *RedisRefreshStore) Namespace() string { return r.namespace }
 
 // startSpan starts a new span for the given operation name, pre-seeded with
 // the storage.backend attribute.


### PR DESCRIPTION
## Summary

- Adds `Namespace() string` to `keys.KeyStore` and `storage.RefreshStore` — **breaking change** for any third-party implementations
- `RedisKeyStore` and `RedisRefreshStore` return the configured `KeyPrefix`; the raw value is stored in a new `namespace` field set at construction alongside the computed Redis key prefixes
- `DiskKeyStore` returns `""` — directory-level isolation applies, no namespace concept
- `MemoryRefreshStore` returns `""` — development-only, shared-Redis multi-instance isolation does not apply
- Both mocks regenerated via `go generate`

## Migration notes for third-party implementations

Add `Namespace() string` to any custom `KeyStore` or `RefreshStore` implementation. Implementations that do not support namespacing should return `""`.

## Test plan

- [x] Full CI (`./run-ci-locally.sh`): all checks passed (168 key + 184 token + 136 storage + 104 logging + 66 metrics + 78 tracing specs, 28 integration specs)
- [x] `grep -n "Namespace" internal/testutil/mock_keystore.go internal/testutil/mock_refreshstore.go` confirms generated methods present
- [x] `go vet`, `golangci-lint`, `govulncheck` all clean

Refs #112