### PR TITLE
feat(keys,storage,metrics): wire namespace through Redis store observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@ All notable changes to this project will be documented in this file.
 
 - **`Namespace string` added to `KeyManagerConfig` and `TokenManagerConfig`** — optional opaque label stored in both manager structs at construction time. Zero value preserves current behavior — no label is attached to observability output. Intended for multi-instance deployments where log lines, trace spans, and metric labels from different manager instances must be disambiguated. Decoupled from `KeyPrefix` — both fields may be set independently. See ADR-007.
 
+- **`RedisKeyStore` and `RedisRefreshStore` emit namespace across all three signal types** — when `KeyPrefix` is non-empty, every span carries a `storage.namespace` attribute, every log line carries a `namespace` field (via `Logger.With` in the constructor — no per-call-site changes), and every Prometheus metric carries a `namespace` label. Zero-value `KeyPrefix` emits an empty string label, preserving backward compatibility. Closes #112 (Phase 3).
+
 ### Fixed
 
 - **`KeyInfo.KeySizeBits` now reports actual key size** — previously sourced from `KeyManagerConfig.KeySize` (caller-supplied), which could silently diverge from the actual RSA key on disk if the `DiskKeyStore` or `RedisKeyStore` was configured with a different key size. Now derived from `keyPair.PrivateKey.N.BitLen()` so the reported value always matches the real key material.

--- a/pkg/keys/redis.go
+++ b/pkg/keys/redis.go
@@ -78,6 +78,9 @@ func NewRedisKeyStore(cfg RedisKeyStoreConfig) (*RedisKeyStore, error) {
 	if cfg.Tracer == nil {
 		cfg.Tracer = defaults.Tracer
 	}
+	if cfg.KeyPrefix != "" {
+		cfg.Logger = cfg.Logger.With("namespace", cfg.KeyPrefix)
+	}
 
 	// ===== STEP 3: Return Initialized Store =====
 	return &RedisKeyStore{
@@ -97,10 +100,13 @@ func NewRedisKeyStore(cfg RedisKeyStoreConfig) (*RedisKeyStore, error) {
 func (r *RedisKeyStore) Namespace() string { return r.namespace }
 
 // startSpan starts a new span for the given operation name, pre-seeded with
-// the storage.backend attribute.
+// the storage.backend and storage.namespace attributes.
 func (r *RedisKeyStore) startSpan(ctx context.Context, operation string) (context.Context, tracing.Span) {
 	return r.tracer.Start(ctx, "RedisKeyStore."+operation,
-		tracing.WithAttributes(map[string]any{"storage.backend": r.backend}),
+		tracing.WithAttributes(map[string]any{
+			"storage.backend":   r.backend,
+			"storage.namespace": r.namespace,
+		}),
 	)
 }
 
@@ -122,14 +128,17 @@ func (r *RedisKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 			"status":          status,
 			"error_type":      errorType,
 			"storage_backend": r.backend,
+			"namespace":       r.namespace,
 		})
 		r.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
 			"operation":       "load_all",
 			"storage_backend": r.backend,
+			"namespace":       r.namespace,
 		})
 		if status == "success" {
 			r.metrics.SetGauge(metricKeyStoreKeysCount, float64(keyCount), map[string]string{
 				"storage_backend": r.backend,
+				"namespace":       r.namespace,
 			})
 		}
 	}()
@@ -235,10 +244,12 @@ func (r *RedisKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.
 			"status":          status,
 			"error_type":      errorType,
 			"storage_backend": r.backend,
+			"namespace":       r.namespace,
 		})
 		r.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
 			"operation":       "save",
 			"storage_backend": r.backend,
+			"namespace":       r.namespace,
 		})
 	}()
 
@@ -314,10 +325,12 @@ func (r *RedisKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta K
 			"status":          status,
 			"error_type":      errorType,
 			"storage_backend": r.backend,
+			"namespace":       r.namespace,
 		})
 		r.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
 			"operation":       "update_metadata",
 			"storage_backend": r.backend,
+			"namespace":       r.namespace,
 		})
 	}()
 
@@ -403,10 +416,12 @@ func (r *RedisKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.Private
 			"status":          status,
 			"error_type":      errorType,
 			"storage_backend": r.backend,
+			"namespace":       r.namespace,
 		})
 		r.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
 			"operation":       "load_key",
 			"storage_backend": r.backend,
+			"namespace":       r.namespace,
 		})
 	}()
 
@@ -509,10 +524,12 @@ func (r *RedisKeyStore) Delete(ctx context.Context, keyID string) error {
 			"status":          status,
 			"error_type":      errorType,
 			"storage_backend": r.backend,
+			"namespace":       r.namespace,
 		})
 		r.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
 			"operation":       "delete",
 			"storage_backend": r.backend,
+			"namespace":       r.namespace,
 		})
 	}()
 

--- a/pkg/keys/redis_test.go
+++ b/pkg/keys/redis_test.go
@@ -521,10 +521,12 @@ var _ = Describe("RedisKeyStore", func() {
 				"status":          status,
 				"error_type":      errorType,
 				"storage_backend": "redis",
+				"namespace":       "",
 			})
 			mockM.EXPECT().RecordDuration("jwtauth_keystore_operation_duration_seconds", gomock.Any(), map[string]string{
 				"operation":       operation,
 				"storage_backend": "redis",
+				"namespace":       "",
 			})
 		}
 
@@ -544,6 +546,7 @@ var _ = Describe("RedisKeyStore", func() {
 				expectOpsMetrics("load_all", "success")
 				mockM.EXPECT().SetGauge("jwtauth_keystore_keys_count", gomock.Any(), map[string]string{
 					"storage_backend": "redis",
+					"namespace":       "",
 				})
 				store := newMetricStore()
 				_, err := store.LoadAll(ctx)

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -116,35 +116,35 @@ func (pm *PrometheusMetrics) registerAllMetrics(namespace string) {
 
 	pm.registerCounter(namespace, "storage_operations_total",
 		"Total number of storage operations",
-		[]string{"operation", "status", "error_type", "storage_backend"})
+		[]string{"operation", "status", "error_type", "storage_backend", "namespace"})
 
 	pm.registerCounter(namespace, "storage_cleanup_tokens_removed_total",
 		"Total number of tokens removed during cleanup",
-		[]string{"storage_backend"})
+		[]string{"storage_backend", "namespace"})
 
 	pm.registerHistogram(namespace, "storage_operation_duration_seconds",
 		"Duration of storage operations in seconds",
-		[]string{"operation", "storage_backend"},
+		[]string{"operation", "storage_backend", "namespace"},
 		[]float64{.0001, .0005, .001, .0025, .005, .01, .025, .05, .1, .25})
 
 	pm.registerGauge(namespace, "storage_tokens_count",
 		"Number of tokens in storage",
-		[]string{"storage_backend"})
+		[]string{"storage_backend", "namespace"})
 
 	// ===== KeyStore Metrics =====
 
 	pm.registerCounter(namespace, "keystore_operations_total",
 		"Total number of key store operations",
-		[]string{"operation", "status", "error_type", "storage_backend"})
+		[]string{"operation", "status", "error_type", "storage_backend", "namespace"})
 
 	pm.registerHistogram(namespace, "keystore_operation_duration_seconds",
 		"Duration of key store operations in seconds",
-		[]string{"operation", "storage_backend"},
+		[]string{"operation", "storage_backend", "namespace"},
 		[]float64{.0001, .0005, .001, .0025, .005, .01, .025, .05, .1, .25})
 
 	pm.registerGauge(namespace, "keystore_keys_count",
 		"Number of keys in the key store",
-		[]string{"storage_backend"})
+		[]string{"storage_backend", "namespace"})
 
 	// ===== KeyManager Metrics =====
 

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -403,7 +403,7 @@ var _ = Describe("Prometheus", func() {
 			})
 
 			It("should handle microsecond precision", func() {
-				labels := map[string]string{"operation": "retrieve", "storage_backend": "memory"}
+				labels := map[string]string{"operation": "retrieve", "storage_backend": "memory", "namespace": ""}
 				pm.RecordDuration("jwtauth_storage_operation_duration_seconds", 100*time.Microsecond, labels)
 
 				Expect(histogramSampleCount(registry, "jwtauth_storage_operation_duration_seconds", labels)).To(Equal(uint64(1)))
@@ -700,10 +700,12 @@ var _ = Describe("Prometheus", func() {
 					"status":          "success",
 					"error_type":      "",
 					"storage_backend": "redis",
+					"namespace":       "",
 				})
 				pm.RecordDuration("jwtauth_storage_operation_duration_seconds", 2*time.Millisecond, map[string]string{
 					"operation":       "store",
 					"storage_backend": "redis",
+					"namespace":       "",
 				})
 
 				// Retrieve operation
@@ -712,28 +714,32 @@ var _ = Describe("Prometheus", func() {
 					"status":          "success",
 					"error_type":      "",
 					"storage_backend": "redis",
+					"namespace":       "",
 				})
 				pm.RecordDuration("jwtauth_storage_operation_duration_seconds", 1*time.Millisecond, map[string]string{
 					"operation":       "retrieve",
 					"storage_backend": "redis",
+					"namespace":       "",
 				})
 
 				// Cleanup
 				pm.AddCounter("jwtauth_storage_cleanup_tokens_removed_total", 25.0, map[string]string{
 					"storage_backend": "redis",
+					"namespace":       "",
 				})
 
 				// Update storage size
 				pm.SetGauge("jwtauth_storage_tokens_count", 975, map[string]string{
 					"storage_backend": "redis",
+					"namespace":       "",
 				})
 
-				Expect(counterValue(registry, "jwtauth_storage_operations_total", map[string]string{"operation": "store", "status": "success", "error_type": "", "storage_backend": "redis"})).To(Equal(1.0))
-				Expect(counterValue(registry, "jwtauth_storage_operations_total", map[string]string{"operation": "retrieve", "status": "success", "error_type": "", "storage_backend": "redis"})).To(Equal(1.0))
-				Expect(counterValue(registry, "jwtauth_storage_cleanup_tokens_removed_total", map[string]string{"storage_backend": "redis"})).To(Equal(25.0))
-				Expect(histogramSampleCount(registry, "jwtauth_storage_operation_duration_seconds", map[string]string{"operation": "store", "storage_backend": "redis"})).To(Equal(uint64(1)))
-				Expect(histogramSampleCount(registry, "jwtauth_storage_operation_duration_seconds", map[string]string{"operation": "retrieve", "storage_backend": "redis"})).To(Equal(uint64(1)))
-				Expect(gaugeValue(registry, "jwtauth_storage_tokens_count", map[string]string{"storage_backend": "redis"})).To(Equal(975.0))
+				Expect(counterValue(registry, "jwtauth_storage_operations_total", map[string]string{"operation": "store", "status": "success", "error_type": "", "storage_backend": "redis", "namespace": ""})).To(Equal(1.0))
+				Expect(counterValue(registry, "jwtauth_storage_operations_total", map[string]string{"operation": "retrieve", "status": "success", "error_type": "", "storage_backend": "redis", "namespace": ""})).To(Equal(1.0))
+				Expect(counterValue(registry, "jwtauth_storage_cleanup_tokens_removed_total", map[string]string{"storage_backend": "redis", "namespace": ""})).To(Equal(25.0))
+				Expect(histogramSampleCount(registry, "jwtauth_storage_operation_duration_seconds", map[string]string{"operation": "store", "storage_backend": "redis", "namespace": ""})).To(Equal(uint64(1)))
+				Expect(histogramSampleCount(registry, "jwtauth_storage_operation_duration_seconds", map[string]string{"operation": "retrieve", "storage_backend": "redis", "namespace": ""})).To(Equal(uint64(1)))
+				Expect(gaugeValue(registry, "jwtauth_storage_tokens_count", map[string]string{"storage_backend": "redis", "namespace": ""})).To(Equal(975.0))
 			})
 		})
 

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -110,14 +110,17 @@ func (m *MemoryRefreshStore) Store(ctx context.Context, tokenID, userID string, 
 			"status":          status,
 			"error_type":      errorType,
 			"storage_backend": m.backend,
+			"namespace":       "",
 		})
 		m.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), map[string]string{
 			"operation":       "store",
 			"storage_backend": m.backend,
+			"namespace":       "",
 		})
 		if status == "success" {
 			m.metrics.SetGauge(metricStorageTokensCount, float64(tokenCount), map[string]string{
 				"storage_backend": m.backend,
+				"namespace":       "",
 			})
 		}
 	}()
@@ -228,10 +231,12 @@ func (m *MemoryRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Ref
 			"status":          status,
 			"error_type":      errorType,
 			"storage_backend": m.backend,
+			"namespace":       "",
 		})
 		m.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), map[string]string{
 			"operation":       "retrieve",
 			"storage_backend": m.backend,
+			"namespace":       "",
 		})
 	}()
 
@@ -343,10 +348,12 @@ func (m *MemoryRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 			"status":          status,
 			"error_type":      errorType,
 			"storage_backend": m.backend,
+			"namespace":       "",
 		})
 		m.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), map[string]string{
 			"operation":       "revoke",
 			"storage_backend": m.backend,
+			"namespace":       "",
 		})
 	}()
 
@@ -416,10 +423,12 @@ func (m *MemoryRefreshStore) RevokeAllForUser(ctx context.Context, userID string
 			"status":          status,
 			"error_type":      errorType,
 			"storage_backend": m.backend,
+			"namespace":       "",
 		})
 		m.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), map[string]string{
 			"operation":       "revoke_all",
 			"storage_backend": m.backend,
+			"namespace":       "",
 		})
 	}()
 
@@ -490,17 +499,21 @@ func (m *MemoryRefreshStore) Cleanup(ctx context.Context) (int, error) {
 			"status":          status,
 			"error_type":      errorType,
 			"storage_backend": m.backend,
+			"namespace":       "",
 		})
 		m.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), map[string]string{
 			"operation":       "cleanup",
 			"storage_backend": m.backend,
+			"namespace":       "",
 		})
 		if status == "success" {
 			m.metrics.AddCounter(metricStorageRemovedTotal, float64(removed), map[string]string{
 				"storage_backend": m.backend,
+				"namespace":       "",
 			})
 			m.metrics.SetGauge(metricStorageTokensCount, float64(remaining), map[string]string{
 				"storage_backend": m.backend,
+				"namespace":       "",
 			})
 		}
 	}()

--- a/pkg/storage/redis.go
+++ b/pkg/storage/redis.go
@@ -77,6 +77,9 @@ func NewRedisRefreshStore(cfg RedisRefreshStoreConfig) (*RedisRefreshStore, erro
 	if cfg.Tracer == nil {
 		cfg.Tracer = defaults.Tracer
 	}
+	if cfg.KeyPrefix != "" {
+		cfg.Logger = cfg.Logger.With("namespace", cfg.KeyPrefix)
+	}
 
 	return &RedisRefreshStore{
 		client:        cfg.Client,
@@ -95,10 +98,13 @@ func NewRedisRefreshStore(cfg RedisRefreshStoreConfig) (*RedisRefreshStore, erro
 func (r *RedisRefreshStore) Namespace() string { return r.namespace }
 
 // startSpan starts a new span for the given operation name, pre-seeded with
-// the storage.backend attribute.
+// the storage.backend and storage.namespace attributes.
 func (r *RedisRefreshStore) startSpan(ctx context.Context, operation string) (context.Context, tracing.Span) {
 	return r.tracer.Start(ctx, "RedisRefreshStore."+operation,
-		tracing.WithAttributes(map[string]any{"storage.backend": r.backend}),
+		tracing.WithAttributes(map[string]any{
+			"storage.backend":   r.backend,
+			"storage.namespace": r.namespace,
+		}),
 	)
 }
 
@@ -123,10 +129,12 @@ func (r *RedisRefreshStore) Store(ctx context.Context, tokenID, userID string, e
 			"status":          status,
 			"error_type":      errorType,
 			"storage_backend": r.backend,
+			"namespace":       r.namespace,
 		})
 		r.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), map[string]string{
 			"operation":       "store",
 			"storage_backend": r.backend,
+			"namespace":       r.namespace,
 		})
 	}()
 
@@ -263,10 +271,12 @@ func (r *RedisRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Refr
 			"status":          status,
 			"error_type":      errorType,
 			"storage_backend": r.backend,
+			"namespace":       r.namespace,
 		})
 		r.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), map[string]string{
 			"operation":       "retrieve",
 			"storage_backend": r.backend,
+			"namespace":       r.namespace,
 		})
 	}()
 
@@ -420,10 +430,12 @@ func (r *RedisRefreshStore) Revoke(ctx context.Context, tokenID string) error {
 			"status":          status,
 			"error_type":      errorType,
 			"storage_backend": r.backend,
+			"namespace":       r.namespace,
 		})
 		r.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), map[string]string{
 			"operation":       "revoke",
 			"storage_backend": r.backend,
+			"namespace":       r.namespace,
 		})
 	}()
 
@@ -510,10 +522,12 @@ func (r *RedisRefreshStore) RevokeAllForUser(ctx context.Context, userID string)
 			"status":          status,
 			"error_type":      errorType,
 			"storage_backend": r.backend,
+			"namespace":       r.namespace,
 		})
 		r.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), map[string]string{
 			"operation":       "revoke_all",
 			"storage_backend": r.backend,
+			"namespace":       r.namespace,
 		})
 	}()
 
@@ -606,17 +620,21 @@ func (r *RedisRefreshStore) Cleanup(ctx context.Context) (int, error) {
 			"status":          status,
 			"error_type":      errorType,
 			"storage_backend": r.backend,
+			"namespace":       r.namespace,
 		})
 		r.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), map[string]string{
 			"operation":       "cleanup",
 			"storage_backend": r.backend,
+			"namespace":       r.namespace,
 		})
 		if status == "success" {
 			r.metrics.AddCounter(metricStorageRemovedTotal, float64(removed), map[string]string{
 				"storage_backend": r.backend,
+				"namespace":       r.namespace,
 			})
 			r.metrics.SetGauge(metricStorageTokensCount, float64(remaining), map[string]string{
 				"storage_backend": r.backend,
+				"namespace":       r.namespace,
 			})
 		}
 	}()

--- a/pkg/storage/suite_test.go
+++ b/pkg/storage/suite_test.go
@@ -621,15 +621,15 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 			It("should record counter and duration on Store success", func() {
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "store", "status": "success", "error_type": "", "storage_backend": backend})
+					map[string]string{"operation": "store", "status": "success", "error_type": "", "storage_backend": backend, "namespace": ""})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
-					map[string]string{"operation": "store", "storage_backend": backend})
+					map[string]string{"operation": "store", "storage_backend": backend, "namespace": ""})
 				// Some implementations (e.g. Memory) update the token-count gauge on
 				// every Store; others (e.g. Redis) only update it in Cleanup.
 				mockM.EXPECT().SetGauge("jwtauth_storage_tokens_count",
 					gomock.Any(),
-					map[string]string{"storage_backend": backend}).AnyTimes()
+					map[string]string{"storage_backend": backend, "namespace": ""}).AnyTimes()
 
 				err := ms.Store(ctx, tokenID, userID, expiresAt, metadata)
 				Expect(err).NotTo(HaveOccurred())
@@ -637,10 +637,10 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 			It("should record validation_error status on Store with empty tokenID", func() {
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "store", "status": "validation_error", "error_type": "validation_error", "storage_backend": backend})
+					map[string]string{"operation": "store", "status": "validation_error", "error_type": "validation_error", "storage_backend": backend, "namespace": ""})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
-					map[string]string{"operation": "store", "storage_backend": backend})
+					map[string]string{"operation": "store", "storage_backend": backend, "namespace": ""})
 
 				err := ms.Store(ctx, "", userID, expiresAt, metadata)
 				Expect(err).To(HaveOccurred())
@@ -649,21 +649,21 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 			It("should record counter and duration on Retrieve success", func() {
 				// Setup: Store the token (expect those metrics too)
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "store", "status": "success", "error_type": "", "storage_backend": backend})
+					map[string]string{"operation": "store", "status": "success", "error_type": "", "storage_backend": backend, "namespace": ""})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
-					map[string]string{"operation": "store", "storage_backend": backend})
+					map[string]string{"operation": "store", "storage_backend": backend, "namespace": ""})
 				mockM.EXPECT().SetGauge("jwtauth_storage_tokens_count",
 					gomock.Any(),
-					map[string]string{"storage_backend": backend}).AnyTimes()
+					map[string]string{"storage_backend": backend, "namespace": ""}).AnyTimes()
 				Expect(ms.Store(ctx, tokenID, userID, expiresAt, metadata)).To(Succeed())
 
 				// Retrieve expectations
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "retrieve", "status": "success", "error_type": "", "storage_backend": backend})
+					map[string]string{"operation": "retrieve", "status": "success", "error_type": "", "storage_backend": backend, "namespace": ""})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
-					map[string]string{"operation": "retrieve", "storage_backend": backend})
+					map[string]string{"operation": "retrieve", "storage_backend": backend, "namespace": ""})
 
 				token, err := ms.Retrieve(ctx, tokenID)
 				Expect(err).NotTo(HaveOccurred())
@@ -672,10 +672,10 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 			It("should record not_found status on Retrieve for nonexistent token", func() {
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "retrieve", "status": "not_found", "error_type": "not_found", "storage_backend": backend})
+					map[string]string{"operation": "retrieve", "status": "not_found", "error_type": "not_found", "storage_backend": backend, "namespace": ""})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
-					map[string]string{"operation": "retrieve", "storage_backend": backend})
+					map[string]string{"operation": "retrieve", "storage_backend": backend, "namespace": ""})
 
 				_, err := ms.Retrieve(ctx, "nonexistent-token")
 				Expect(err).To(MatchError(storage.ErrTokenNotFound))
@@ -684,29 +684,29 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 			It("should record revoked status on Retrieve for revoked token", func() {
 				// Store
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "store", "status": "success", "error_type": "", "storage_backend": backend})
+					map[string]string{"operation": "store", "status": "success", "error_type": "", "storage_backend": backend, "namespace": ""})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
-					map[string]string{"operation": "store", "storage_backend": backend})
+					map[string]string{"operation": "store", "storage_backend": backend, "namespace": ""})
 				mockM.EXPECT().SetGauge("jwtauth_storage_tokens_count",
 					gomock.Any(),
-					map[string]string{"storage_backend": backend}).AnyTimes()
+					map[string]string{"storage_backend": backend, "namespace": ""}).AnyTimes()
 				Expect(ms.Store(ctx, tokenID, userID, expiresAt, metadata)).To(Succeed())
 
 				// Revoke
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "revoke", "status": "success", "error_type": "", "storage_backend": backend})
+					map[string]string{"operation": "revoke", "status": "success", "error_type": "", "storage_backend": backend, "namespace": ""})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
-					map[string]string{"operation": "revoke", "storage_backend": backend})
+					map[string]string{"operation": "revoke", "storage_backend": backend, "namespace": ""})
 				Expect(ms.Revoke(ctx, tokenID)).To(Succeed())
 
 				// Retrieve
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "retrieve", "status": "revoked", "error_type": "revoked", "storage_backend": backend})
+					map[string]string{"operation": "retrieve", "status": "revoked", "error_type": "revoked", "storage_backend": backend, "namespace": ""})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
-					map[string]string{"operation": "retrieve", "storage_backend": backend})
+					map[string]string{"operation": "retrieve", "storage_backend": backend, "namespace": ""})
 
 				_, err := ms.Retrieve(ctx, tokenID)
 				Expect(err).To(MatchError(storage.ErrTokenRevoked))
@@ -715,21 +715,21 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 			It("should record counter and duration on Revoke success", func() {
 				// Store
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "store", "status": "success", "error_type": "", "storage_backend": backend})
+					map[string]string{"operation": "store", "status": "success", "error_type": "", "storage_backend": backend, "namespace": ""})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
-					map[string]string{"operation": "store", "storage_backend": backend})
+					map[string]string{"operation": "store", "storage_backend": backend, "namespace": ""})
 				mockM.EXPECT().SetGauge("jwtauth_storage_tokens_count",
 					gomock.Any(),
-					map[string]string{"storage_backend": backend}).AnyTimes()
+					map[string]string{"storage_backend": backend, "namespace": ""}).AnyTimes()
 				Expect(ms.Store(ctx, tokenID, userID, expiresAt, metadata)).To(Succeed())
 
 				// Revoke
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "revoke", "status": "success", "error_type": "", "storage_backend": backend})
+					map[string]string{"operation": "revoke", "status": "success", "error_type": "", "storage_backend": backend, "namespace": ""})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
-					map[string]string{"operation": "revoke", "storage_backend": backend})
+					map[string]string{"operation": "revoke", "storage_backend": backend, "namespace": ""})
 
 				Expect(ms.Revoke(ctx, tokenID)).To(Succeed())
 			})
@@ -737,21 +737,21 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 			It("should record counter and duration on RevokeAllForUser success", func() {
 				// Store
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "store", "status": "success", "error_type": "", "storage_backend": backend})
+					map[string]string{"operation": "store", "status": "success", "error_type": "", "storage_backend": backend, "namespace": ""})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
-					map[string]string{"operation": "store", "storage_backend": backend})
+					map[string]string{"operation": "store", "storage_backend": backend, "namespace": ""})
 				mockM.EXPECT().SetGauge("jwtauth_storage_tokens_count",
 					gomock.Any(),
-					map[string]string{"storage_backend": backend}).AnyTimes()
+					map[string]string{"storage_backend": backend, "namespace": ""}).AnyTimes()
 				Expect(ms.Store(ctx, tokenID, userID, expiresAt, metadata)).To(Succeed())
 
 				// RevokeAllForUser
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "revoke_all", "status": "success", "error_type": "", "storage_backend": backend})
+					map[string]string{"operation": "revoke_all", "status": "success", "error_type": "", "storage_backend": backend, "namespace": ""})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
-					map[string]string{"operation": "revoke_all", "storage_backend": backend})
+					map[string]string{"operation": "revoke_all", "storage_backend": backend, "namespace": ""})
 
 				Expect(ms.RevokeAllForUser(ctx, userID)).To(Succeed())
 			})
@@ -761,14 +761,14 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 				// Store short-lived token
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "store", "status": "success", "error_type": "", "storage_backend": backend})
+					map[string]string{"operation": "store", "status": "success", "error_type": "", "storage_backend": backend, "namespace": ""})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
-					map[string]string{"operation": "store", "storage_backend": backend})
+					map[string]string{"operation": "store", "storage_backend": backend, "namespace": ""})
 				// Memory updates the gauge on Store (value=1 after first insert); Redis does not.
 				mockM.EXPECT().SetGauge("jwtauth_storage_tokens_count",
 					float64(1),
-					map[string]string{"storage_backend": backend}).AnyTimes()
+					map[string]string{"storage_backend": backend, "namespace": ""}).AnyTimes()
 				err := ms.Store(ctx, tokenID, userID, veryShortLived, metadata)
 				if err != nil {
 					Skip("store rejected short-lived token")
@@ -778,16 +778,16 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 				// Cleanup expectations
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "cleanup", "status": "success", "error_type": "", "storage_backend": backend})
+					map[string]string{"operation": "cleanup", "status": "success", "error_type": "", "storage_backend": backend, "namespace": ""})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
-					map[string]string{"operation": "cleanup", "storage_backend": backend})
+					map[string]string{"operation": "cleanup", "storage_backend": backend, "namespace": ""})
 				mockM.EXPECT().AddCounter("jwtauth_storage_cleanup_tokens_removed_total",
 					float64(1),
-					map[string]string{"storage_backend": backend})
+					map[string]string{"storage_backend": backend, "namespace": ""})
 				mockM.EXPECT().SetGauge("jwtauth_storage_tokens_count",
 					float64(0),
-					map[string]string{"storage_backend": backend})
+					map[string]string{"storage_backend": backend, "namespace": ""})
 
 				count, err := ms.Cleanup(ctx)
 				Expect(err).NotTo(HaveOccurred())
@@ -796,16 +796,16 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 			It("should record zero removed count and gauge on Cleanup with no tokens", func() {
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
-					map[string]string{"operation": "cleanup", "status": "success", "error_type": "", "storage_backend": backend})
+					map[string]string{"operation": "cleanup", "status": "success", "error_type": "", "storage_backend": backend, "namespace": ""})
 				mockM.EXPECT().RecordDuration("jwtauth_storage_operation_duration_seconds",
 					gomock.Any(),
-					map[string]string{"operation": "cleanup", "storage_backend": backend})
+					map[string]string{"operation": "cleanup", "storage_backend": backend, "namespace": ""})
 				mockM.EXPECT().AddCounter("jwtauth_storage_cleanup_tokens_removed_total",
 					float64(0),
-					map[string]string{"storage_backend": backend})
+					map[string]string{"storage_backend": backend, "namespace": ""})
 				mockM.EXPECT().SetGauge("jwtauth_storage_tokens_count",
 					float64(0),
-					map[string]string{"storage_backend": backend})
+					map[string]string{"storage_backend": backend, "namespace": ""})
 
 				count, err := ms.Cleanup(ctx)
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary

Phase 3 of the KeyPrefix namespace observability work (closes #112).

- **Spans** — `startSpan()` in both `RedisKeyStore` and `RedisRefreshStore` now sets a `storage.namespace` attribute alongside `storage.backend`
- **Logs** — constructors call `Logger.With("namespace", cfg.KeyPrefix)` when `KeyPrefix` is non-empty, so every downstream log call carries the field without per-call-site changes
- **Metrics** — all 7 Prometheus metric registrations gain a `"namespace"` label; all call sites in both Redis stores (23 total) and `MemoryRefreshStore` (13 total) emit the label
- **Backward compatibility** — zero-value `KeyPrefix` emits `""` for all three signals; no label-set cardinality breaks

## Test plan

- [x] `./run-ci-locally.sh` passes (168 keys + 184 tokens + 136 storage + 104 logging + 66 metrics + 78 tracing + 28 integration specs, all green)
- [x] Storage suite passes for both `MemoryRefreshStore` and `RedisRefreshStore` runs of the shared Phase 10 metrics suite
- [x] No linter issues (`golangci-lint`, `govulncheck`, `go vet` all clean)