### PR TITLE
feat(keys,metrics): wire namespace through KeyManager observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,8 @@ All notable changes to this project will be documented in this file.
 
 - **`RedisKeyStore` and `RedisRefreshStore` emit namespace across all three signal types** — when `KeyPrefix` is non-empty, every span carries a `storage.namespace` attribute, every log line carries a `namespace` field (via `Logger.With` in the constructor — no per-call-site changes), and every Prometheus metric carries a `namespace` label. Zero-value `KeyPrefix` emits an empty string label, preserving backward compatibility. Closes #112 (Phase 3).
 
+- **`KeyManager` emits namespace across all three signal types** — every span carries a `key.namespace` attribute, every log line carries a `namespace` field (via `Logger.With` in the constructor), and every Prometheus label on key management metrics (`key_rotations_total`, `key_signing_operations_total`, `key_validation_operations_total`, `key_operation_duration_seconds`, `key_active_versions_count`) includes `namespace`. Zero-value `Namespace` emits an empty string label, preserving backward compatibility. Closes #112 (Phase 4).
+
 ### Fixed
 
 - **`KeyInfo.KeySizeBits` now reports actual key size** — previously sourced from `KeyManagerConfig.KeySize` (caller-supplied), which could silently diverge from the actual RSA key on disk if the `DiskKeyStore` or `RedisKeyStore` was configured with a different key size. Now derived from `keyPair.PrivateKey.N.BitLen()` so the reported value always matches the real key material.

--- a/pkg/keys/manager.go
+++ b/pkg/keys/manager.go
@@ -127,8 +127,9 @@ type Manager struct {
 	currentKeyID string              // ID of the key currently used for signing
 
 	// ===== Observability =====
-	metrics metrics.Metrics // never nil; defaults to NoOpMetrics
-	tracer  tracing.Tracer  // never nil; defaults to NoOpTracer
+	metrics   metrics.Metrics // never nil; defaults to NoOpMetrics
+	tracer    tracing.Tracer  // never nil; defaults to NoOpTracer
+	namespace string          // = cfg.Namespace; emitted across all three signal types
 
 	// ===== Synchronization =====
 	mu sync.RWMutex // Protects keys, currentKeyID
@@ -294,6 +295,9 @@ func NewManager(config KeyManagerConfig) (*Manager, error) {
 	if config.Tracer == nil {
 		config.Tracer = defaults.Tracer
 	}
+	if config.Namespace != "" {
+		config.Logger = config.Logger.With("namespace", config.Namespace)
+	}
 
 	// ===== STEP 4: Validate Ranges (After Defaults) =====
 	if config.KeySize < 2048 {
@@ -306,6 +310,7 @@ func NewManager(config KeyManagerConfig) (*Manager, error) {
 		keys:           make(map[string]*KeyPair),
 		metrics:        config.Metrics,
 		tracer:         config.Tracer,
+		namespace:      config.Namespace,
 		stopRotationCh: make(chan struct{}),
 	}, nil
 }
@@ -372,7 +377,7 @@ func (m *Manager) Start(ctx context.Context) error {
 		m.config.Logger.Info("loaded existing keys from store", ctx,
 			"keyID", m.currentKeyID,
 			"keyCount", len(storedKeys))
-		m.metrics.SetGauge(metricKeyActiveVersionsCount, float64(keyCount), nil)
+		m.metrics.SetGauge(metricKeyActiveVersionsCount, float64(keyCount), map[string]string{"namespace": m.namespace})
 	} else {
 		// ===== STEP 4b: Generate Initial Key Pair =====
 		privateKey, err := rsa.GenerateKey(rand.Reader, m.config.KeySize)
@@ -414,7 +419,7 @@ func (m *Manager) Start(ctx context.Context) error {
 		m.config.Logger.Info("generated new RSA key pair", ctx,
 			"keyID", keyID,
 			"keySize", m.config.KeySize)
-		m.metrics.SetGauge(metricKeyActiveVersionsCount, float64(keyCount), nil)
+		m.metrics.SetGauge(metricKeyActiveVersionsCount, float64(keyCount), map[string]string{"namespace": m.namespace})
 	}
 
 	// ===== STEP 5: Start Rotation Scheduler =====
@@ -439,7 +444,7 @@ func (m *Manager) GetCurrentSigningKey(ctx context.Context) (*rsa.PrivateKey, st
 
 	// ===== STEP 1: Check Manager is Running =====
 	if !m.IsRunning() {
-		m.metrics.IncrementCounter(metricKeySigningOpsTotal, map[string]string{"status": "error", "error_type": "error"})
+		m.metrics.IncrementCounter(metricKeySigningOpsTotal, map[string]string{"status": "error", "error_type": "error", "namespace": m.namespace})
 		span.RecordError(ErrManagerNotRunning)
 		span.SetStatus(tracing.StatusError, ErrManagerNotRunning.Error())
 		return nil, "", ErrManagerNotRunning
@@ -447,7 +452,7 @@ func (m *Manager) GetCurrentSigningKey(ctx context.Context) (*rsa.PrivateKey, st
 
 	// ===== STEP 2: Context Check =====
 	if err := ctx.Err(); err != nil {
-		m.metrics.IncrementCounter(metricKeySigningOpsTotal, map[string]string{"status": "cancelled", "error_type": "cancelled"})
+		m.metrics.IncrementCounter(metricKeySigningOpsTotal, map[string]string{"status": "cancelled", "error_type": "cancelled", "namespace": m.namespace})
 		span.RecordError(err)
 		span.SetStatus(tracing.StatusError, err.Error())
 		return nil, "", err
@@ -461,14 +466,14 @@ func (m *Manager) GetCurrentSigningKey(ctx context.Context) (*rsa.PrivateKey, st
 	keyPair, found := m.keys[m.currentKeyID]
 
 	if !found {
-		m.metrics.IncrementCounter(metricKeySigningOpsTotal, map[string]string{"status": "error", "error_type": "error"})
+		m.metrics.IncrementCounter(metricKeySigningOpsTotal, map[string]string{"status": "error", "error_type": "error", "namespace": m.namespace})
 		span.RecordError(ErrKeyNotFound)
 		span.SetStatus(tracing.StatusError, ErrKeyNotFound.Error())
 		return nil, "", ErrKeyNotFound
 	}
 
 	// ===== STEP 4: Return Key and ID =====
-	m.metrics.IncrementCounter(metricKeySigningOpsTotal, map[string]string{"status": "success", "error_type": ""})
+	m.metrics.IncrementCounter(metricKeySigningOpsTotal, map[string]string{"status": "success", "error_type": "", "namespace": m.namespace})
 	span.SetAttribute("key_id", m.currentKeyID)
 	span.SetStatus(tracing.StatusOK, "")
 	return keyPair.PrivateKey, m.currentKeyID, nil
@@ -535,7 +540,7 @@ func (m *Manager) GetPublicKey(ctx context.Context, keyID string) (*rsa.PublicKe
 	status := "error"
 	errorType := "error"
 	defer func() {
-		m.metrics.IncrementCounter(metricKeyValidationOpsTotal, map[string]string{"status": status, "error_type": errorType})
+		m.metrics.IncrementCounter(metricKeyValidationOpsTotal, map[string]string{"status": status, "error_type": errorType, "namespace": m.namespace})
 	}()
 
 	// ===== STEP 1: Validate Key ID =====
@@ -751,8 +756,8 @@ func (m *Manager) RotateKeys(ctx context.Context) error {
 	status := "error"
 	errorType := "error"
 	defer func() {
-		m.metrics.IncrementCounter(metricKeyRotationsTotal, map[string]string{"status": status, "error_type": errorType})
-		m.metrics.RecordDuration(metricKeyOpDuration, time.Since(start), map[string]string{"operation": "rotate"})
+		m.metrics.IncrementCounter(metricKeyRotationsTotal, map[string]string{"status": status, "error_type": errorType, "namespace": m.namespace})
+		m.metrics.RecordDuration(metricKeyOpDuration, time.Since(start), map[string]string{"operation": "rotate", "namespace": m.namespace})
 	}()
 
 	// ===== STEP 1: Check Context =====
@@ -837,7 +842,7 @@ func (m *Manager) RotateKeys(ctx context.Context) error {
 
 	status = "success"
 	errorType = ""
-	m.metrics.SetGauge(metricKeyActiveVersionsCount, float64(len(m.keys)), nil)
+	m.metrics.SetGauge(metricKeyActiveVersionsCount, float64(len(m.keys)), map[string]string{"namespace": m.namespace})
 	m.config.Logger.Info("key rotation successful", ctx,
 		"newKeyID", keyID,
 		"oldKeyID", oldKeyID,
@@ -947,7 +952,7 @@ func (m *Manager) cleanupExpiredKeys(ctx context.Context) {
 
 	// ===== STEP 6: Update Active Keys Gauge (only when keys were removed) =====
 	if count > 0 {
-		m.metrics.SetGauge(metricKeyActiveVersionsCount, float64(len(m.keys)), nil)
+		m.metrics.SetGauge(metricKeyActiveVersionsCount, float64(len(m.keys)), map[string]string{"namespace": m.namespace})
 	}
 }
 
@@ -955,8 +960,14 @@ func base64urlEncode(data []byte) string {
 	return base64.RawURLEncoding.EncodeToString(data)
 }
 
-// startSpan begins a new tracing span for the given Manager operation.
+// startSpan begins a new tracing span for the given Manager operation,
+// pre-seeded with the key.namespace attribute.
 func (m *Manager) startSpan(ctx context.Context, operation string, opts ...tracing.SpanOption) (context.Context, tracing.Span) {
+	opts = append([]tracing.SpanOption{
+		tracing.WithAttributes(map[string]any{
+			"key.namespace": m.namespace,
+		}),
+	}, opts...)
 	return m.tracer.Start(ctx, "KeyManager."+operation, opts...)
 }
 

--- a/pkg/keys/manager_test.go
+++ b/pkg/keys/manager_test.go
@@ -759,7 +759,7 @@ var _ = Describe("Manager", func() {
 				},
 			}
 			mockKS.EXPECT().LoadAll(gomock.Any()).Return(storedKeys, nil)
-			mockM.EXPECT().SetGauge("jwtauth_key_active_versions_count", float64(1), gomock.Nil())
+			mockM.EXPECT().SetGauge("jwtauth_key_active_versions_count", float64(1), map[string]string{"namespace": ""})
 
 			m, err := keys.NewManager(keys.KeyManagerConfig{
 				KeyStore:            mockKS,
@@ -780,10 +780,10 @@ var _ = Describe("Manager", func() {
 			if status == "success" {
 				errorType = ""
 			}
-			mockM.EXPECT().IncrementCounter("jwtauth_key_rotations_total", map[string]string{"status": status, "error_type": errorType})
-			mockM.EXPECT().RecordDuration("jwtauth_key_operation_duration_seconds", gomock.Any(), map[string]string{"operation": "rotate"})
+			mockM.EXPECT().IncrementCounter("jwtauth_key_rotations_total", map[string]string{"status": status, "error_type": errorType, "namespace": ""})
+			mockM.EXPECT().RecordDuration("jwtauth_key_operation_duration_seconds", gomock.Any(), map[string]string{"operation": "rotate", "namespace": ""})
 			if status == "success" {
-				mockM.EXPECT().SetGauge("jwtauth_key_active_versions_count", gomock.Any(), gomock.Nil())
+				mockM.EXPECT().SetGauge("jwtauth_key_active_versions_count", gomock.Any(), map[string]string{"namespace": ""})
 			}
 		}
 
@@ -842,7 +842,7 @@ var _ = Describe("Manager", func() {
 					_ = m.Shutdown(shutdownCtx)
 				}()
 
-				mockM.EXPECT().IncrementCounter("jwtauth_key_signing_operations_total", map[string]string{"status": "success", "error_type": ""})
+				mockM.EXPECT().IncrementCounter("jwtauth_key_signing_operations_total", map[string]string{"status": "success", "error_type": "", "namespace": ""})
 
 				_, _, err := m.GetCurrentSigningKey(ctx)
 				Expect(err).NotTo(HaveOccurred())
@@ -858,7 +858,7 @@ var _ = Describe("Manager", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				mockM.EXPECT().IncrementCounter("jwtauth_key_signing_operations_total", map[string]string{"status": "error", "error_type": "error"})
+				mockM.EXPECT().IncrementCounter("jwtauth_key_signing_operations_total", map[string]string{"status": "error", "error_type": "error", "namespace": ""})
 
 				_, _, err = m.GetCurrentSigningKey(ctx)
 				Expect(err).To(MatchError(keys.ErrManagerNotRunning))
@@ -875,7 +875,7 @@ var _ = Describe("Manager", func() {
 				cancelledCtx, cancelFn := context.WithCancel(context.Background())
 				cancelFn()
 
-				mockM.EXPECT().IncrementCounter("jwtauth_key_signing_operations_total", map[string]string{"status": "cancelled", "error_type": "cancelled"})
+				mockM.EXPECT().IncrementCounter("jwtauth_key_signing_operations_total", map[string]string{"status": "cancelled", "error_type": "cancelled", "namespace": ""})
 
 				_, _, err := m.GetCurrentSigningKey(cancelledCtx)
 				Expect(err).To(MatchError(context.Canceled))
@@ -891,7 +891,7 @@ var _ = Describe("Manager", func() {
 					_ = m.Shutdown(shutdownCtx)
 				}()
 
-				mockM.EXPECT().IncrementCounter("jwtauth_key_validation_operations_total", map[string]string{"status": "success", "error_type": ""})
+				mockM.EXPECT().IncrementCounter("jwtauth_key_validation_operations_total", map[string]string{"status": "success", "error_type": "", "namespace": ""})
 
 				_, err := m.GetPublicKey(ctx, "existing-metric-key")
 				Expect(err).NotTo(HaveOccurred())
@@ -905,7 +905,7 @@ var _ = Describe("Manager", func() {
 					_ = m.Shutdown(shutdownCtx)
 				}()
 
-				mockM.EXPECT().IncrementCounter("jwtauth_key_validation_operations_total", map[string]string{"status": "not_found", "error_type": "not_found"})
+				mockM.EXPECT().IncrementCounter("jwtauth_key_validation_operations_total", map[string]string{"status": "not_found", "error_type": "not_found", "namespace": ""})
 				mockKS.EXPECT().LoadKey(gomock.Any(), "ghost-key").Return(nil, nil, keys.ErrKeyStoreKeyNotFound)
 
 				_, err := m.GetPublicKey(ctx, "ghost-key")
@@ -923,7 +923,7 @@ var _ = Describe("Manager", func() {
 				cancelledCtx, cancelFn := context.WithCancel(context.Background())
 				cancelFn()
 
-				mockM.EXPECT().IncrementCounter("jwtauth_key_validation_operations_total", map[string]string{"status": "cancelled", "error_type": "cancelled"})
+				mockM.EXPECT().IncrementCounter("jwtauth_key_validation_operations_total", map[string]string{"status": "cancelled", "error_type": "cancelled", "namespace": ""})
 
 				_, err := m.GetPublicKey(cancelledCtx, "some-key")
 				Expect(err).To(MatchError(context.Canceled))

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -150,19 +150,19 @@ func (pm *PrometheusMetrics) registerAllMetrics(namespace string) {
 
 	pm.registerCounter(namespace, "key_rotations_total",
 		"Total number of key rotations",
-		[]string{"status", "error_type"})
+		[]string{"status", "error_type", "namespace"})
 
 	pm.registerCounter(namespace, "key_signing_operations_total",
 		"Total number of key signing operations",
-		[]string{"status", "error_type"})
+		[]string{"status", "error_type", "namespace"})
 
 	pm.registerCounter(namespace, "key_validation_operations_total",
 		"Total number of key validation operations",
-		[]string{"status", "error_type"})
+		[]string{"status", "error_type", "namespace"})
 
 	pm.registerHistogram(namespace, "key_operation_duration_seconds",
 		"Duration of key operations in seconds",
-		[]string{"operation"},
+		[]string{"operation", "namespace"},
 		[]float64{.0001, .0005, .001, .0025, .005, .01, .025, .05})
 
 	pm.registerGauge(namespace, "key_current_version",
@@ -171,7 +171,7 @@ func (pm *PrometheusMetrics) registerAllMetrics(namespace string) {
 
 	pm.registerGauge(namespace, "key_active_versions_count",
 		"Number of active key versions",
-		[]string{})
+		[]string{"namespace"})
 }
 
 // registerCounter creates a CounterVec with the given namespace, name, help

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -749,41 +749,47 @@ var _ = Describe("Prometheus", func() {
 				pm.IncrementCounter("jwtauth_key_rotations_total", map[string]string{
 					"status":     "success",
 					"error_type": "",
+					"namespace":  "",
 				})
 				pm.RecordDuration("jwtauth_key_operation_duration_seconds", 100*time.Millisecond, map[string]string{
 					"operation": "rotate",
+					"namespace": "",
 				})
 
 				// Update key gauges
 				pm.SetGauge("jwtauth_key_current_version", 5, map[string]string{})
-				pm.SetGauge("jwtauth_key_active_versions_count", 2, map[string]string{})
+				pm.SetGauge("jwtauth_key_active_versions_count", 2, map[string]string{"namespace": ""})
 
 				// Signing operations
 				pm.IncrementCounter("jwtauth_key_signing_operations_total", map[string]string{
 					"status":     "success",
 					"error_type": "",
+					"namespace":  "",
 				})
 				pm.RecordDuration("jwtauth_key_operation_duration_seconds", 500*time.Microsecond, map[string]string{
 					"operation": "sign",
+					"namespace": "",
 				})
 
 				// Validation operations
 				pm.IncrementCounter("jwtauth_key_validation_operations_total", map[string]string{
 					"status":     "success",
 					"error_type": "",
+					"namespace":  "",
 				})
 				pm.RecordDuration("jwtauth_key_operation_duration_seconds", 300*time.Microsecond, map[string]string{
 					"operation": "validate",
+					"namespace": "",
 				})
 
-				Expect(counterValue(registry, "jwtauth_key_rotations_total", map[string]string{"status": "success", "error_type": ""})).To(Equal(1.0))
-				Expect(counterValue(registry, "jwtauth_key_signing_operations_total", map[string]string{"status": "success", "error_type": ""})).To(Equal(1.0))
-				Expect(counterValue(registry, "jwtauth_key_validation_operations_total", map[string]string{"status": "success", "error_type": ""})).To(Equal(1.0))
+				Expect(counterValue(registry, "jwtauth_key_rotations_total", map[string]string{"status": "success", "error_type": "", "namespace": ""})).To(Equal(1.0))
+				Expect(counterValue(registry, "jwtauth_key_signing_operations_total", map[string]string{"status": "success", "error_type": "", "namespace": ""})).To(Equal(1.0))
+				Expect(counterValue(registry, "jwtauth_key_validation_operations_total", map[string]string{"status": "success", "error_type": "", "namespace": ""})).To(Equal(1.0))
 				Expect(gaugeValue(registry, "jwtauth_key_current_version", map[string]string{})).To(Equal(5.0))
-				Expect(gaugeValue(registry, "jwtauth_key_active_versions_count", map[string]string{})).To(Equal(2.0))
-				Expect(histogramSampleCount(registry, "jwtauth_key_operation_duration_seconds", map[string]string{"operation": "rotate"})).To(Equal(uint64(1)))
-				Expect(histogramSampleCount(registry, "jwtauth_key_operation_duration_seconds", map[string]string{"operation": "sign"})).To(Equal(uint64(1)))
-				Expect(histogramSampleCount(registry, "jwtauth_key_operation_duration_seconds", map[string]string{"operation": "validate"})).To(Equal(uint64(1)))
+				Expect(gaugeValue(registry, "jwtauth_key_active_versions_count", map[string]string{"namespace": ""})).To(Equal(2.0))
+				Expect(histogramSampleCount(registry, "jwtauth_key_operation_duration_seconds", map[string]string{"operation": "rotate", "namespace": ""})).To(Equal(uint64(1)))
+				Expect(histogramSampleCount(registry, "jwtauth_key_operation_duration_seconds", map[string]string{"operation": "sign", "namespace": ""})).To(Equal(uint64(1)))
+				Expect(histogramSampleCount(registry, "jwtauth_key_operation_duration_seconds", map[string]string{"operation": "validate", "namespace": ""})).To(Equal(uint64(1)))
 			})
 		})
 	})


### PR DESCRIPTION
## Summary

- Adds `namespace string` field to `Manager` struct, assigned from `KeyManagerConfig.Namespace` in `NewManager`
- Enriches the logger via `Logger.With("namespace", cfg.Namespace)` at construction when non-empty — no per-call-site changes required
- Seeds `key.namespace` attribute on every `KeyManager` span via `startSpan()`
- Adds `namespace` label to 5 `KeyManager` metric registrations: `key_rotations_total`, `key_signing_operations_total`, `key_validation_operations_total`, `key_operation_duration_seconds`, `key_active_versions_count`
- Threads `"namespace": m.namespace` through all 11 metric call sites
- Updates `prometheus_test.go` and `manager_test.go` expectations accordingly

Zero-value `Namespace` emits an empty string label — backward compatible.

Closes #112 (Phase 4 of 5)

## Test plan

- [x] `./run-ci-locally.sh` passes — 168 unit + 28 integration specs green
- [ ] `grep -n "namespace" pkg/keys/manager.go` shows field, constructor enrichment, `startSpan`, and all metric sites