### PR TITLE
feat(tokens,metrics): wire namespace through TokenManager observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,8 @@ All notable changes to this project will be documented in this file.
 
 - **`KeyManager` emits namespace across all three signal types** — every span carries a `key.namespace` attribute, every log line carries a `namespace` field (via `Logger.With` in the constructor), and every Prometheus label on key management metrics (`key_rotations_total`, `key_signing_operations_total`, `key_validation_operations_total`, `key_operation_duration_seconds`, `key_active_versions_count`) includes `namespace`. Zero-value `Namespace` emits an empty string label, preserving backward compatibility. Closes #112 (Phase 4).
 
+- **`TokenManager` emits namespace across all three signal types** — every span carries a `token.namespace` attribute, every log line carries a `namespace` field (via `Logger.With` in the constructor), and every Prometheus label on token management metrics (`tokens_issued_total`, `tokens_validated_total`, `tokens_refreshed_total`, `tokens_revoked_total`, `tokens_introspected_total`, `operations_total`, `operation_duration_seconds`, `active_tokens`) includes `namespace`. Zero-value `Namespace` emits an empty string label, preserving backward compatibility. Closes #112 (Phase 5).
+
 ### Fixed
 
 - **`KeyInfo.KeySizeBits` now reports actual key size** — previously sourced from `KeyManagerConfig.KeySize` (caller-supplied), which could silently diverge from the actual RSA key on disk if the `DiskKeyStore` or `RedisKeyStore` was configured with a different key size. Now derived from `keyPair.PrivateKey.N.BitLen()` so the reported value always matches the real key material.

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -77,36 +77,36 @@ func (pm *PrometheusMetrics) registerAllMetrics(namespace string) {
 
 	pm.registerCounter(namespace, "tokens_issued_total",
 		"Total number of tokens issued",
-		[]string{"status", "error_type"})
+		[]string{"status", "error_type", "namespace"})
 
 	pm.registerCounter(namespace, "tokens_validated_total",
 		"Total number of tokens validated",
-		[]string{"status", "error_type"})
+		[]string{"status", "error_type", "namespace"})
 
 	pm.registerCounter(namespace, "tokens_refreshed_total",
 		"Total number of tokens refreshed",
-		[]string{"status", "error_type"})
+		[]string{"status", "error_type", "namespace"})
 
 	pm.registerCounter(namespace, "tokens_revoked_total",
 		"Total number of tokens revoked",
-		[]string{"operation", "status"})
+		[]string{"operation", "status", "namespace"})
 
 	pm.registerCounter(namespace, "tokens_introspected_total",
 		"Total number of token introspections",
-		[]string{"status"})
+		[]string{"status", "namespace"})
 
 	pm.registerCounter(namespace, "operations_total",
 		"Total number of operations",
-		[]string{"operation", "status"})
+		[]string{"operation", "status", "namespace"})
 
 	pm.registerHistogram(namespace, "operation_duration_seconds",
 		"Duration of operations in seconds",
-		[]string{"operation"},
+		[]string{"operation", "namespace"},
 		[]float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10})
 
 	pm.registerGauge(namespace, "active_tokens",
 		"Number of active tokens",
-		[]string{"storage_backend"})
+		[]string{"storage_backend", "namespace"})
 
 	pm.registerGauge(namespace, "service_running",
 		"Whether the service is running (1) or stopped (0)",

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -223,6 +223,7 @@ var _ = Describe("Prometheus", func() {
 				labels := map[string]string{
 					"operation": "validate",
 					"status":    "success",
+					"namespace": "",
 				}
 
 				pm.IncrementCounter("jwtauth_operations_total", labels)
@@ -233,8 +234,8 @@ var _ = Describe("Prometheus", func() {
 			})
 
 			It("should handle different label combinations independently", func() {
-				successLabels := map[string]string{"operation": "issue", "status": "success"}
-				failureLabels := map[string]string{"operation": "issue", "status": "failure"}
+				successLabels := map[string]string{"operation": "issue", "status": "success", "namespace": ""}
+				failureLabels := map[string]string{"operation": "issue", "status": "failure", "namespace": ""}
 
 				pm.IncrementCounter("jwtauth_operations_total", successLabels)
 				pm.IncrementCounter("jwtauth_operations_total", failureLabels)
@@ -245,14 +246,14 @@ var _ = Describe("Prometheus", func() {
 
 			Context("AddCounter", func() {
 				It("should add specific value to counter", func() {
-					labels := map[string]string{"operation": "batch", "status": "success"}
+					labels := map[string]string{"operation": "batch", "status": "success", "namespace": ""}
 					pm.AddCounter("jwtauth_operations_total", 5.0, labels)
 
 					Expect(counterValue(registry, "jwtauth_operations_total", labels)).To(Equal(5.0))
 				})
 
 				It("should accumulate values across multiple calls", func() {
-					labels := map[string]string{"operation": "batch", "status": "success"}
+					labels := map[string]string{"operation": "batch", "status": "success", "namespace": ""}
 
 					pm.AddCounter("jwtauth_operations_total", 5.0, labels)
 					pm.AddCounter("jwtauth_operations_total", 3.0, labels)
@@ -261,7 +262,7 @@ var _ = Describe("Prometheus", func() {
 				})
 
 				It("should handle fractional values", func() {
-					labels := map[string]string{"operation": "partial", "status": "success"}
+					labels := map[string]string{"operation": "partial", "status": "success", "namespace": ""}
 					pm.AddCounter("jwtauth_operations_total", 0.5, labels)
 
 					Expect(counterValue(registry, "jwtauth_operations_total", labels)).To(Equal(0.5))
@@ -274,14 +275,14 @@ var _ = Describe("Prometheus", func() {
 	Describe("Phase 2: Counter Operations - Happy Path", func() {
 		Context("IncrementCounter", func() {
 			It("should increment counter by 1", func() {
-				labels := map[string]string{"operation": "issue", "status": "success"}
+				labels := map[string]string{"operation": "issue", "status": "success", "namespace": ""}
 				pm.IncrementCounter("jwtauth_operations_total", labels)
 
 				Expect(counterValue(registry, "jwtauth_operations_total", labels)).To(Equal(1.0))
 			})
 
 			It("should support multiple increments", func() {
-				labels := map[string]string{"operation": "validate", "status": "success"}
+				labels := map[string]string{"operation": "validate", "status": "success", "namespace": ""}
 
 				pm.IncrementCounter("jwtauth_operations_total", labels)
 				pm.IncrementCounter("jwtauth_operations_total", labels)
@@ -291,8 +292,8 @@ var _ = Describe("Prometheus", func() {
 			})
 
 			It("should handle different label combinations independently", func() {
-				successLabels := map[string]string{"operation": "issue", "status": "success"}
-				failureLabels := map[string]string{"operation": "issue", "status": "failure"}
+				successLabels := map[string]string{"operation": "issue", "status": "success", "namespace": ""}
+				failureLabels := map[string]string{"operation": "issue", "status": "failure", "namespace": ""}
 
 				pm.IncrementCounter("jwtauth_operations_total", successLabels)
 				pm.IncrementCounter("jwtauth_operations_total", failureLabels)
@@ -307,14 +308,14 @@ var _ = Describe("Prometheus", func() {
 	Describe("Phase 3: Gauge Operations", func() {
 		Context("SetGauge - basic usage", func() {
 			It("should set gauge to specific value", func() {
-				labels := map[string]string{"storage_backend": "memory"}
+				labels := map[string]string{"storage_backend": "memory", "namespace": ""}
 				pm.SetGauge("jwtauth_active_tokens", 100, labels)
 
 				Expect(gaugeValue(registry, "jwtauth_active_tokens", labels)).To(Equal(100.0))
 			})
 
 			It("should overwrite previous gauge value", func() {
-				labels := map[string]string{"storage_backend": "redis"}
+				labels := map[string]string{"storage_backend": "redis", "namespace": ""}
 
 				pm.SetGauge("jwtauth_active_tokens", 50, labels)
 				pm.SetGauge("jwtauth_active_tokens", 75, labels)
@@ -325,7 +326,7 @@ var _ = Describe("Prometheus", func() {
 
 		Context("SetGauge - value changes", func() {
 			It("should allow gauge to increase", func() {
-				labels := map[string]string{"storage_backend": "memory"}
+				labels := map[string]string{"storage_backend": "memory", "namespace": ""}
 
 				pm.SetGauge("jwtauth_active_tokens", 50, labels)
 				pm.SetGauge("jwtauth_active_tokens", 100, labels)
@@ -334,7 +335,7 @@ var _ = Describe("Prometheus", func() {
 			})
 
 			It("should allow gauge to decrease", func() {
-				labels := map[string]string{"storage_backend": "memory"}
+				labels := map[string]string{"storage_backend": "memory", "namespace": ""}
 
 				pm.SetGauge("jwtauth_active_tokens", 100, labels)
 				pm.SetGauge("jwtauth_active_tokens", 50, labels)
@@ -363,7 +364,7 @@ var _ = Describe("Prometheus", func() {
 	Describe("Phase 4: Histogram Operations", func() {
 		Context("RecordHistogram", func() {
 			It("should record single value", func() {
-				labels := map[string]string{"operation": "issue"}
+				labels := map[string]string{"operation": "issue", "namespace": ""}
 				pm.RecordHistogram("jwtauth_operation_duration_seconds", 0.123, labels)
 
 				Expect(histogramSampleCount(registry, "jwtauth_operation_duration_seconds", labels)).To(Equal(uint64(1)))
@@ -371,7 +372,7 @@ var _ = Describe("Prometheus", func() {
 			})
 
 			It("should record distribution of values", func() {
-				labels := map[string]string{"operation": "validate"}
+				labels := map[string]string{"operation": "validate", "namespace": ""}
 
 				pm.RecordHistogram("jwtauth_operation_duration_seconds", 0.001, labels)
 				pm.RecordHistogram("jwtauth_operation_duration_seconds", 0.005, labels)
@@ -384,7 +385,7 @@ var _ = Describe("Prometheus", func() {
 			})
 
 			It("should place values in correct buckets", func() {
-				labels := map[string]string{"operation": "refresh"}
+				labels := map[string]string{"operation": "refresh", "namespace": ""}
 				pm.RecordHistogram("jwtauth_operation_duration_seconds", 0.025, labels)
 
 				// 0.025 should appear in the ≤0.025 bucket and all larger buckets
@@ -395,7 +396,7 @@ var _ = Describe("Prometheus", func() {
 
 		Context("RecordDuration", func() {
 			It("should convert duration to seconds", func() {
-				labels := map[string]string{"operation": "issue"}
+				labels := map[string]string{"operation": "issue", "namespace": ""}
 				pm.RecordDuration("jwtauth_operation_duration_seconds", 250*time.Millisecond, labels)
 
 				Expect(histogramSampleCount(registry, "jwtauth_operation_duration_seconds", labels)).To(Equal(uint64(1)))
@@ -411,7 +412,7 @@ var _ = Describe("Prometheus", func() {
 			})
 
 			It("should handle long durations", func() {
-				labels := map[string]string{"operation": "cleanup"}
+				labels := map[string]string{"operation": "cleanup", "namespace": ""}
 				pm.RecordDuration("jwtauth_operation_duration_seconds", 5*time.Second, labels)
 
 				Expect(histogramSampleCount(registry, "jwtauth_operation_duration_seconds", labels)).To(Equal(uint64(1)))
@@ -506,6 +507,7 @@ var _ = Describe("Prometheus", func() {
 							pm.IncrementCounter("jwtauth_operations_total", map[string]string{
 								"operation": "concurrent",
 								"status":    "success",
+								"namespace": "",
 							})
 						}
 						done <- true
@@ -517,7 +519,7 @@ var _ = Describe("Prometheus", func() {
 					<-done
 				}
 
-				labels := map[string]string{"operation": "concurrent", "status": "success"}
+				labels := map[string]string{"operation": "concurrent", "status": "success", "namespace": ""}
 				Expect(counterValue(registry, "jwtauth_operations_total", labels)).To(Equal(float64(goroutines * incrementsPerGoroutine)))
 			})
 
@@ -530,6 +532,7 @@ var _ = Describe("Prometheus", func() {
 						pm.AddCounter("jwtauth_operations_total", 10.0, map[string]string{
 							"operation": "concurrent_add",
 							"status":    "success",
+							"namespace": "",
 						})
 						done <- true
 					}()
@@ -539,7 +542,7 @@ var _ = Describe("Prometheus", func() {
 					<-done
 				}
 
-				labels := map[string]string{"operation": "concurrent_add", "status": "success"}
+				labels := map[string]string{"operation": "concurrent_add", "status": "success", "namespace": ""}
 				Expect(counterValue(registry, "jwtauth_operations_total", labels)).To(Equal(50.0))
 			})
 		})
@@ -553,6 +556,7 @@ var _ = Describe("Prometheus", func() {
 						defer GinkgoRecover()
 						pm.SetGauge("jwtauth_active_tokens", value, map[string]string{
 							"storage_backend": "concurrent",
+							"namespace":       "",
 						})
 						done <- true
 					}(float64(i))
@@ -563,7 +567,7 @@ var _ = Describe("Prometheus", func() {
 				}
 
 				// Last write wins — value must be one of the 10 values written
-				labels := map[string]string{"storage_backend": "concurrent"}
+				labels := map[string]string{"storage_backend": "concurrent", "namespace": ""}
 				Expect(gaugeValue(registry, "jwtauth_active_tokens", labels)).To(BeNumerically(">=", 0))
 				Expect(gaugeValue(registry, "jwtauth_active_tokens", labels)).To(BeNumerically("<", 10))
 			})
@@ -579,6 +583,7 @@ var _ = Describe("Prometheus", func() {
 						for j := 0; j < 100; j++ {
 							pm.RecordHistogram("jwtauth_operation_duration_seconds", 0.001, map[string]string{
 								"operation": "concurrent",
+								"namespace": "",
 							})
 						}
 						done <- true
@@ -589,7 +594,7 @@ var _ = Describe("Prometheus", func() {
 					<-done
 				}
 
-				labels := map[string]string{"operation": "concurrent"}
+				labels := map[string]string{"operation": "concurrent", "namespace": ""}
 				Expect(histogramSampleCount(registry, "jwtauth_operation_duration_seconds", labels)).To(Equal(uint64(1000)))
 			})
 		})
@@ -607,9 +612,11 @@ var _ = Describe("Prometheus", func() {
 				pm.IncrementCounter("jwtauth_operations_total", map[string]string{
 					"operation": "issue",
 					"status":    "success",
+					"namespace": "",
 				})
 				pm.SetGauge("jwtauth_active_tokens", 42, map[string]string{
 					"storage_backend": "memory",
+					"namespace":       "",
 				})
 
 				req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
@@ -637,6 +644,7 @@ var _ = Describe("Prometheus", func() {
 				pm.IncrementCounter("jwtauth_operations_total", map[string]string{
 					"operation": "test",
 					"status":    "success",
+					"namespace": "",
 				})
 
 				metricFamilies, err := pm.Registry().Gather()
@@ -654,41 +662,48 @@ var _ = Describe("Prometheus", func() {
 				pm.IncrementCounter("jwtauth_tokens_issued_total", map[string]string{
 					"status":     "success",
 					"error_type": "",
+					"namespace":  "",
 				})
 				pm.RecordDuration("jwtauth_operation_duration_seconds", 50*time.Millisecond, map[string]string{
 					"operation": "issue",
+					"namespace": "",
 				})
 
 				// Validate token
 				pm.IncrementCounter("jwtauth_tokens_validated_total", map[string]string{
 					"status":     "success",
 					"error_type": "",
+					"namespace":  "",
 				})
 				pm.RecordDuration("jwtauth_operation_duration_seconds", 5*time.Millisecond, map[string]string{
 					"operation": "validate",
+					"namespace": "",
 				})
 
 				// Refresh token
 				pm.IncrementCounter("jwtauth_tokens_refreshed_total", map[string]string{
 					"status":     "success",
 					"error_type": "",
+					"namespace":  "",
 				})
 				pm.RecordDuration("jwtauth_operation_duration_seconds", 30*time.Millisecond, map[string]string{
 					"operation": "refresh",
+					"namespace": "",
 				})
 
 				// Update active tokens
 				pm.SetGauge("jwtauth_active_tokens", 150, map[string]string{
 					"storage_backend": "redis",
+					"namespace":       "",
 				})
 
-				Expect(counterValue(registry, "jwtauth_tokens_issued_total", map[string]string{"status": "success", "error_type": ""})).To(Equal(1.0))
-				Expect(counterValue(registry, "jwtauth_tokens_validated_total", map[string]string{"status": "success", "error_type": ""})).To(Equal(1.0))
-				Expect(counterValue(registry, "jwtauth_tokens_refreshed_total", map[string]string{"status": "success", "error_type": ""})).To(Equal(1.0))
-				Expect(histogramSampleCount(registry, "jwtauth_operation_duration_seconds", map[string]string{"operation": "issue"})).To(Equal(uint64(1)))
-				Expect(histogramSampleCount(registry, "jwtauth_operation_duration_seconds", map[string]string{"operation": "validate"})).To(Equal(uint64(1)))
-				Expect(histogramSampleCount(registry, "jwtauth_operation_duration_seconds", map[string]string{"operation": "refresh"})).To(Equal(uint64(1)))
-				Expect(gaugeValue(registry, "jwtauth_active_tokens", map[string]string{"storage_backend": "redis"})).To(Equal(150.0))
+				Expect(counterValue(registry, "jwtauth_tokens_issued_total", map[string]string{"status": "success", "error_type": "", "namespace": ""})).To(Equal(1.0))
+				Expect(counterValue(registry, "jwtauth_tokens_validated_total", map[string]string{"status": "success", "error_type": "", "namespace": ""})).To(Equal(1.0))
+				Expect(counterValue(registry, "jwtauth_tokens_refreshed_total", map[string]string{"status": "success", "error_type": "", "namespace": ""})).To(Equal(1.0))
+				Expect(histogramSampleCount(registry, "jwtauth_operation_duration_seconds", map[string]string{"operation": "issue", "namespace": ""})).To(Equal(uint64(1)))
+				Expect(histogramSampleCount(registry, "jwtauth_operation_duration_seconds", map[string]string{"operation": "validate", "namespace": ""})).To(Equal(uint64(1)))
+				Expect(histogramSampleCount(registry, "jwtauth_operation_duration_seconds", map[string]string{"operation": "refresh", "namespace": ""})).To(Equal(uint64(1)))
+				Expect(gaugeValue(registry, "jwtauth_active_tokens", map[string]string{"storage_backend": "redis", "namespace": ""})).To(Equal(150.0))
 			})
 		})
 

--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -204,6 +204,10 @@ func NewManager(config TokenManagerConfig) (*Manager, error) {
 		config.Tracer = DefaultTokenManagerConfig().Tracer
 	}
 
+	if config.Namespace != "" {
+		config.Logger = config.Logger.With("namespace", config.Namespace)
+	}
+
 	if config.KeyManager == nil {
 		return nil, ErrInvalidConfig("KeyManager is required")
 	}
@@ -249,6 +253,11 @@ func NewManager(config TokenManagerConfig) (*Manager, error) {
 
 // startSpan begins a new tracing span for the given Manager operation.
 func (m *Manager) startSpan(ctx context.Context, operation string, opts ...tracing.SpanOption) (context.Context, tracing.Span) {
+	opts = append([]tracing.SpanOption{
+		tracing.WithAttributes(map[string]any{
+			"token.namespace": m.namespace,
+		}),
+	}, opts...)
 	return m.tracer.Start(ctx, "TokenManager."+operation, opts...)
 }
 
@@ -399,9 +408,11 @@ func (m *Manager) IssueAccessToken(ctx context.Context, userID string) (string, 
 		m.metrics.IncrementCounter(metricTokensIssuedTotal, map[string]string{
 			"status":     status,
 			"error_type": errorType,
+			"namespace":  m.namespace,
 		})
 		m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 			"operation": "issue_access_token",
+			"namespace":  m.namespace,
 		})
 	}()
 
@@ -543,9 +554,11 @@ func (m *Manager) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 		m.metrics.IncrementCounter(metricTokensIssuedTotal, map[string]string{
 			"status":     status,
 			"error_type": errorType,
+			"namespace":  m.namespace,
 		})
 		m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 			"operation": "issue_access_token",
+			"namespace":  m.namespace,
 		})
 	}()
 
@@ -694,9 +707,11 @@ func (m *Manager) IssueRefreshToken(ctx context.Context, userID string) (string,
 		m.metrics.IncrementCounter(metricTokensIssuedTotal, map[string]string{
 			"status":     status,
 			"error_type": errorType,
+			"namespace":  m.namespace,
 		})
 		m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 			"operation": "issue_refresh_token",
+			"namespace":  m.namespace,
 		})
 	}()
 
@@ -814,9 +829,11 @@ func (m *Manager) IssueRefreshTokenWithClaims(ctx context.Context, userID string
 		m.metrics.IncrementCounter(metricTokensIssuedTotal, map[string]string{
 			"status":     status,
 			"error_type": errorType,
+			"namespace":  m.namespace,
 		})
 		m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 			"operation": "issue_refresh_token",
+			"namespace":  m.namespace,
 		})
 	}()
 
@@ -937,9 +954,11 @@ func (m *Manager) IssueTokenPair(ctx context.Context, userID string) (string, st
 		m.metrics.IncrementCounter(metricTokensIssuedTotal, map[string]string{
 			"status":     status,
 			"error_type": errorType,
+			"namespace":  m.namespace,
 		})
 		m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 			"operation": "issue_token_pair",
+			"namespace":  m.namespace,
 		})
 	}()
 
@@ -1115,9 +1134,11 @@ func (m *Manager) IssueTokenPairWithClaims(ctx context.Context, userID string, a
 		m.metrics.IncrementCounter(metricTokensIssuedTotal, map[string]string{
 			"status":     status,
 			"error_type": errorType,
+			"namespace":  m.namespace,
 		})
 		m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 			"operation": "issue_token_pair",
+			"namespace":  m.namespace,
 		})
 	}()
 
@@ -1294,9 +1315,11 @@ func (m *Manager) ValidateAccessToken(ctx context.Context, tokenString string) (
 		m.metrics.IncrementCounter(metricTokensValidatedTotal, map[string]string{
 			"status":     status,
 			"error_type": errorType,
+			"namespace":  m.namespace,
 		})
 		m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 			"operation": "validate_access_token",
+			"namespace":  m.namespace,
 		})
 	}()
 
@@ -1550,9 +1573,11 @@ func (m *Manager) RefreshAccessToken(ctx context.Context, refreshToken string) (
 		m.metrics.IncrementCounter(metricTokensRefreshedTotal, map[string]string{
 			"status":     status,
 			"error_type": errorType,
+			"namespace":  m.namespace,
 		})
 		m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 			"operation": "refresh_access_token",
+			"namespace":  m.namespace,
 		})
 	}()
 
@@ -1685,9 +1710,11 @@ func (m *Manager) RefreshAccessTokenWithClaims(ctx context.Context, refreshToken
 		m.metrics.IncrementCounter(metricTokensRefreshedTotal, map[string]string{
 			"status":     status,
 			"error_type": errorType,
+			"namespace":  m.namespace,
 		})
 		m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 			"operation": "refresh_access_token",
+			"namespace":  m.namespace,
 		})
 	}()
 
@@ -1816,9 +1843,11 @@ func (m *Manager) RevokeRefreshToken(ctx context.Context, tokenID string) error 
 		m.metrics.IncrementCounter(metricTokensRevokedTotal, map[string]string{
 			"operation": "single",
 			"status":    status,
+			"namespace":  m.namespace,
 		})
 		m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 			"operation": "revoke_token",
+			"namespace":  m.namespace,
 		})
 	}()
 
@@ -1886,9 +1915,11 @@ func (m *Manager) RevokeAllUserTokens(ctx context.Context, userID string) error 
 		m.metrics.IncrementCounter(metricTokensRevokedTotal, map[string]string{
 			"operation": "all_user",
 			"status":    status,
+			"namespace":  m.namespace,
 		})
 		m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 			"operation": "revoke_all_user_tokens",
+			"namespace":  m.namespace,
 		})
 	}()
 
@@ -1962,9 +1993,11 @@ func (m *Manager) IntrospectToken(ctx context.Context, token string) (*TokenMeta
 	defer func() {
 		m.metrics.IncrementCounter(metricTokensIntrospectedTotal, map[string]string{
 			"status": status,
+			"namespace": m.namespace,
 		})
 		m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 			"operation": "introspect_token",
+			"namespace":  m.namespace,
 		})
 	}()
 
@@ -2085,9 +2118,11 @@ func (m *Manager) CleanupExpiredTokens(ctx context.Context) (int, error) {
 		m.metrics.IncrementCounter(metricOperationsTotal, map[string]string{
 			"operation": "cleanup",
 			"status":    status,
+			"namespace":  m.namespace,
 		})
 		m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 			"operation": "cleanup",
+			"namespace":  m.namespace,
 		})
 	}()
 

--- a/pkg/tokens/manager_metrics_test.go
+++ b/pkg/tokens/manager_metrics_test.go
@@ -105,9 +105,11 @@ var _ = Describe("TokenManager Metrics", func() {
 			mockM.EXPECT().IncrementCounter("jwtauth_tokens_issued_total", map[string]string{
 				"status":     "success",
 				"error_type": "",
+				"namespace":  "",
 			})
 			mockM.EXPECT().RecordDuration("jwtauth_operation_duration_seconds", gomock.Any(), map[string]string{
 				"operation": "issue_access_token",
+				"namespace": "",
 			})
 			_, err := service.IssueAccessToken(ctx, "user-1")
 			Expect(err).NotTo(HaveOccurred())
@@ -117,9 +119,11 @@ var _ = Describe("TokenManager Metrics", func() {
 			mockM.EXPECT().IncrementCounter("jwtauth_tokens_issued_total", map[string]string{
 				"status":     "not_running",
 				"error_type": "not_running",
+				"namespace":  "",
 			})
 			mockM.EXPECT().RecordDuration("jwtauth_operation_duration_seconds", gomock.Any(), map[string]string{
 				"operation": "issue_access_token",
+				"namespace": "",
 			})
 			_, err := service.IssueAccessToken(ctx, "user-1")
 			Expect(err).To(MatchError(tokens.ErrManagerNotRunning))
@@ -130,9 +134,11 @@ var _ = Describe("TokenManager Metrics", func() {
 			mockM.EXPECT().IncrementCounter("jwtauth_tokens_issued_total", map[string]string{
 				"status":     "invalid_input",
 				"error_type": "invalid_input",
+				"namespace":  "",
 			})
 			mockM.EXPECT().RecordDuration("jwtauth_operation_duration_seconds", gomock.Any(), map[string]string{
 				"operation": "issue_access_token",
+				"namespace": "",
 			})
 			_, err := service.IssueAccessToken(ctx, "")
 			Expect(err).To(MatchError(tokens.ErrInvalidUserID))
@@ -143,9 +149,11 @@ var _ = Describe("TokenManager Metrics", func() {
 			mockM.EXPECT().IncrementCounter("jwtauth_tokens_issued_total", map[string]string{
 				"status":     "invalid_input",
 				"error_type": "invalid_input",
+				"namespace":  "",
 			})
 			mockM.EXPECT().RecordDuration("jwtauth_operation_duration_seconds", gomock.Any(), map[string]string{
 				"operation": "issue_access_token",
+				"namespace": "",
 			})
 			_, err := service.IssueAccessToken(ctx, "   ")
 			Expect(err).To(MatchError(tokens.ErrInvalidUserID))
@@ -163,9 +171,11 @@ var _ = Describe("TokenManager Metrics", func() {
 			mockM.EXPECT().IncrementCounter("jwtauth_tokens_issued_total", map[string]string{
 				"status":     "success",
 				"error_type": "",
+				"namespace":  "",
 			})
 			mockM.EXPECT().RecordDuration("jwtauth_operation_duration_seconds", gomock.Any(), map[string]string{
 				"operation": "issue_refresh_token",
+				"namespace": "",
 			})
 			_, err := service.IssueRefreshToken(ctx, "user-1")
 			Expect(err).NotTo(HaveOccurred())
@@ -184,6 +194,7 @@ var _ = Describe("TokenManager Metrics", func() {
 			mockM.EXPECT().IncrementCounter("jwtauth_tokens_issued_total", gomock.Any())
 			mockM.EXPECT().RecordDuration("jwtauth_operation_duration_seconds", gomock.Any(), map[string]string{
 				"operation": "issue_access_token",
+				"namespace": "",
 			})
 			tokenStr, err := service.IssueAccessToken(ctx, "user-1")
 			Expect(err).NotTo(HaveOccurred())
@@ -193,9 +204,11 @@ var _ = Describe("TokenManager Metrics", func() {
 			mockM.EXPECT().IncrementCounter("jwtauth_tokens_validated_total", map[string]string{
 				"status":     "success",
 				"error_type": "",
+				"namespace":  "",
 			})
 			mockM.EXPECT().RecordDuration("jwtauth_operation_duration_seconds", gomock.Any(), map[string]string{
 				"operation": "validate_access_token",
+				"namespace": "",
 			})
 			_, err = service.ValidateAccessToken(ctx, tokenStr)
 			Expect(err).NotTo(HaveOccurred())
@@ -205,9 +218,11 @@ var _ = Describe("TokenManager Metrics", func() {
 			mockM.EXPECT().IncrementCounter("jwtauth_tokens_validated_total", map[string]string{
 				"status":     "not_running",
 				"error_type": "not_running",
+				"namespace":  "",
 			})
 			mockM.EXPECT().RecordDuration("jwtauth_operation_duration_seconds", gomock.Any(), map[string]string{
 				"operation": "validate_access_token",
+				"namespace": "",
 			})
 			_, err := service.ValidateAccessToken(ctx, "some-token")
 			Expect(err).To(MatchError(tokens.ErrManagerNotRunning))
@@ -233,14 +248,17 @@ var _ = Describe("TokenManager Metrics", func() {
 			mockM.EXPECT().IncrementCounter("jwtauth_tokens_issued_total", gomock.Any())
 			mockM.EXPECT().RecordDuration("jwtauth_operation_duration_seconds", gomock.Any(), map[string]string{
 				"operation": "issue_access_token",
+				"namespace": "",
 			})
 			// RefreshAccessToken metrics
 			mockM.EXPECT().IncrementCounter("jwtauth_tokens_refreshed_total", map[string]string{
 				"status":     "success",
 				"error_type": "",
+				"namespace":  "",
 			})
 			mockM.EXPECT().RecordDuration("jwtauth_operation_duration_seconds", gomock.Any(), map[string]string{
 				"operation": "refresh_access_token",
+				"namespace": "",
 			})
 			_, err := service.RefreshAccessToken(ctx, "rt-1")
 			Expect(err).NotTo(HaveOccurred())
@@ -259,9 +277,11 @@ var _ = Describe("TokenManager Metrics", func() {
 			mockM.EXPECT().IncrementCounter("jwtauth_tokens_refreshed_total", map[string]string{
 				"status":     "expired",
 				"error_type": "expired",
+				"namespace":  "",
 			})
 			mockM.EXPECT().RecordDuration("jwtauth_operation_duration_seconds", gomock.Any(), map[string]string{
 				"operation": "refresh_access_token",
+				"namespace": "",
 			})
 			_, err := service.RefreshAccessToken(ctx, "rt-expired")
 			Expect(err).To(MatchError(tokens.ErrRefreshTokenExpired))
@@ -279,9 +299,11 @@ var _ = Describe("TokenManager Metrics", func() {
 			mockM.EXPECT().IncrementCounter("jwtauth_tokens_revoked_total", map[string]string{
 				"operation": "single",
 				"status":    "success",
+				"namespace": "",
 			})
 			mockM.EXPECT().RecordDuration("jwtauth_operation_duration_seconds", gomock.Any(), map[string]string{
 				"operation": "revoke_token",
+				"namespace": "",
 			})
 			Expect(service.RevokeRefreshToken(ctx, "rt-1")).To(Succeed())
 		})
@@ -291,9 +313,11 @@ var _ = Describe("TokenManager Metrics", func() {
 			mockM.EXPECT().IncrementCounter("jwtauth_tokens_revoked_total", map[string]string{
 				"operation": "single",
 				"status":    "invalid_input",
+				"namespace": "",
 			})
 			mockM.EXPECT().RecordDuration("jwtauth_operation_duration_seconds", gomock.Any(), map[string]string{
 				"operation": "revoke_token",
+				"namespace": "",
 			})
 			Expect(service.RevokeRefreshToken(ctx, "")).To(MatchError(tokens.ErrInvalidRefreshToken))
 		})
@@ -310,9 +334,11 @@ var _ = Describe("TokenManager Metrics", func() {
 			mockM.EXPECT().IncrementCounter("jwtauth_tokens_revoked_total", map[string]string{
 				"operation": "all_user",
 				"status":    "success",
+				"namespace": "",
 			})
 			mockM.EXPECT().RecordDuration("jwtauth_operation_duration_seconds", gomock.Any(), map[string]string{
 				"operation": "revoke_all_user_tokens",
+				"namespace": "",
 			})
 			Expect(service.RevokeAllUserTokens(ctx, "user-1")).To(Succeed())
 		})
@@ -333,10 +359,12 @@ var _ = Describe("TokenManager Metrics", func() {
 			}
 			mockStore.EXPECT().Retrieve(gomock.Any(), "rt-1").Return(storedToken, nil)
 			mockM.EXPECT().IncrementCounter("jwtauth_tokens_introspected_total", map[string]string{
-				"status": "success",
+				"status":    "success",
+				"namespace": "",
 			})
 			mockM.EXPECT().RecordDuration("jwtauth_operation_duration_seconds", gomock.Any(), map[string]string{
 				"operation": "introspect_token",
+				"namespace": "",
 			})
 			meta, err := service.IntrospectToken(ctx, "rt-1")
 			Expect(err).NotTo(HaveOccurred())
@@ -347,10 +375,12 @@ var _ = Describe("TokenManager Metrics", func() {
 			startService()
 			mockStore.EXPECT().Retrieve(gomock.Any(), "unknown-rt").Return(nil, storage.ErrTokenNotFound)
 			mockM.EXPECT().IncrementCounter("jwtauth_tokens_introspected_total", map[string]string{
-				"status": "success",
+				"status":    "success",
+				"namespace": "",
 			})
 			mockM.EXPECT().RecordDuration("jwtauth_operation_duration_seconds", gomock.Any(), map[string]string{
 				"operation": "introspect_token",
+				"namespace": "",
 			})
 			meta, err := service.IntrospectToken(ctx, "unknown-rt")
 			Expect(err).NotTo(HaveOccurred())
@@ -369,9 +399,11 @@ var _ = Describe("TokenManager Metrics", func() {
 			mockM.EXPECT().IncrementCounter("jwtauth_operations_total", map[string]string{
 				"operation": "cleanup",
 				"status":    "success",
+				"namespace": "",
 			})
 			mockM.EXPECT().RecordDuration("jwtauth_operation_duration_seconds", gomock.Any(), map[string]string{
 				"operation": "cleanup",
+				"namespace": "",
 			})
 			count, err := service.CleanupExpiredTokens(ctx)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary

- Adds `"namespace"` label to 8 `TokenManager` metric registrations in `pkg/metrics/prometheus.go`: `tokens_issued_total`, `tokens_validated_total`, `tokens_refreshed_total`, `tokens_revoked_total`, `tokens_introspected_total`, `operations_total`, `operation_duration_seconds`, `active_tokens`
- Enriches the logger via `Logger.With("namespace", cfg.Namespace)` in the `NewManager` constructor when `Namespace` is non-empty (no per-call-site changes needed)
- Updates `startSpan()` to prepend `"token.namespace": m.namespace` as the first span attribute on every `TokenManager` span
- Adds `"namespace": m.namespace` to all 26 metric call sites in `pkg/tokens/manager.go`
- Updates mock expectations in `pkg/tokens/manager_metrics_test.go` and call sites in `pkg/metrics/prometheus_test.go` to include `"namespace": ""`
- Zero-value `Namespace` emits an empty string label, preserving backward compatibility

Closes #112 (Phase 5 of 5).

## Test plan

- [x] `./run-ci-locally.sh` — 168 unit + 184 tokens + 28 integration specs, all green
- [x] `pkg/tokens/manager_metrics_test.go` — all 28 mock expectations updated to match new label signatures
- [x] `pkg/metrics/prometheus_test.go` — all affected call sites updated