### PR TITLE
feat(storage,tokens): add ListTokensForUser cursor-based pagination (#105 Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to this project will be documented in this file.
 
 - **`storage.RefreshStore` gains `ListTokens(ctx, cursor, count)` method** — existing third-party implementations must add this method. `MemoryRefreshStore` and `RedisRefreshStore` are already updated. See #105.
 
+- **`storage.RefreshStore` gains `ListTokensForUser(ctx, userID, cursor, count)` method** — existing third-party implementations must add this method. `MemoryRefreshStore` and `RedisRefreshStore` are already updated. See #105.
+
 ### Security
 
 - **`kid` path traversal fix** — `DiskKeyStore` and `RedisKeyStore` now validate the
@@ -112,6 +114,12 @@ All notable changes to this project will be documented in this file.
 - **Compile-time `var _ RefreshStore` assertions added to `MemoryRefreshStore` and `RedisRefreshStore`** — interface compliance is now verified at compile time. Closes #106.
 
 - **4 new Prometheus metrics registered in `PrometheusMetrics`** — storage-layer metrics (`jwtauth_storage_list_tokens_total`, `jwtauth_storage_list_tokens_duration_seconds`) and token-manager-layer metrics (`jwtauth_tokens_list_total`, `jwtauth_tokens_list_duration_seconds`); all carry `namespace` and `error_type` labels.
+
+- **`ListTokensForUser(ctx, userID, cursor, count)` added to `RefreshStore` interface and both implementations** — user-scoped cursor-based token iteration. `MemoryRefreshStore` uses an integer offset cursor into the user's insertion-order token slice; `RedisRefreshStore` uses Redis SSCAN cursor passthrough on the user set key, hydrating tokens via the existing `fetchTokensByIDs` pipeline helper. Returns `ErrInvalidUserID` if `userID` is empty. All other cursor and filtering semantics are identical to `ListTokens`. `MockRefreshStore` regenerated. See #105.
+
+- **`Manager.ListTokensForUser(ctx, userID, cursor, count)` added to `tokens.Manager`** — thin delegation to `RefreshStore.ListTokensForUser` following the same pattern as `Manager.ListTokens`. Emits a `token.list_tokens_for_user` span (attrs: `token.namespace`, `token.user_id`, `token.cursor`, `token.count`, `token.result_count`), logs success and failure, and records `jwtauth_tokens_list_for_user_total` counter and `jwtauth_tokens_list_for_user_duration_seconds` histogram with `namespace` and `error_type` labels.
+
+- **4 additional Prometheus metrics registered in `PrometheusMetrics`** — storage-layer metrics (`jwtauth_storage_list_tokens_for_user_total`, `jwtauth_storage_list_tokens_for_user_duration_seconds`) and token-manager-layer metrics (`jwtauth_tokens_list_for_user_total`, `jwtauth_tokens_list_for_user_duration_seconds`); all carry `namespace` and `error_type` labels.
 
 - **`Namespace string` added to `KeyManagerConfig` and `TokenManagerConfig`** — optional opaque label stored in both manager structs at construction time. Zero value preserves current behavior — no label is attached to observability output. Intended for multi-instance deployments where log lines, trace spans, and metric labels from different manager instances must be disambiguated. Decoupled from `KeyPrefix` — both fields may be set independently. See ADR-007.
 

--- a/internal/testutil/mock_refreshstore.go
+++ b/internal/testutil/mock_refreshstore.go
@@ -73,6 +73,22 @@ func (mr *MockRefreshStoreMockRecorder) ListTokens(ctx, cursor, count any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTokens", reflect.TypeOf((*MockRefreshStore)(nil).ListTokens), ctx, cursor, count)
 }
 
+// ListTokensForUser mocks base method.
+func (m *MockRefreshStore) ListTokensForUser(ctx context.Context, userID, cursor string, count int) ([]*storage.RefreshToken, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTokensForUser", ctx, userID, cursor, count)
+	ret0, _ := ret[0].([]*storage.RefreshToken)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ListTokensForUser indicates an expected call of ListTokensForUser.
+func (mr *MockRefreshStoreMockRecorder) ListTokensForUser(ctx, userID, cursor, count any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTokensForUser", reflect.TypeOf((*MockRefreshStore)(nil).ListTokensForUser), ctx, userID, cursor, count)
+}
+
 // Namespace mocks base method.
 func (m *MockRefreshStore) Namespace() string {
 	m.ctrl.T.Helper()

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -113,6 +113,15 @@ func (pm *PrometheusMetrics) registerAllMetrics(namespace string) {
 		[]string{"namespace"},
 		[]float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10})
 
+	pm.registerCounter(namespace, "tokens_list_for_user_total",
+		"Total number of list-tokens-for-user operations on the token manager",
+		[]string{"namespace", "error_type"})
+
+	pm.registerHistogram(namespace, "tokens_list_for_user_duration_seconds",
+		"Duration of list-tokens-for-user operations on the token manager in seconds",
+		[]string{"namespace"},
+		[]float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10})
+
 	pm.registerGauge(namespace, "active_tokens",
 		"Number of active tokens",
 		[]string{"storage_backend", "namespace"})
@@ -146,6 +155,15 @@ func (pm *PrometheusMetrics) registerAllMetrics(namespace string) {
 
 	pm.registerHistogram(namespace, "storage_list_tokens_duration_seconds",
 		"Duration of list-tokens operations in seconds",
+		[]string{"storage_backend", "namespace"},
+		[]float64{.0001, .0005, .001, .0025, .005, .01, .025, .05, .1, .25})
+
+	pm.registerCounter(namespace, "storage_list_tokens_for_user_total",
+		"Total number of list-tokens-for-user operations",
+		[]string{"storage_backend", "namespace", "error_type"})
+
+	pm.registerHistogram(namespace, "storage_list_tokens_for_user_duration_seconds",
+		"Duration of list-tokens-for-user operations in seconds",
 		[]string{"storage_backend", "namespace"},
 		[]float64{.0001, .0005, .001, .0025, .005, .01, .025, .05, .1, .25})
 

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -114,6 +114,18 @@ type RefreshStore interface {
 	// provides. Returns the context error if the context is cancelled.
 	ListTokens(ctx context.Context, cursor string, count int) ([]*RefreshToken, string, error)
 
+	// ListTokensForUser returns a page of refresh tokens belonging to userID
+	// starting from cursor. Pass an empty string for cursor to begin from the
+	// start. Returns the next cursor and a nil error on success. Returns an
+	// empty next cursor when iteration is exhausted. Count is a hint — actual
+	// page size may vary.
+	//
+	// All tokens are returned regardless of revocation or expiry status — the
+	// caller is responsible for filtering. Cursor semantics are best-effort and
+	// share the same guarantees as ListTokens. Returns ErrInvalidUserID if
+	// userID is empty. Returns the context error if the context is cancelled.
+	ListTokensForUser(ctx context.Context, userID string, cursor string, count int) ([]*RefreshToken, string, error)
+
 	// Namespace returns the namespace this store is operating in. For Redis-backed
 	// stores this matches the configured KeyPrefix. Implementations that do not
 	// support namespacing return empty string.

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -662,6 +663,127 @@ func (m *MemoryRefreshStore) ListTokens(ctx context.Context, cursor string, coun
 	span.SetAttribute("storage.result_count", resultCount)
 	span.SetStatus(tracing.StatusOK, "")
 	m.logger.Info("listTokens: page returned", ctx,
+		"result_count", resultCount,
+		"next_cursor", nextCursor)
+
+	return tokens, nextCursor, nil
+}
+
+// ListTokensForUser returns a page of refresh tokens belonging to userID
+// starting from cursor. Pass an empty string for cursor to begin from the
+// start. Returns the next cursor and a nil error on success. Returns an empty
+// next cursor when iteration is exhausted.
+//
+// All tokens are returned regardless of revocation or expiry status — the
+// caller is responsible for filtering. The cursor is an integer offset into
+// the stable insertion-order slice for userID — best-effort when tokens are
+// added or removed between pages. Returns ErrInvalidUserID if userID is empty.
+// Returns the context error if the context is cancelled.
+func (m *MemoryRefreshStore) ListTokensForUser(ctx context.Context, userID string, cursor string, count int) ([]*RefreshToken, string, error) {
+	ctx, span := m.startSpan(ctx, "ListTokensForUser")
+	defer span.End()
+	span.SetAttribute("storage.user_id", userID)
+	span.SetAttribute("storage.cursor", cursor)
+	span.SetAttribute("storage.count", count)
+
+	start := time.Now()
+	errorType := "error"
+	resultCount := 0
+	defer func() {
+		m.metrics.IncrementCounter(metricListTokensForUserTotal, map[string]string{
+			"storage_backend": m.backend,
+			"namespace":       "",
+			"error_type":      errorType,
+		})
+		m.metrics.RecordDuration(metricListTokensForUserDuration, time.Since(start), map[string]string{
+			"storage_backend": m.backend,
+			"namespace":       "",
+		})
+	}()
+
+	// ===== STEP 1: Check Context =====
+	if err := ctx.Err(); err != nil {
+		errorType = "cancelled"
+		m.logger.Warn("listTokensForUser aborted: context cancelled", ctx, "reason", err)
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
+		return nil, "", err
+	}
+
+	// ===== STEP 2: Validate Inputs =====
+	if len(strings.TrimSpace(userID)) == 0 {
+		errorType = "validation_error"
+		m.logger.Warn("listTokensForUser rejected: userID is empty or whitespace", ctx)
+		span.RecordError(ErrInvalidUserID)
+		span.SetStatus(tracing.StatusError, ErrInvalidUserID.Error())
+		return nil, "", ErrInvalidUserID
+	}
+
+	// ===== STEP 3: Acquire Read Lock =====
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	// ===== STEP 4: Parse Cursor as Integer Offset =====
+	offset := 0
+	if cursor != "" {
+		if parsed, err := strconv.Atoi(cursor); err == nil && parsed > 0 {
+			offset = parsed
+		}
+	}
+
+	// ===== STEP 5: Build Page from User's Token Slice =====
+	tokenIDs := m.userTokens[userID]
+	if offset >= len(tokenIDs) {
+		errorType = ""
+		span.SetStatus(tracing.StatusOK, "")
+		m.logger.Info("listTokensForUser: page returned", ctx,
+			"user_id", userID,
+			"result_count", 0,
+			"next_cursor", "")
+		return nil, "", nil
+	}
+
+	end := offset + count
+	if count <= 0 || end > len(tokenIDs) {
+		end = len(tokenIDs)
+	}
+	page := tokenIDs[offset:end]
+
+	tokens := make([]*RefreshToken, 0, len(page))
+	for _, id := range page {
+		t, ok := m.tokens[id]
+		if !ok {
+			continue
+		}
+		cp := &RefreshToken{
+			TokenID:   t.TokenID,
+			UserID:    t.UserID,
+			ExpiresAt: t.ExpiresAt,
+			CreatedAt: t.CreatedAt,
+			Revoked:   t.Revoked,
+		}
+		if t.Metadata != nil {
+			cp.Metadata = make(map[string]interface{}, len(t.Metadata))
+			for k, v := range t.Metadata {
+				cp.Metadata[k] = v
+			}
+		}
+		tokens = append(tokens, cp)
+	}
+
+	// ===== STEP 6: Compute Next Cursor =====
+	nextCursor := ""
+	if end < len(tokenIDs) {
+		nextCursor = strconv.Itoa(end)
+	}
+
+	// ===== STEP 7: Log and Return =====
+	errorType = ""
+	resultCount = len(tokens)
+	span.SetAttribute("storage.result_count", resultCount)
+	span.SetStatus(tracing.StatusOK, "")
+	m.logger.Info("listTokensForUser: page returned", ctx,
+		"user_id", userID,
 		"result_count", resultCount,
 		"next_cursor", nextCursor)
 

--- a/pkg/storage/observability.go
+++ b/pkg/storage/observability.go
@@ -11,4 +11,7 @@ const (
 
 	metricListTokensTotal    = "jwtauth_storage_list_tokens_total"
 	metricListTokensDuration = "jwtauth_storage_list_tokens_duration_seconds"
+
+	metricListTokensForUserTotal    = "jwtauth_storage_list_tokens_for_user_total"
+	metricListTokensForUserDuration = "jwtauth_storage_list_tokens_for_user_duration_seconds"
 )

--- a/pkg/storage/redis.go
+++ b/pkg/storage/redis.go
@@ -827,6 +827,113 @@ func (r *RedisRefreshStore) ListTokens(ctx context.Context, cursor string, count
 	return tokens, nextCursor, nil
 }
 
+// ListTokensForUser returns a page of refresh tokens belonging to userID
+// starting from cursor. Pass an empty string for cursor to begin from the
+// start. Returns the next cursor and a nil error on success. Returns an empty
+// next cursor when iteration is exhausted.
+//
+// All tokens are returned regardless of revocation or expiry status — the
+// caller is responsible for filtering. Cursor semantics mirror Redis SSCAN:
+// tokens inserted or deleted between pages may appear, be skipped, or
+// duplicated. Returns ErrInvalidUserID if userID is empty. Returns the context
+// error if the context is cancelled.
+func (r *RedisRefreshStore) ListTokensForUser(ctx context.Context, userID string, cursor string, count int) ([]*RefreshToken, string, error) {
+	ctx, span := r.startSpan(ctx, "ListTokensForUser")
+	defer span.End()
+	span.SetAttribute("storage.user_id", userID)
+	span.SetAttribute("storage.cursor", cursor)
+	span.SetAttribute("storage.count", count)
+
+	start := time.Now()
+	errorType := "error"
+	resultCount := 0
+	defer func() {
+		r.metrics.IncrementCounter(metricListTokensForUserTotal, map[string]string{
+			"storage_backend": r.backend,
+			"namespace":       r.namespace,
+			"error_type":      errorType,
+		})
+		r.metrics.RecordDuration(metricListTokensForUserDuration, time.Since(start), map[string]string{
+			"storage_backend": r.backend,
+			"namespace":       r.namespace,
+		})
+	}()
+
+	// ===== STEP 1: Check Context =====
+	if err := ctx.Err(); err != nil {
+		errorType = "cancelled"
+		r.logger.Warn("listTokensForUser aborted: context cancelled", ctx, "reason", err)
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
+		return nil, "", err
+	}
+
+	// ===== STEP 2: Validate Inputs =====
+	if len(strings.TrimSpace(userID)) == 0 {
+		errorType = "validation_error"
+		r.logger.Warn("listTokensForUser rejected: userID is empty or whitespace", ctx)
+		span.RecordError(ErrInvalidUserID)
+		span.SetStatus(tracing.StatusError, ErrInvalidUserID.Error())
+		return nil, "", ErrInvalidUserID
+	}
+
+	// ===== STEP 3: Parse Cursor =====
+	var redisCursor uint64
+	if cursor != "" {
+		parsed, err := strconv.ParseUint(cursor, 10, 64)
+		if err != nil {
+			errorType = "invalid_cursor"
+			r.logger.Warn("listTokensForUser: invalid cursor — starting from 0", ctx, "cursor", cursor)
+		} else {
+			redisCursor = parsed
+		}
+	}
+
+	// ===== STEP 4: SSCAN the User's Token Set =====
+	scanCount := int64(count)
+	if scanCount <= 0 {
+		scanCount = 10
+	}
+	userSetKey := r.userSetPrefix + userID
+	tokenIDs, nextRedisCursor, err := r.client.SScan(ctx, userSetKey, redisCursor, "*", scanCount).Result()
+	if err != nil {
+		errorType = "redis_error"
+		r.logger.Error("listTokensForUser failed: redis sscan error", ctx,
+			"user_id", userID, "error", err)
+		wrapped := fmt.Errorf("failed to scan user tokens: %w", err)
+		span.RecordError(wrapped)
+		span.SetStatus(tracing.StatusError, wrapped.Error())
+		return nil, "", wrapped
+	}
+
+	// ===== STEP 5: Hydrate Token IDs =====
+	tokens, err := r.fetchTokensByIDs(ctx, tokenIDs)
+	if err != nil {
+		errorType = "redis_error"
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
+		return nil, "", err
+	}
+
+	// ===== STEP 6: Compute Next Cursor =====
+	nextCursor := ""
+	if nextRedisCursor != 0 {
+		nextCursor = strconv.FormatUint(nextRedisCursor, 10)
+	}
+
+	// ===== STEP 7: Log and Return =====
+	errorType = ""
+	resultCount = len(tokens)
+	span.SetAttribute("storage.result_count", resultCount)
+	span.SetStatus(tracing.StatusOK, "")
+	r.logger.Info("listTokensForUser: page returned", ctx,
+		"user_id", userID,
+		"result_count", resultCount,
+		"next_cursor", nextCursor)
+
+	return tokens, nextCursor, nil
+}
+
 // fetchTokensByIDs retrieves RefreshToken records for the given tokenIDs using
 // a pipelined HGETALL. Missing or unparseable tokens are skipped with a warning.
 func (r *RedisRefreshStore) fetchTokensByIDs(ctx context.Context, tokenIDs []string) ([]*RefreshToken, error) {

--- a/pkg/storage/suite_test.go
+++ b/pkg/storage/suite_test.go
@@ -1001,5 +1001,131 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 				Expect(tokenIDs[expired]).To(BeTrue(), "expired token missing from ListTokens")
 			})
 		})
+
+		// PHASE 13: ListTokensForUser — User-scoped Cursor-based Pagination
+		//
+		// Verifies that ListTokensForUser correctly scopes iteration to a single
+		// user's tokens and that cursor-based pagination exhausts the set cleanly.
+
+		Describe("Phase 13: ListTokensForUser", func() {
+			It("should return empty result for user with no tokens", func() {
+				tokens, next, err := store.ListTokensForUser(ctx, "ghost-user", "", 10)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tokens).To(BeEmpty())
+				Expect(next).To(BeEmpty())
+			})
+
+			It("should return all tokens for a user in a single page", func() {
+				user := "user-single-page"
+				ids := []string{"tok-a", "tok-b", "tok-c"}
+				for _, id := range ids {
+					Expect(store.Store(ctx, id, user, expiresAt, nil)).To(Succeed())
+				}
+
+				tokens, next, err := store.ListTokensForUser(ctx, user, "", 100)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(next).To(BeEmpty())
+				got := make(map[string]bool)
+				for _, t := range tokens {
+					got[t.TokenID] = true
+				}
+				for _, id := range ids {
+					Expect(got[id]).To(BeTrue(), "expected token %s in result", id)
+				}
+			})
+
+			It("should paginate across multiple pages and exhaust the set", func() {
+				user := "user-paginate"
+				total := 7
+				for i := 0; i < total; i++ {
+					Expect(store.Store(ctx, fmt.Sprintf("page-tok-%d", i), user, expiresAt, nil)).To(Succeed())
+				}
+
+				var all []*storage.RefreshToken
+				cursor := ""
+				for {
+					page, next, err := store.ListTokensForUser(ctx, user, cursor, 3)
+					Expect(err).NotTo(HaveOccurred())
+					all = append(all, page...)
+					cursor = next
+					if cursor == "" {
+						break
+					}
+				}
+				Expect(all).To(HaveLen(total))
+			})
+
+			It("should isolate tokens between different users", func() {
+				userA := "user-isolation-a"
+				userB := "user-isolation-b"
+				Expect(store.Store(ctx, "tok-iso-a1", userA, expiresAt, nil)).To(Succeed())
+				Expect(store.Store(ctx, "tok-iso-a2", userA, expiresAt, nil)).To(Succeed())
+				Expect(store.Store(ctx, "tok-iso-b1", userB, expiresAt, nil)).To(Succeed())
+
+				tokensA, _, err := store.ListTokensForUser(ctx, userA, "", 100)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tokensA).To(HaveLen(2))
+				for _, t := range tokensA {
+					Expect(t.UserID).To(Equal(userA))
+				}
+
+				tokensB, _, err := store.ListTokensForUser(ctx, userB, "", 100)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tokensB).To(HaveLen(1))
+				Expect(tokensB[0].UserID).To(Equal(userB))
+			})
+
+			It("should return ErrInvalidUserID for empty userID", func() {
+				_, _, err := store.ListTokensForUser(ctx, "", "", 10)
+				Expect(err).To(MatchError(storage.ErrInvalidUserID))
+			})
+
+			It("should return empty next cursor when iteration is exhausted", func() {
+				user := "user-exhaust"
+				Expect(store.Store(ctx, "tok-exhaust-1", user, expiresAt, nil)).To(Succeed())
+				Expect(store.Store(ctx, "tok-exhaust-2", user, expiresAt, nil)).To(Succeed())
+
+				_, finalCursor, err := store.ListTokensForUser(ctx, user, "", 100)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(finalCursor).To(BeEmpty())
+			})
+
+			It("should return context error on cancelled context", func() {
+				cancelledCtx, cancel := context.WithCancel(context.Background())
+				cancel()
+
+				_, _, err := store.ListTokensForUser(cancelledCtx, userID, "", 10)
+				Expect(err).To(MatchError(context.Canceled))
+			})
+
+			It("should return revoked and active tokens for the user", func() {
+				user := "user-mixed"
+				active := "tok-user-active"
+				revoked := "tok-user-revoked"
+
+				Expect(store.Store(ctx, active, user, expiresAt, nil)).To(Succeed())
+				Expect(store.Store(ctx, revoked, user, expiresAt, nil)).To(Succeed())
+				Expect(store.Revoke(ctx, revoked)).To(Succeed())
+
+				var all []*storage.RefreshToken
+				cursor := ""
+				for {
+					page, next, err := store.ListTokensForUser(ctx, user, cursor, 100)
+					Expect(err).NotTo(HaveOccurred())
+					all = append(all, page...)
+					cursor = next
+					if cursor == "" {
+						break
+					}
+				}
+
+				tokenIDs := map[string]bool{}
+				for _, t := range all {
+					tokenIDs[t.TokenID] = true
+				}
+				Expect(tokenIDs[active]).To(BeTrue(), "active token missing from ListTokensForUser")
+				Expect(tokenIDs[revoked]).To(BeTrue(), "revoked token missing from ListTokensForUser")
+			})
+		})
 	})
 }

--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -2225,6 +2225,69 @@ func (m *Manager) ListTokens(ctx context.Context, cursor string, count int) ([]*
 	return tokens, nextCursor, nil
 }
 
+// ListTokensForUser returns a page of refresh tokens belonging to userID from
+// the underlying store. See storage.RefreshStore.ListTokensForUser for cursor
+// and filtering semantics. Returns ErrInvalidUserID if userID is empty.
+// Returns the context error if the context is cancelled.
+func (m *Manager) ListTokensForUser(ctx context.Context, userID string, cursor string, count int) ([]*storage.RefreshToken, string, error) {
+	ctx, span := m.startSpan(ctx, "ListTokensForUser")
+	defer span.End()
+	span.SetAttribute("token.namespace", m.namespace)
+	span.SetAttribute("token.user_id", userID)
+	span.SetAttribute("token.cursor", cursor)
+	span.SetAttribute("token.count", count)
+
+	start := time.Now()
+	errorType := "error"
+	defer func() {
+		m.metrics.IncrementCounter(metricTokensListForUserTotal, map[string]string{
+			"namespace":  m.namespace,
+			"error_type": errorType,
+		})
+		m.metrics.RecordDuration(metricTokensListForUserDuration, time.Since(start), map[string]string{
+			"namespace": m.namespace,
+		})
+	}()
+
+	// ===== STEP 1: Service State Check =====
+	if !m.isRunning.Load() {
+		errorType = "not_running"
+		m.logger.Warn("attempted listTokensForUser while service stopped", ctx)
+		span.RecordError(ErrManagerNotRunning)
+		span.SetStatus(tracing.StatusError, ErrManagerNotRunning.Error())
+		return nil, "", ErrManagerNotRunning
+	}
+
+	// ===== STEP 2: Context Check =====
+	if err := ctx.Err(); err != nil {
+		errorType = "cancelled"
+		m.logger.Info("context cancelled during listTokensForUser", ctx, "error", err)
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
+		return nil, "", err
+	}
+
+	// ===== STEP 3: Delegate to Store =====
+	tokens, nextCursor, err := m.refreshStore.ListTokensForUser(ctx, userID, cursor, count)
+	if err != nil {
+		m.logger.Error("failed to list tokens for user", ctx, "user_id", userID, "error", err)
+		wrapped := fmt.Errorf("list tokens for user failed: %w", err)
+		span.RecordError(wrapped)
+		span.SetStatus(tracing.StatusError, wrapped.Error())
+		return nil, "", wrapped
+	}
+
+	// ===== STEP 4: Record Success and Log =====
+	errorType = ""
+	span.SetAttribute("token.result_count", len(tokens))
+	span.SetStatus(tracing.StatusOK, "")
+	m.logger.Info("tokens listed for user", ctx,
+		"user_id", userID,
+		"result_count", len(tokens),
+		"next_cursor", nextCursor)
+	return tokens, nextCursor, nil
+}
+
 // generateTokenID creates a cryptographically random token identifier.
 //
 // The token ID (jti claim) is used for:

--- a/pkg/tokens/manager_list_tokens_test.go
+++ b/pkg/tokens/manager_list_tokens_test.go
@@ -146,4 +146,100 @@ var _ = Describe("TokenManager ListTokens", func() {
 			})
 		})
 	})
+
+	Describe("ListTokensForUser", func() {
+		It("should return page from store on success", func() {
+			expected := []*storage.RefreshToken{
+				{TokenID: "tok-1", UserID: "user-42"},
+				{TokenID: "tok-2", UserID: "user-42"},
+			}
+			mockStore.EXPECT().
+				ListTokensForUser(gomock.Any(), "user-42", "", 10).
+				Return(expected, "", nil)
+
+			page, next, err := service.ListTokensForUser(ctx, "user-42", "", 10)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(page).To(Equal(expected))
+			Expect(next).To(BeEmpty())
+		})
+
+		It("should propagate userID, cursor, and count to store", func() {
+			mockStore.EXPECT().
+				ListTokensForUser(gomock.Any(), "user-42", "cursor-abc", 5).
+				Return(nil, "", nil)
+
+			service.ListTokensForUser(ctx, "user-42", "cursor-abc", 5)
+		})
+
+		It("should return next cursor from store", func() {
+			mockStore.EXPECT().
+				ListTokensForUser(gomock.Any(), "user-42", "", 2).
+				Return([]*storage.RefreshToken{{TokenID: "tok-1"}}, "cursor-xyz", nil)
+
+			_, next, err := service.ListTokensForUser(ctx, "user-42", "", 2)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(next).To(Equal("cursor-xyz"))
+		})
+
+		It("should log success with user_id, result count, and next cursor", func() {
+			mockStore.EXPECT().
+				ListTokensForUser(gomock.Any(), "user-42", "", 10).
+				Return([]*storage.RefreshToken{{TokenID: "tok-1"}}, "next", nil)
+
+			service.ListTokensForUser(ctx, "user-42", "", 10)
+
+			Eventually(func() bool {
+				return mockLogger.HasLog("info", "tokens listed for user")
+			}).Should(BeTrue())
+		})
+
+		Context("when store returns an error", func() {
+			It("should return wrapped error", func() {
+				storeErr := errors.New("redis unavailable")
+				mockStore.EXPECT().
+					ListTokensForUser(gomock.Any(), "user-42", "", 10).
+					Return(nil, "", storeErr)
+
+				_, _, err := service.ListTokensForUser(ctx, "user-42", "", 10)
+
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, storeErr)).To(BeTrue())
+			})
+
+			It("should log the error", func() {
+				mockStore.EXPECT().
+					ListTokensForUser(gomock.Any(), "user-42", "", 10).
+					Return(nil, "", errors.New("store error"))
+
+				service.ListTokensForUser(ctx, "user-42", "", 10)
+
+				Eventually(func() bool {
+					return mockLogger.HasLog("error", "failed to list tokens for user")
+				}).Should(BeTrue())
+			})
+		})
+
+		Context("when service is not running", func() {
+			It("should return ErrManagerNotRunning", func() {
+				stoppedService := newTestManager(mockKM, mockStore, mockLogger)
+
+				_, _, err := stoppedService.ListTokensForUser(ctx, "user-42", "", 10)
+
+				Expect(err).To(MatchError(tokens.ErrManagerNotRunning))
+			})
+		})
+
+		Context("when context is cancelled", func() {
+			It("should return context error", func() {
+				cancelledCtx, cancel := context.WithCancel(ctx)
+				cancel()
+
+				_, _, err := service.ListTokensForUser(cancelledCtx, "user-42", "", 10)
+
+				Expect(err).To(MatchError(context.Canceled))
+			})
+		})
+	})
 })

--- a/pkg/tokens/observability.go
+++ b/pkg/tokens/observability.go
@@ -15,4 +15,7 @@ const (
 
 	metricTokensListTotal    = "jwtauth_tokens_list_total"
 	metricTokensListDuration = "jwtauth_tokens_list_duration_seconds"
+
+	metricTokensListForUserTotal    = "jwtauth_tokens_list_for_user_total"
+	metricTokensListForUserDuration = "jwtauth_tokens_list_for_user_duration_seconds"
 )


### PR DESCRIPTION
## Summary

- Adds `ListTokensForUser(ctx, userID, cursor, count)` to the `RefreshStore` interface and both implementations — user-scoped cursor iteration over a single user's tokens
- `MemoryRefreshStore` uses an integer offset cursor into the stable insertion-order `userTokens[userID]` slice
- `RedisRefreshStore` uses Redis `SSCAN` cursor passthrough on the user set key (`user_tokens:{userID}`), hydrating results via the existing `fetchTokensByIDs` pipeline helper from Phase 1
- `Manager.ListTokensForUser` delegates to the store with full observability: `token.list_tokens_for_user` span (carrying `token.user_id`), `Info`/`Error` logs, `jwtauth_tokens_list_for_user_total` counter and `jwtauth_tokens_list_for_user_duration_seconds` histogram
- 4 new Prometheus metrics registered (`jwtauth_storage_list_tokens_for_user_total`, `jwtauth_storage_list_tokens_for_user_duration_seconds`, `jwtauth_tokens_list_for_user_total`, `jwtauth_tokens_list_for_user_duration_seconds`)
- `MockRefreshStore` regenerated

## Test plan

- [x] Phase 13 in `pkg/storage/suite_test.go` — 8 specs × 2 backends (memory + Redis/miniredis): empty user, single page, multi-page pagination, user isolation, empty userID → `ErrInvalidUserID`, cursor exhaustion, context cancellation, revoked + active tokens
- [x] `ListTokensForUser` context block in `pkg/tokens/manager_list_tokens_test.go` — 8 unit specs covering success path, cursor/count propagation, next cursor forwarding, success log, store error wrapping, error log, not-running guard, context cancellation
- [x] `./run-ci-locally.sh` — 784 unit + 28 integration specs passing under `-race`; lint and govulncheck clean

Closes part of #105 (Phase 2 of 3). Phase 3 (documentation + example) follows after this merges.