### PR TITLE
feat(tokens): expose TokenID in TokenMetadata for raw-token revocation (#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,8 @@ All notable changes to this project will be documented in this file.
 
 - **`TokenManager` emits namespace across all three signal types** — every span carries a `token.namespace` attribute, every log line carries a `namespace` field (via `Logger.With` in the constructor), and every Prometheus label on token management metrics (`tokens_issued_total`, `tokens_validated_total`, `tokens_refreshed_total`, `tokens_revoked_total`, `tokens_introspected_total`, `operations_total`, `operation_duration_seconds`, `active_tokens`) includes `namespace`. Zero-value `Namespace` emits an empty string label, preserving backward compatibility. Closes #112 (Phase 5).
 
+- **`TokenMetadata.TokenID` (`jti`) populated by `IntrospectToken`** — callers can now revoke a token by ID directly from introspection results without parsing the JWT themselves (closes #108). Per RFC 7662 §2.2; set from `refreshToken.TokenID` for found tokens and from the caller-supplied token string for the not-found path.
+
 ### Fixed
 
 - **`KeyInfo.KeySizeBits` now reports actual key size** — previously sourced from `KeyManagerConfig.KeySize` (caller-supplied), which could silently diverge from the actual RSA key on disk if the `DiskKeyStore` or `RedisKeyStore` was configured with a different key size. Now derived from `keyPair.PrivateKey.N.BitLen()` so the reported value always matches the real key material.

--- a/pkg/tokens/claims.go
+++ b/pkg/tokens/claims.go
@@ -162,6 +162,9 @@ type TokenMetadata struct {
 	// Scope contains OAuth2 scopes if present
 	Scope string `json:"scope,omitempty"`
 
+	// TokenID is the unique identifier for this token (jti claim), per RFC 7662.
+	TokenID string `json:"jti,omitempty"`
+
 	// Custom contains any custom claims
 	Custom map[string]interface{} `json:"custom,omitempty"`
 }

--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -2047,6 +2047,7 @@ func (m *Manager) IntrospectToken(ctx context.Context, token string) (*TokenMeta
 			TokenType: "refresh_token",
 			ExpiresAt: time.Time{},
 			IssuedAt:  time.Time{},
+			TokenID:   token,
 		}, nil
 	}
 
@@ -2067,6 +2068,7 @@ func (m *Manager) IntrospectToken(ctx context.Context, token string) (*TokenMeta
 			TokenType: "refresh_token",
 			ExpiresAt: refreshToken.ExpiresAt,
 			IssuedAt:  refreshToken.CreatedAt,
+			TokenID:   refreshToken.TokenID,
 		}, nil
 	}
 
@@ -2083,6 +2085,7 @@ func (m *Manager) IntrospectToken(ctx context.Context, token string) (*TokenMeta
 			TokenType: "refresh_token",
 			ExpiresAt: refreshToken.ExpiresAt,
 			IssuedAt:  refreshToken.CreatedAt,
+			TokenID:   refreshToken.TokenID,
 		}, nil
 	}
 
@@ -2100,6 +2103,7 @@ func (m *Manager) IntrospectToken(ctx context.Context, token string) (*TokenMeta
 		TokenType: "refresh_token",
 		ExpiresAt: refreshToken.ExpiresAt,
 		IssuedAt:  refreshToken.CreatedAt,
+		TokenID:   refreshToken.TokenID,
 	}, nil
 }
 

--- a/pkg/tokens/manager_test.go
+++ b/pkg/tokens/manager_test.go
@@ -1606,6 +1606,7 @@ var _ = Describe("TokenManager", func() {
 		Context("with valid refresh token", func() {
 			It("should return token metadata", func() {
 				mockStore.EXPECT().Retrieve(gomock.Any(), refreshToken).Return(&storage.RefreshToken{
+					TokenID:   refreshToken,
 					UserID:    testUserID,
 					ExpiresAt: time.Now().Add(1 * time.Hour),
 					CreatedAt: time.Now(),
@@ -1618,6 +1619,7 @@ var _ = Describe("TokenManager", func() {
 				Expect(metadata.Active).To(BeTrue())
 				Expect(metadata.Subject).To(Equal(testUserID))
 				Expect(metadata.TokenType).To(Equal("refresh_token"))
+				Expect(metadata.TokenID).To(Equal(refreshToken))
 			})
 
 			It("should include expiration info", func() {
@@ -1638,6 +1640,7 @@ var _ = Describe("TokenManager", func() {
 		Context("with expired token", func() {
 			It("should return inactive status", func() {
 				mockStore.EXPECT().Retrieve(gomock.Any(), refreshToken).Return(&storage.RefreshToken{
+					TokenID:   refreshToken,
 					UserID:    testUserID,
 					ExpiresAt: time.Now().Add(-1 * time.Hour),
 					CreatedAt: time.Now().Add(-25 * time.Hour),
@@ -1648,6 +1651,7 @@ var _ = Describe("TokenManager", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(metadata.Active).To(BeFalse())
+				Expect(metadata.TokenID).To(Equal(refreshToken))
 			})
 		})
 
@@ -1660,12 +1664,14 @@ var _ = Describe("TokenManager", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(metadata.Active).To(BeFalse())
 				Expect(metadata.Subject).To(BeEmpty())
+				Expect(metadata.TokenID).To(Equal("invalid-token"))
 			})
 		})
 
 		Context("with revoked token", func() {
 			It("should return inactive status", func() {
 				mockStore.EXPECT().Retrieve(gomock.Any(), refreshToken).Return(&storage.RefreshToken{
+					TokenID:   refreshToken,
 					UserID:    testUserID,
 					ExpiresAt: time.Now().Add(1 * time.Hour),
 					CreatedAt: time.Now(),
@@ -1677,6 +1683,7 @@ var _ = Describe("TokenManager", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(metadata.Active).To(BeFalse())
 				Expect(metadata.Subject).To(Equal(testUserID))
+				Expect(metadata.TokenID).To(Equal(refreshToken))
 			})
 		})
 


### PR DESCRIPTION
## Summary

- Adds `TokenID string` (`json:"jti,omitempty"`) to `TokenMetadata` in `pkg/tokens/claims.go`, after `Scope` and before `Custom`, matching RFC 7662 §2.2
- Populates `TokenID` in all four `IntrospectToken` return paths: `refreshToken.TokenID` for found tokens (active/expired/revoked), caller-supplied token string for the not-found path
- Adds `TokenID` assertions to the active, expired, revoked, and not-found `IntrospectToken` test cases in `manager_test.go`; updates mock `storage.RefreshToken` stubs to set `TokenID` where the storage record is available

## Why

`IntrospectToken` is the only library path from a raw refresh token string to its metadata, but `TokenMetadata` silently dropped the `jti` claim. Without it, callers (e.g. jwtauth-service's `RevokeToken` RPC) had to parse the JWT themselves to extract the ID before calling `RevokeRefreshToken` — coupling them to JWT internals outside the library's contract.

After this change the clean path is:

```go
meta, err := mgr.IntrospectToken(ctx, rawRefreshToken)
if err != nil || !meta.Active {
    return status.Error(codes.Unauthenticated, "invalid token")
}
err = mgr.RevokeRefreshToken(ctx, meta.TokenID)
```

## Test plan

- [ ] `./run-ci-locally.sh` — all checks pass (200 unit + 28 integration specs)
- [ ] `IntrospectToken` active case asserts `metadata.TokenID == refreshToken`
- [ ] `IntrospectToken` expired case asserts `metadata.TokenID == refreshToken`
- [ ] `IntrospectToken` revoked case asserts `metadata.TokenID == refreshToken`
- [ ] `IntrospectToken` not-found case asserts `metadata.TokenID == "invalid-token"`
- [ ] No interface or mock regeneration required — `TokenMetadata` is not part of any interface

Closes #108.