### PR TITLE
fix(security): add aud to reserved claims guard in WithClaims methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to this project will be documented in this file.
 
 ### Security
 
+- **`aud` added to reserved claims guard in `IssueAccessTokenWithClaims` and `IssueTokenPairWithClaims`** — callers can no longer override the manager's configured audience via custom claims. The warn-log path already covered this case; only the guard map needed updating. See #109.
+
 - **`kid` path traversal fix** — `DiskKeyStore` and `RedisKeyStore` now validate the
   `kid` header value against a UUID v4 format at every method boundary (`Save`,
   `UpdateMetadata`, `LoadKey`, `Delete`) before constructing any filesystem path or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to this project will be documented in this file.
 
 ### Security
 
-- **`aud` added to reserved claims guard in `IssueAccessTokenWithClaims` and `IssueTokenPairWithClaims`** — callers can no longer override the manager's configured audience via custom claims. The warn-log path already covered this case; only the guard map needed updating. See #109.
+- **`aud` added to reserved claims guard in `IssueAccessTokenWithClaims` and `IssueTokenPairWithClaims`** — callers can no longer override the manager's configured audience via custom claims. The warn-log path already covered this case; only the guard map needed updating. See #109 and ADR-008.
 
 - **`kid` path traversal fix** — `DiskKeyStore` and `RedisKeyStore` now validate the
   `kid` header value against a UUID v4 format at every method boundary (`Save`,

--- a/README.md
+++ b/README.md
@@ -1213,6 +1213,8 @@ This library follows SOLID principles and clean architecture patterns. For detai
 | [ADR-004](doc/adr/004-kid-validation.md) | `kid` UUID validation at every `KeyStore` boundary — path traversal prevention | 2026-04-21 |
 | [ADR-005](doc/adr/005-security-boundaries.md) | Security boundaries — explicit validation gate for every attacker-controlled token field | 2026-04-21 |
 | [ADR-006](doc/adr/006-keyprefix-namespace-isolation.md) | `KeyPrefix` — optional namespace isolation for Redis backends; opaque separator for any multi-instance deployment | 2026-04-27 |
+| [ADR-007](doc/adr/007-namespace-consistency-contract.md) | Namespace field on `ManagerConfig` and `KeyManagerConfig` for observability consistency | 2026-04-27 |
+| [ADR-008](doc/adr/008-reserved-claims-at-issuance.md) | Reserved claims protection at issuance — `aud` and other manager-controlled claims cannot be overridden via `CustomClaims` | 2026-04-29 |
 
 ## Rate Limiting
 

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -1072,6 +1072,9 @@ Key design decisions are captured in `doc/adr/`. Each ADR documents the context,
 | [003](adr/003-rs256-only.md) | RS256 Only (No Algorithm Flexibility) | 2026-04-01 |
 | [004](adr/004-kid-validation.md) | `kid` UUID Validation at KeyStore Boundary | 2026-04-21 |
 | [005](adr/005-security-boundaries.md) | Security Boundaries — Attacker-Controlled Token Fields | 2026-04-21 |
+| [006](adr/006-keyprefix-namespace-isolation.md) | `KeyPrefix` — Namespace Isolation in Redis Backends | 2026-04-27 |
+| [007](adr/007-namespace-consistency-contract.md) | Namespace Field on Manager Configs for Observability Consistency | 2026-04-27 |
+| [008](adr/008-reserved-claims-at-issuance.md) | Reserved Claims Protection at Token Issuance | 2026-04-29 |
 
 ---
 

--- a/doc/adr/008-reserved-claims-at-issuance.md
+++ b/doc/adr/008-reserved-claims-at-issuance.md
@@ -1,0 +1,78 @@
+# ADR-008: Reserved Claims Protection at Token Issuance
+
+**Status**: Accepted  
+**Date**: 2026-04-29  
+**Deciders**: Architecture Team
+
+## Context
+
+jwtauth exposes `CustomClaims` (a `map[string]interface{}`) on `IssueAccessTokenWithClaims`
+and `IssueTokenPairWithClaims` so callers can embed application-specific data in access
+tokens. Standard JWT claims — `sub`, `iss`, `aud`, `exp`, `iat`, `nbf`, `jti` — are
+controlled by the `Manager` instance and set from its configuration at issuance time.
+
+Without an explicit guard, a caller could pass any of these keys in `CustomClaims` and
+silently overwrite the manager-set value. The `aud` claim was missing from the guard until
+issue #109 was filed, making the audience overrideable by any caller with access to
+`IssueAccessTokenWithClaims`.
+
+Per-call audience override has a legitimate use case — service-to-service tokens targeting
+different downstream services from a single manager — but allowing it silently through
+`CustomClaims` is the wrong mechanism. It is invisible at the call site, untestable in
+isolation, and undermines the manager's security invariants for callers who are unaware of
+the interaction.
+
+## Decision
+
+**All standard JWT claims that the `Manager` controls at the instance level are declared
+as reserved and silently dropped — with a warning log — if a caller passes them in
+`CustomClaims`.**
+
+The reserved set is:
+
+```go
+reservedClaims := map[string]bool{
+    "sub": true, "iss": true, "aud": true, "exp": true,
+    "iat": true, "nbf": true, "jti": true,
+}
+```
+
+Any key in this map that appears in `CustomClaims` is dropped before the JWT is built.
+A `Warn`-level log entry is emitted so the mistake is visible during development and
+integration testing.
+
+Per-call audience targeting is intentionally **not** supported through `CustomClaims`.
+If that capability is needed in the future, it must be exposed through an explicit API
+surface — for example, a functional option:
+
+```go
+IssueAccessTokenWithClaims(ctx, userID, claims, tokens.WithAudience("svc-payments"))
+```
+
+This makes the override visible at the call site, allows it to be tested independently,
+and does not require callers to know which claim keys are reserved.
+
+## Consequences
+
+**Positive:**
+- Manager security invariants — particularly audience binding — cannot be undermined
+  through `CustomClaims`, regardless of how the caller constructs their claims map.
+- The warn-log drop path makes mistakes visible during development without causing a
+  hard failure that breaks production callers on upgrade.
+- The design is consistent with ADR-005: every security-sensitive claim has a named
+  gate, whether on the validation path (inbound tokens) or the issuance path (outbound).
+
+**Negative:**
+- Callers who legitimately need per-call audience targeting cannot do so today. They
+  must either instantiate one `Manager` per audience or wait for an explicit option
+  to be added to the API.
+- The silent-drop behaviour means a misconfigured caller will not receive an error —
+  they will issue tokens without their intended custom claim. This is the standard
+  tradeoff for reserved-key guards in extensible claim maps.
+
+## References
+
+- Related: ADR-005 (Security Boundaries — Attacker-Controlled Token Fields) — covers
+  the validation-side gate for `aud` and other claims
+- Issue #109 — identified the missing `aud` entry in the reserved claims guard
+- RFC 7519 §4.1 — Registered Claim Names

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -23,3 +23,4 @@ Each ADR includes:
 - [ADR-005: Security Boundaries — Attacker-Controlled Token Fields](005-security-boundaries.md)
 - [ADR-006: KeyPrefix — Namespace Isolation in Redis Backends](006-keyprefix-namespace-isolation.md)
 - [ADR-007: Namespace Field on Manager Configs for Observability Consistency](007-namespace-consistency-contract.md)
+- [ADR-008: Reserved Claims Protection at Token Issuance](008-reserved-claims-at-issuance.md)

--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -639,7 +639,7 @@ func (m *Manager) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 
 	// Merge custom claims — reserved keys are silently dropped.
 	reservedClaims := map[string]bool{
-		"sub": true, "iss": true, "exp": true,
+		"sub": true, "iss": true, "aud": true, "exp": true,
 		"iat": true, "nbf": true, "jti": true,
 	}
 
@@ -1216,7 +1216,7 @@ func (m *Manager) IssueTokenPairWithClaims(ctx context.Context, userID string, a
 
 	// Merge access claims — reserved keys are silently dropped.
 	reservedClaims := map[string]bool{
-		"sub": true, "iss": true, "exp": true,
+		"sub": true, "iss": true, "aud": true, "exp": true,
 		"iat": true, "nbf": true, "jti": true,
 	}
 


### PR DESCRIPTION
## Summary

- Adds `"aud": true` to the `reservedClaims` map in `IssueAccessTokenWithClaims` and `IssueTokenPairWithClaims` — the manager's configured audience can no longer be silently overwritten via `CustomClaims`
- The existing warn-log drop path handles the case automatically; only the guard map needed updating
- **ADR-008** added (`doc/adr/008-reserved-claims-at-issuance.md`) — documents why all manager-controlled standard claims are reserved at issuance, and why per-call audience targeting (a legitimate use case for service-to-service tokens) belongs behind an explicit `WithAudience` option rather than the claims map
- ADR index, `ARCHITECTURE.md`, and `README.md` updated — also catches up ADR-006 and ADR-007 rows missing from `ARCHITECTURE.md`
- CHANGELOG updated under `### Security` in `[Unreleased] — v0.4.0`

## Test plan

- [x] `grep -n '"aud": true' pkg/tokens/manager.go` returns exactly 2 lines
- [x] `bash run-ci-locally.sh` — all 784 specs (unit + integration) pass

closes #109