### PR TITLE
docs(phase-1): fix broken constructor snippets and Logger interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,6 +827,7 @@ type Logger interface {
     Info(msg string, args ...interface{})
     Warn(msg string, args ...interface{})
     Error(msg string, args ...interface{})
+    With(keysAndValues ...interface{}) Logger
 }
 
 // Adapt your existing logger
@@ -840,7 +841,7 @@ func (m *MyZapAdapter) Debug(msg string, args ...interface{}) {
 func (m *MyZapAdapter) Info(msg string, args ...interface{}) {
     m.logger.Sugar().Infow(msg, args...)
 }
-// ... implement Warn, Error
+// ... implement Warn, Error, With
 ```
 
 ### Correlation ID

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -1088,6 +1088,6 @@ Key design decisions are captured in `doc/adr/`. Each ADR documents the context,
 
 ---
 
-**Last Updated**: April 18, 2026
-**Version**: v0.4.0 (in progress)
-**Status**: Active Development (KeyManager + DiskKeyStore + RedisKeyStore + RefreshStore [Memory + Redis] + Metrics [Prometheus] + Logging [Correlation ID] + Distributed Tracing — all stable and fully instrumented; TokenManager in beta)
+**Last Updated**: April 29, 2026
+**Version**: v0.4.0
+**Status**: Stable (KeyManager + DiskKeyStore + RedisKeyStore + RefreshStore [Memory + Redis] + Metrics [Prometheus] + Logging [Correlation ID] + Distributed Tracing + TokenManager — all stable and fully instrumented)

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -25,8 +25,8 @@ if err := redisClient.Ping(ctx).Err(); err != nil {
     log.Fatalf("Redis unavailable: %v", err)
 }
 
-ks, _ := keys.NewRedisKeyStore(redisClient, logger, pm)
-store := storage.NewRedisRefreshStore(redisClient, logger, pm)
+ks, _    := keys.NewRedisKeyStore(keys.RedisKeyStoreConfig{Client: redisClient, Logger: logger, Metrics: pm})
+store, _ := storage.NewRedisRefreshStore(storage.RedisRefreshStoreConfig{Client: redisClient, Logger: logger, Metrics: pm})
 ```
 
 ### Service Start Order
@@ -104,9 +104,9 @@ pm := metrics.NewPrometheusMetrics(metrics.PrometheusConfig{
     Namespace: "myapp",  // prefix for all metric names; defaults to "jwtauth"
 })
 
-ks, _   := keys.NewDiskKeyStore("./keys", 2048, logger, pm)
-km, _   := keys.NewManager(keys.KeyManagerConfig{KeyStore: ks, Metrics: pm})
-store   := storage.NewMemoryRefreshStore(logger, pm)
+ks, _    := keys.NewDiskKeyStore(keys.DiskKeyStoreConfig{Dir: "./keys", KeySize: 2048, Logger: logger, Metrics: pm})
+km, _    := keys.NewManager(keys.KeyManagerConfig{KeyStore: ks, Metrics: pm})
+store, _ := storage.NewMemoryRefreshStore(storage.MemoryRefreshStoreConfig{Logger: logger, Metrics: pm})
 mgr, _  := tokens.NewManager(tokens.TokenManagerConfig{
     KeyManager:   km,
     RefreshStore: store,
@@ -284,7 +284,7 @@ if err := km.Shutdown(shutdownCtx); err != nil {
 
 **Single-instance** (development, small deployments):
 ```go
-store := storage.NewMemoryRefreshStore(logger, pm)
+store, _ := storage.NewMemoryRefreshStore(storage.MemoryRefreshStoreConfig{Logger: logger, Metrics: pm})
 ```
 
 **Multi-instance** (Kubernetes, load-balanced):
@@ -292,7 +292,7 @@ store := storage.NewMemoryRefreshStore(logger, pm)
 redisClient := redis.NewClient(&redis.Options{
     Addr: os.Getenv("REDIS_ADDR"),
 })
-store := storage.NewRedisRefreshStore(redisClient, logger, pm)
+store, _ := storage.NewRedisRefreshStore(storage.RedisRefreshStoreConfig{Client: redisClient, Logger: logger, Metrics: pm})
 ```
 
 ---

--- a/doc/MIGRATION.md
+++ b/doc/MIGRATION.md
@@ -45,7 +45,7 @@ import (
 )
 
 // Step 1: Create KeyManager (handles keys + rotation)
-ks, _ := keys.NewDiskKeyStore("./keys", 2048, nil, nil)
+ks, _ := keys.NewDiskKeyStore(keys.DiskKeyStoreConfig{Dir: "./keys", KeySize: 2048})
 km, _ := keys.NewManager(keys.KeyManagerConfig{
     KeyStore:            ks,
     KeyRotationInterval: 30 * 24 * time.Hour,
@@ -53,7 +53,7 @@ km, _ := keys.NewManager(keys.KeyManagerConfig{
 })
 
 // Step 2: Create RefreshStore (handles refresh tokens)
-refreshStore := storage.NewMemoryRefreshStore(nil, nil)
+refreshStore, _ := storage.NewMemoryRefreshStore(storage.MemoryRefreshStoreConfig{})
 
 // Step 3: Create TokenManager (coordinates everything)
 mgr, _ := tokens.NewManager(tokens.TokenManagerConfig{
@@ -302,8 +302,8 @@ km, _ := keys.NewManager(keys.KeyManagerConfig{
 **Development/Single-Instance:**
 ```go
 // Use in-memory storage
-ks, _ := keys.NewDiskKeyStore("./keys", 2048, nil, nil)
-refreshStore := storage.NewMemoryRefreshStore(nil, nil)
+ks, _ := keys.NewDiskKeyStore(keys.DiskKeyStoreConfig{Dir: "./keys", KeySize: 2048})
+refreshStore, _ := storage.NewMemoryRefreshStore(storage.MemoryRefreshStoreConfig{})
 ```
 
 **Production/Multi-Instance:**
@@ -314,10 +314,10 @@ import "github.com/redis/go-redis/v9"
 client := redis.NewClient(&redis.Options{Addr: "redis:6379"})
 
 // Shared key storage
-ks, _ := keys.NewRedisKeyStore(client, logger, metrics)
+ks, _ := keys.NewRedisKeyStore(keys.RedisKeyStoreConfig{Client: client, Logger: logger, Metrics: metrics})
 
 // Shared refresh token storage
-refreshStore := storage.NewRedisRefreshStore(client, logger, metrics)
+refreshStore, _ := storage.NewRedisRefreshStore(storage.RedisRefreshStoreConfig{Client: client, Logger: logger, Metrics: metrics})
 ```
 
 **No code changes** — just swap the storage backend.


### PR DESCRIPTION
## Summary

- Fix 11 broken positional constructor calls across `doc/MIGRATION.md` (5) and `doc/DEPLOYMENT.md` (6) — all now use config-struct form matching the v0.4.0 API
- Add missing `With(keysAndValues ...interface{}) Logger` fifth method to the Logger interface block in `README.md`; update adapter comment from `Warn, Error` to `Warn, Error, With`
- Update `doc/ARCHITECTURE.md` footer: date → April 29 2026, version → v0.4.0 (remove "in progress"), status → Stable

## Why

All constructor snippets referenced the pre-v0.4.0 positional API that no longer exists. Anyone copying them would get compile errors. The Logger interface block was also missing the `With` method added in v0.4.0, which would cause any custom adapter built from that snippet to fail to satisfy the interface.

## Test plan

- [ ] `grep -n "NewDiskKeyStore\|NewRedisKeyStore\|NewMemoryRefreshStore\|NewRedisRefreshStore" doc/MIGRATION.md doc/DEPLOYMENT.md` — all results show config-struct form
- [ ] `grep -n "With(" README.md | head -5` — confirms `With` in Logger interface at line 830