### PR TITLE
docs(pre-release): README consistency audit + v0.4.0 CHANGELOG gaps + v0.5.0 UPGRADING stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,17 @@ All notable changes to this project will be documented in this file.
 
 - **`examples/README.md`** — added Correlation ID Example entry, cross-reference note in the Common Pattern section, updated Framework Comparison table with a Correlation ID column, corrected title (jwtauth is an engine, not a framework).
 
+- **`doc/UPGRADING.md`** — new file; step-by-step upgrade guide from v0.3.x → v0.4.0 covering all eight categories of breaking changes with Before/After code snippets, compile-time assertion guidance, and a dedicated section for interface additions that affect only custom implementations. Created in PR #121.
+
+- **ADR-006, ADR-007, ADR-008** — three additional Architecture Decision Records:
+  - `006-keyprefix-opaque-namespace.md` — `KeyPrefix` as an opaque Redis key namespace separator; empty string preserves existing layout; library does not interpret or validate the value.
+  - `007-namespace-consistency-contract.md` — `Namespace` as a decoupled observability label on `KeyManagerConfig` and `TokenManagerConfig`; independent of `KeyPrefix`; zero value preserves existing behavior.
+  - `008-reserved-claims-at-issuance.md` — reserved JWT claim protection at issuance; `CustomClaims` entries for `sub`, `iss`, `aud`, `exp`, `iat`, `nbf`, `jti` are silently dropped; per-call audience targeting deferred to a future `WithAudience` IssueOption (see #124).
+
+- **`examples/token-audit/`** — new example demonstrating cursor-based token enumeration using `ListTokens` and `ListTokensForUser`; covers resumable pagination for audit and reconciliation pipelines. Created in PR #121.
+
+- **`doc/DEPLOYMENT.md` additions** — four new operator-facing sections added in PRs #126–#129: namespace isolation (multi-instance `KeyPrefix` + `Namespace` wiring), token enumeration (cursor-based audit pattern), reserved claims (CustomClaims guard explanation with link to ADR-008), and corrected constructor snippets throughout.
+
 ### Testing
 
 - **`pkg/tokens` test DRY cleanup — shared `newTestManager` helper** — `createService` closure was independently defined in both `manager_test.go` and `manager_lifecycle_test.go`; extracted to `pkg/tokens/helpers_test.go` as `newTestManagerConfig` and `newTestManager` package-level helpers within the `tokens_test` package. 25 call sites updated across both files — no new dependency between packages. Fixes DRY violation M4.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **You verify identity. jwtauth manages everything after:** zero-downtime key rotation, access token issuance, refresh token lifecycle, and instant revocation across horizontal scale.
 
-> **API Stability (pre-v1.0)**: All components are production-quality with comprehensive test coverage. The API surface is still evolving before v1.0.0 — v0.5.0 will add a variadic `IssueOption` parameter to the issuance methods for per-call audience targeting (#124). Changes will be additive and backwards-compatible.
+> **API Stability (pre-v1.0)**: All components are production-quality with comprehensive test coverage. The API surface is still evolving before v1.0.0. **v0.5.0 planned changes:** `IssueOption` / `WithAudience` for per-call audience targeting (#124) — additive, all existing call sites compile unchanged. Audience-based token revocation `RevokeAllForAudience` (#135) — adds `Audience string` to `RefreshToken` and two new methods to `RefreshStore`; custom implementations must be updated (see `UPGRADING.md`).
 
 ## Overview
 

--- a/doc/UPGRADING.md
+++ b/doc/UPGRADING.md
@@ -4,9 +4,50 @@ This document describes breaking changes and the mechanical steps required to up
 
 ---
 
-## Unreleased
+## v0.4.x → v0.5.0
 
-No breaking changes documented yet.
+v0.5.0 introduces two sets of changes to `storage.RefreshStore`. Code that only
+*calls* jwtauth is unaffected. Code that provides a custom `RefreshStore` implementation
+must add the new members or it will not compile.
+
+### 1. `storage.RefreshToken` — new `Audience` field
+
+A new `Audience string` field is added to `RefreshToken`. Custom serialization or
+storage backends that persist `RefreshToken` structs must handle the new field.
+
+```go
+type RefreshToken struct {
+    // ... existing fields unchanged ...
+    Audience string // NEW — audience of the paired access token at issuance time
+}
+```
+
+The value is populated from the per-call `WithAudience` IssueOption when provided,
+or from the manager's configured `TokenManagerConfig.Audience` otherwise.
+
+### 2. `storage.RefreshStore` — two new revocation methods
+
+```go
+// RevokeAllForAudience marks all non-expired refresh tokens targeting the given
+// audience as revoked. Returns the count of tokens revoked.
+RevokeAllForAudience(ctx context.Context, audience string) (int, error)
+
+// RevokeAllForUserAndAudience marks all refresh tokens for the given user and
+// audience as revoked. Returns the count of tokens revoked.
+RevokeAllForUserAndAudience(ctx context.Context, userID, audience string) (int, error)
+```
+
+Add compile-time assertions to catch missed methods early:
+
+```go
+var _ storage.RefreshStore = (*MyRefreshStore)(nil)
+```
+
+### Additive changes (no action required)
+
+`IssueOption` / `WithAudience` (#124) adds a variadic `...tokens.IssueOption` parameter
+to four issuance methods. All existing call sites compile and behave unchanged — the
+parameter is optional and defaults to the manager's configured audience.
 
 ---
 


### PR DESCRIPTION
## Summary

Pre-v0.4.0 documentation cleanup covering three areas:

**README consistency audit (commit `aaeade1`)**
- Removed stale Beta/In-Development labels
- Added missing `Tracer`, `Namespace`, `KeySize` rows to `KeyManagerConfig` table
- Added missing `Tracer`, `Namespace` rows to `TokenManagerConfig` table
- Promoted tracing and namespace bullets from "In Development" to the main feature list

**CHANGELOG documentation gaps (commit `96579ea`)**
- Added missing `### Documentation` entries for: `doc/UPGRADING.md` (PR #121), ADR-006/007/008, `examples/token-audit/` (PR #121), `doc/DEPLOYMENT.md` additions (PRs #126–#129)
- API-level entries were already complete

**API stability callout + v0.5.0 forward signal (commit `96579ea`)**
- Updated README stability note to accurately describe both v0.5.0 changes: `WithAudience` (#124, additive) and `RevokeAllForAudience` (#135, breaking for custom `RefreshStore` implementations)
- Replaced empty `UPGRADING.md` Unreleased stub with a full `v0.4.x → v0.5.0` section documenting the two known breaks and the additive `IssueOption` change

## Test plan

- [ ] `grep "v0.5.0" CHANGELOG.md README.md doc/UPGRADING.md` — appears in all three
- [ ] `grep "ADR-006\|ADR-007\|ADR-008" CHANGELOG.md` — all three ADRs present
- [ ] `grep "token-audit" CHANGELOG.md` — example entry present
- [ ] `grep "RevokeAllForAudience" doc/UPGRADING.md` — method signature present
- [ ] README renders correctly (no broken table rows)

refs #124, refs #135