### PR TITLE
fix(shutdown): shutdownChan recreation + pre-cancelled ctx drain in TokenManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,22 @@ All notable changes to this project will be documented in this file.
 
 - **`doc/DEPLOYMENT.md` additions** — four new operator-facing sections added in PRs #126–#129: namespace isolation (multi-instance `KeyPrefix` + `Namespace` wiring), token enumeration (cursor-based audit pattern), reserved claims (CustomClaims guard explanation with link to ADR-008), and corrected constructor snippets throughout.
 
+### Bug Fixes
+
+- **`TokenManager.Shutdown` — restart-safety**: `shutdownChan` is now recreated after a
+  clean shutdown, matching `KeyManager`'s existing pattern. Previously, calling
+  `Start → Shutdown → Start` would silently break the cleanup goroutine on the second start —
+  `IsRunning()` returned `true` but background cleanup was dead.
+
+- **`TokenManager.Shutdown` — pre-cancelled context drain**: Added a non-blocking ctx drain
+  before the blocking goroutine-wait select, eliminating the same race condition fixed in
+  `KeyManager.Shutdown` (PR #137). Prevents flaky behavior when both `done` and `ctx.Done()`
+  are simultaneously ready.
+
+- **`prometheus-metrics` example — graceful shutdown**: Replaced `http.ListenAndServe` with
+  `http.Server.Shutdown` and `signal.NotifyContext` (SIGTERM/SIGINT). Background collection
+  goroutine now exits cleanly on signal instead of only via `os.Exit`.
+
 ### Testing
 
 - **`pkg/tokens` test DRY cleanup — shared `newTestManager` helper** — `createService` closure was independently defined in both `manager_test.go` and `manager_lifecycle_test.go`; extracted to `pkg/tokens/helpers_test.go` as `newTestManagerConfig` and `newTestManager` package-level helpers within the `tokens_test` package. 25 call sites updated across both files — no new dependency between packages. Fixes DRY violation M4.

--- a/examples/prometheus-metrics/main.go
+++ b/examples/prometheus-metrics/main.go
@@ -5,6 +5,9 @@ import (
 	"log"
 	"log/slog"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/aetomala/jwtauth/pkg/keys"
@@ -52,8 +55,8 @@ func main() {
 	}
 
 	// ===== STEP 2: Start KeyManager =====
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
 	if err := km.Start(ctx); err != nil {
 		log.Fatal("Failed to start KeyManager:", err)
@@ -85,9 +88,21 @@ func main() {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 
-	log.Println("Starting metrics server on :9090")
-	if err := http.ListenAndServe(":9090", mux); err != nil {
-		log.Fatal(err)
+	srv := &http.Server{Addr: ":9090", Handler: mux}
+	go func() {
+		log.Println("Starting metrics server on :9090")
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Printf("metrics server error: %v", err)
+		}
+	}()
+
+	<-ctx.Done()
+	stop() // release signal catch so a second Ctrl-C kills immediately
+
+	srvShutdownCtx, srvShutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer srvShutdownCancel()
+	if err := srv.Shutdown(srvShutdownCtx); err != nil {
+		log.Printf("server shutdown error: %v", err)
 	}
 }
 

--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -261,12 +261,15 @@ func (m *Manager) startSpan(ctx context.Context, operation string, opts ...traci
 	return m.tracer.Start(ctx, "TokenManager."+operation, opts...)
 }
 
-// Start initializes the service and begins background operationm. It starts
+// Start initializes the service and begins background operations. It starts
 // the KeyManager and launches the cleanup goroutine that periodically purges
-// expired refresh tokenm.
+// expired refresh tokens.
 //
 // Start is idempotent — calling it on an already-running service is a no-op.
 // Returns an error if the KeyManager fails to start or the context is cancelled.
+// The ctx passed to Start is forwarded to the cleanup goroutine's store calls —
+// pass a long-lived context (e.g. the process root) so cleanup continues for
+// the full lifetime of the service.
 func (m *Manager) Start(ctx context.Context) error {
 	ctx, span := m.startSpan(ctx, "Start")
 	defer span.End()
@@ -338,6 +341,10 @@ func (m *Manager)cleanupLoop(ctx context.Context) {
 // Shutdown is idempotent — calling it on a stopped service is a no-op.
 // Returns context.DeadlineExceeded if the goroutines do not finish within
 // the deadline, or any error returned by the KeyManager's Shutdown.
+// After a clean shutdown the manager may be restarted via Start. Restart is
+// not guaranteed after a timeout shutdown — the cleanup goroutine may still
+// hold a reference to the closed channel; treat a timeout Shutdown as fatal
+// and discard the manager.
 func (m *Manager) Shutdown(ctx context.Context) error {
 	ctx, span := m.startSpan(ctx, "Shutdown")
 	defer span.End()
@@ -362,9 +369,21 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 		close(done)
 	}()
 
+	// Drain a pre-cancelled context before the blocking select so that a
+	// caller-cancelled ctx reliably wins over a fast goroutine exit.
+	select {
+	case <-ctx.Done():
+		span.RecordError(ctx.Err())
+		span.SetStatus(tracing.StatusError, ctx.Err().Error())
+		return ctx.Err()
+	default:
+	}
+
 	select {
 	case <-done:
-		// Goroutines completed
+		// Goroutines completed — recreate shutdownChan so the manager can be
+		// restarted via Start.
+		m.shutdownChan = make(chan struct{})
 	case <-ctx.Done():
 		// Timeout
 		m.logger.Warn("shutdown timeout waiting for goroutines", ctx,

--- a/pkg/tokens/manager_lifecycle_test.go
+++ b/pkg/tokens/manager_lifecycle_test.go
@@ -324,6 +324,38 @@ var _ = Describe("TokenManager", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("key manager shutdown failed"))
 		})
+
+		It("should return context error when shutdown context is pre-cancelled", func() {
+			// Allow cleanup if the ticker fires before Shutdown is called.
+			mockStore.EXPECT().Cleanup(gomock.Any()).Return(0, nil).AnyTimes()
+
+			cancelledCtx, cancel := context.WithCancel(context.Background())
+			cancel() // immediately cancelled
+
+			err := service.Shutdown(cancelledCtx)
+			Expect(errors.Is(err, context.Canceled)).To(BeTrue())
+			// AfterEach: IsRunning() is false — Shutdown block skipped, ctrl.Finish() is safe.
+		})
+
+		It("should handle concurrent Shutdown calls without panicking", func() {
+			// CompareAndSwap prevents double-close of shutdownChan; verify concurrency is safe.
+			mockKM.EXPECT().Shutdown(gomock.Any()).Return(nil).AnyTimes()
+			mockStore.EXPECT().Cleanup(gomock.Any()).Return(0, nil).AnyTimes()
+
+			var wg sync.WaitGroup
+			for i := 0; i < 5; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					defer GinkgoRecover()
+					shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+					defer cancel()
+					_ = service.Shutdown(shutdownCtx)
+				}()
+			}
+			wg.Wait()
+			Expect(service.IsRunning()).To(BeFalse())
+		})
 	})
 
 	// ========================================================================
@@ -402,6 +434,78 @@ var _ = Describe("TokenManager", func() {
 			// Operations should fail after shutdown
 			_, err = service.IssueAccessToken(ctx, "user-456")
 			Expect(err).To(Equal(tokens.ErrManagerNotRunning))
+		})
+
+		It("should support restart (Start → Shutdown → Start → Shutdown)", func() {
+			mockKM.EXPECT().Start(gomock.Any()).Return(nil).Times(2)
+			mockKM.EXPECT().Shutdown(gomock.Any()).Return(nil).Times(2)
+			mockStore.EXPECT().Cleanup(gomock.Any()).Return(0, nil).AnyTimes()
+
+			service = newTestManager(mockKM, mockStore, mockLogger)
+
+			// First cycle
+			Expect(service.Start(ctx)).To(Succeed())
+			Expect(service.IsRunning()).To(BeTrue())
+			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer shutdownCancel()
+			Expect(service.Shutdown(shutdownCtx)).To(Succeed())
+			Expect(service.IsRunning()).To(BeFalse())
+
+			// Second cycle
+			Expect(service.Start(ctx)).To(Succeed())
+			Expect(service.IsRunning()).To(BeTrue())
+			shutdownCtx2, shutdownCancel2 := context.WithTimeout(context.Background(), 2*time.Second)
+			defer shutdownCancel2()
+			Expect(service.Shutdown(shutdownCtx2)).To(Succeed())
+			Expect(service.IsRunning()).To(BeFalse())
+		})
+
+		It("should run cleanup goroutine after restart", func() {
+			// Without the shutdownChan recreation fix, IsRunning() returns true after
+			// the second Start but the cleanup goroutine exits immediately because
+			// shutdownChan is already closed. This spec detects that silent failure.
+			mockKM.EXPECT().Start(gomock.Any()).Return(nil).Times(2)
+			mockKM.EXPECT().Shutdown(gomock.Any()).Return(nil).Times(2)
+
+			service = newTestManager(mockKM, mockStore, mockLogger)
+
+			// Single DoAndReturn expectation for both cycles — gomock FIFO means a
+			// second AnyTimes registration would never be reached.
+			cleanupCalled := make(chan struct{}, 100)
+			mockStore.EXPECT().Cleanup(gomock.Any()).
+				DoAndReturn(func(context.Context) (int, error) {
+					select {
+					case cleanupCalled <- struct{}{}:
+					default:
+					}
+					return 0, nil
+				}).AnyTimes()
+
+			// First cycle
+			Expect(service.Start(ctx)).To(Succeed())
+			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 2*time.Second)
+			Expect(service.Shutdown(shutdownCtx)).To(Succeed())
+			shutdownCancel()
+
+			// Drain any calls from the first cycle before restarting.
+			draining := true
+			for draining {
+				select {
+				case <-cleanupCalled:
+				default:
+					draining = false
+				}
+			}
+
+			// Second start — verify the cleanup goroutine is alive.
+			Expect(service.Start(ctx)).To(Succeed())
+
+			// If bug is present: cleanupCalled never receives (goroutine exits immediately).
+			Eventually(cleanupCalled, 2*time.Second).Should(Receive())
+
+			shutdownCtx2, shutdownCancel2 := context.WithTimeout(context.Background(), 2*time.Second)
+			Expect(service.Shutdown(shutdownCtx2)).To(Succeed())
+			shutdownCancel2()
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- **BUG 1 — restart-safety**: `shutdownChan` is now recreated inside the `case <-done:` branch of `Shutdown`, matching the existing `KeyManager` pattern. Previously, `Start → Shutdown → Start` silently broke background cleanup on the second start — `IsRunning()` returned `true` but the cleanup goroutine exited immediately on the already-closed channel.

- **BUG 2 — pre-cancelled ctx drain**: Added a non-blocking drain select before the blocking goroutine-wait select in `Shutdown`, eliminating the same race fixed in `KeyManager.Shutdown` (PR #137). A pre-cancelled ctx now reliably returns `ctx.Err()` instead of non-deterministically returning `nil`.

- **Docstrings**: `Start` documents the long-lived ctx requirement; `Shutdown` documents the restart-after-timeout limitation (channel not recreated on timeout path — goroutine still running).

- **`prometheus-metrics` example**: Replaced blocking `http.ListenAndServe` + `log.Fatal` (defers never run) with `signal.NotifyContext` + `http.Server.Shutdown`. Background collection goroutine now exits cleanly on SIGTERM/SIGINT.

- **4 new lifecycle tests** (race-clean): pre-cancelled ctx drain, restart cycle (`Start → Shutdown → Start → Shutdown`), cleanup goroutine alive after restart (deep check — detects the silent failure without the BUG 1 fix), concurrent `Shutdown` safety.

## Test plan

- [ ] `ginkgo -r --race --cover --skip-package=integration pkg/tokens` — 204 specs pass
- [ ] `./run-ci-locally.sh` — vet, lint, govulncheck, 788 unit + 34 integration specs all pass with `--race`
- [ ] Verify `grep -n "shutdownChan = make" pkg/tokens/manager.go` returns line 386
- [ ] Verify `grep -n "case <-ctx.Done" pkg/tokens/manager.go` returns two lines (drain + blocking select)