### PR TITLE
feat(tokens): add IssueOption type and WithAudience functional option (#124 Phase 1)

### DIFF
--- a/pkg/tokens/options.go
+++ b/pkg/tokens/options.go
@@ -1,0 +1,46 @@
+package tokens
+
+// IssueOption configures per-call behaviour of token issuing methods.
+type IssueOption func(*issueConfig)
+
+type issueConfig struct {
+	audience []string // nil means "use manager default"
+}
+
+// WithAudience overrides the manager's configured Audience for this single issuing call.
+// Passing no arguments is a no-op — the manager's configured Audience is used.
+// On IssueRefreshToken and IssueRefreshTokenWithClaims, the audience affects the stored
+// refresh token record only, not the opaque token value itself.
+func WithAudience(audience ...string) IssueOption {
+	return func(c *issueConfig) {
+		if len(audience) > 0 {
+			c.audience = audience
+		}
+	}
+}
+
+// resolveAudience returns the effective audience for a call.
+// Falls back to managerDefault when no WithAudience option provides a non-empty slice.
+func resolveAudience(managerDefault []string, opts []IssueOption) []string {
+	cfg := &issueConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+	if len(cfg.audience) > 0 {
+		return cfg.audience
+	}
+	return managerDefault
+}
+
+// audienceEqual reports whether two audience slices have identical contents.
+func audienceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

- Introduces `IssueOption func(*issueConfig)` — the functional option type for per-call token configuration
- Adds `WithAudience(...string) IssueOption` — overrides the manager's configured audience for a single issuing call; zero-arg call is a no-op
- Adds `resolveAudience(managerDefault []string, opts []IssueOption) []string` — falls back to manager default when no option provides a non-empty audience
- Adds `audienceEqual(a, b []string) bool` — slice equality helper used for observability comparisons in Phase 3

No method signatures change in this phase. All existing call sites compile unchanged.

Mirrors the `SpanOption func(*spanConfig)` pattern in `pkg/tracing/interface.go`.

## Phase tracker

| Phase | Description | Branch | Status |
|---|---|---|---|
| **1** | `IssueOption` type + `WithAudience` + `resolveAudience` | `feat/124-issue-option-type` | **This PR** |
| 2 | `Store()` signature + `RefreshToken.Audience` + all callers + mock regen | `feat/124-store-audience-field` | Pending |
| 3 | Wire `opts ...IssueOption` into all 6 issuing methods + observability + tests | `feat/124-wire-with-audience` | Pending |
| 4 | `RefreshAccessToken` audience propagation fix + `TokenMetadata.Audience` | `feat/124-refresh-propagation` | Pending |
| 5 | Atomic `operation` → `revocation_scope` rename on `tokens_revoked_total` | `feat/124-revocation-scope-metric` | Pending |
| 6 | Docs, UPGRADING.md, CHANGELOG.md, README, ARCHITECTURE.md, chi-example | `docs/124-audience` | Pending |

## Test plan

- [x] `go build ./pkg/tokens/...` — clean
- [x] `go vet ./pkg/tokens/...` — clean
- [x] `./run-ci-locally.sh` — 788 unit + 34 integration specs, 0 lint issues, no vulnerabilities

Closes part of #124