### PR TITLE
feat(storage): add Audience field to RefreshToken and Store() signature (#124 Phase 2)

### DIFF
--- a/internal/testutil/mock_refreshstore.go
+++ b/internal/testutil/mock_refreshstore.go
@@ -147,15 +147,15 @@ func (mr *MockRefreshStoreMockRecorder) RevokeAllForUser(ctx, userID any) *gomoc
 }
 
 // Store mocks base method.
-func (m *MockRefreshStore) Store(ctx context.Context, tokenID, userID string, expiresAt time.Time, metadata map[string]any) error {
+func (m *MockRefreshStore) Store(ctx context.Context, tokenID, userID string, audience []string, expiresAt time.Time, metadata map[string]any) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Store", ctx, tokenID, userID, expiresAt, metadata)
+	ret := m.ctrl.Call(m, "Store", ctx, tokenID, userID, audience, expiresAt, metadata)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Store indicates an expected call of Store.
-func (mr *MockRefreshStoreMockRecorder) Store(ctx, tokenID, userID, expiresAt, metadata any) *gomock.Call {
+func (mr *MockRefreshStoreMockRecorder) Store(ctx, tokenID, userID, audience, expiresAt, metadata any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Store", reflect.TypeOf((*MockRefreshStore)(nil).Store), ctx, tokenID, userID, expiresAt, metadata)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Store", reflect.TypeOf((*MockRefreshStore)(nil).Store), ctx, tokenID, userID, audience, expiresAt, metadata)
 }

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -27,18 +27,20 @@ type RefreshStore interface {
 	// The token should be stored with:
 	//   - Expiration time (for TTL/cleanup)
 	//   - User ID (for revocation by user)
+	//   - Audience (for audience-scoped revocation; nil inherits the manager default)
 	//   - Metadata (optional, for audit/tracking)
 	//
 	// Args:
 	//   - ctx: Request context for cancellation and deadline propagation
 	//   - tokenID: Unique identifier for the token
 	//   - userID: User who owns the token
+	//   - audience: Audience for this token; nil means caller inherits manager default
 	//   - expiresAt: When the token expires
 	//   - metadata: Optional metadata (IP, user agent, etc.)
 	//
 	// Returns:
 	//   - error: If storage fails
-	Store(ctx context.Context, tokenID, userID string, expiresAt time.Time, metadata map[string]interface{}) error
+	Store(ctx context.Context, tokenID, userID string, audience []string, expiresAt time.Time, metadata map[string]interface{}) error
 
 	// Retrieve fetches a refresh token by ID.
 	//
@@ -139,5 +141,6 @@ type RefreshToken struct {
 	ExpiresAt time.Time
 	CreatedAt time.Time
 	Revoked   bool
+	Audience  []string
 	Metadata  map[string]interface{}
 }

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -97,9 +97,9 @@ func (m *MemoryRefreshStore) startSpan(ctx context.Context, operation string) (c
 // is already in the past. Returns the context error if the context is
 // cancelled before the write.
 //
-// A defensive copy of metadata is made so later mutations to the caller's map
-// do not affect the stored token.
-func (m *MemoryRefreshStore) Store(ctx context.Context, tokenID, userID string, expiresAt time.Time, metadata map[string]interface{}) error {
+// A defensive copy of metadata and audience is made so later mutations to the
+// caller's slices or maps do not affect the stored token.
+func (m *MemoryRefreshStore) Store(ctx context.Context, tokenID, userID string, audience []string, expiresAt time.Time, metadata map[string]interface{}) error {
 	ctx, span := m.startSpan(ctx, "Store")
 	defer span.End()
 	span.SetAttribute("token_id", tokenID)
@@ -173,7 +173,13 @@ func (m *MemoryRefreshStore) Store(ctx context.Context, tokenID, userID string, 
 		return ErrTokenExpired
 	}
 
-	// ===== STEP 3: Defensive Copy of Metadata =====
+	// ===== STEP 3: Defensive Copies of Audience and Metadata =====
+	var audienceCopy []string
+	if len(audience) > 0 {
+		audienceCopy = make([]string, len(audience))
+		copy(audienceCopy, audience)
+	}
+
 	var newMetadata map[string]interface{}
 	if metadata != nil {
 		newMetadata = make(map[string]interface{}, len(metadata))
@@ -197,6 +203,7 @@ func (m *MemoryRefreshStore) Store(ctx context.Context, tokenID, userID string, 
 		ExpiresAt: expiresAt,
 		CreatedAt: time.Now(),
 		Revoked:   false,
+		Audience:  audienceCopy,
 		Metadata:  newMetadata,
 	}
 	m.tokens[tokenID] = token
@@ -316,6 +323,11 @@ func (m *MemoryRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Ref
 		ExpiresAt: token.ExpiresAt,
 		CreatedAt: token.CreatedAt,
 		Revoked:   token.Revoked,
+	}
+
+	if len(token.Audience) > 0 {
+		safeToken.Audience = make([]string, len(token.Audience))
+		copy(safeToken.Audience, token.Audience)
 	}
 
 	if token.Metadata != nil {
@@ -635,20 +647,24 @@ func (m *MemoryRefreshStore) ListTokens(ctx context.Context, cursor string, coun
 	tokens := make([]*RefreshToken, 0, len(page))
 	for _, id := range page {
 		t := m.tokens[id]
-		copy := &RefreshToken{
+		cp := &RefreshToken{
 			TokenID:   t.TokenID,
 			UserID:    t.UserID,
 			ExpiresAt: t.ExpiresAt,
 			CreatedAt: t.CreatedAt,
 			Revoked:   t.Revoked,
 		}
+		if len(t.Audience) > 0 {
+			cp.Audience = make([]string, len(t.Audience))
+			copy(cp.Audience, t.Audience)
+		}
 		if t.Metadata != nil {
-			copy.Metadata = make(map[string]interface{}, len(t.Metadata))
+			cp.Metadata = make(map[string]interface{}, len(t.Metadata))
 			for k, v := range t.Metadata {
-				copy.Metadata[k] = v
+				cp.Metadata[k] = v
 			}
 		}
-		tokens = append(tokens, copy)
+		tokens = append(tokens, cp)
 	}
 
 	// ===== STEP 6: Compute Next Cursor =====
@@ -761,6 +777,10 @@ func (m *MemoryRefreshStore) ListTokensForUser(ctx context.Context, userID strin
 			ExpiresAt: t.ExpiresAt,
 			CreatedAt: t.CreatedAt,
 			Revoked:   t.Revoked,
+		}
+		if len(t.Audience) > 0 {
+			cp.Audience = make([]string, len(t.Audience))
+			copy(cp.Audience, t.Audience)
 		}
 		if t.Metadata != nil {
 			cp.Metadata = make(map[string]interface{}, len(t.Metadata))

--- a/pkg/storage/memory_test.go
+++ b/pkg/storage/memory_test.go
@@ -31,7 +31,7 @@ var _ = Describe("MemoryRefreshStore — Constructor", func() {
 		store := storage.NewMemoryRefreshStore(storage.MemoryRefreshStoreConfig{})
 		tokenID := "defaults-token"
 		userID := "defaults-user"
-		Expect(store.Store(ctx, tokenID, userID, time.Now().Add(time.Hour), nil)).To(Succeed())
+		Expect(store.Store(ctx, tokenID, userID, nil, time.Now().Add(time.Hour), nil)).To(Succeed())
 		_, err := store.Retrieve(ctx, tokenID)
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -49,7 +49,7 @@ var _ = Describe("MemoryRefreshStore — Constructor", func() {
 		store := storage.NewMemoryRefreshStore(storage.MemoryRefreshStoreConfig{Tracer: mockTracer})
 		tokenID := "tracer-token"
 		userID := "tracer-user"
-		Expect(store.Store(ctx, tokenID, userID, time.Now().Add(time.Hour), nil)).To(Succeed())
+		Expect(store.Store(ctx, tokenID, userID, nil, time.Now().Add(time.Hour), nil)).To(Succeed())
 	})
 })
 
@@ -80,7 +80,7 @@ var _ = Describe("MemoryRefreshStore — Phase 10: Tracing", func() {
 			mockSpan.EXPECT().SetStatus(tracing.StatusOK, "")
 			mockSpan.EXPECT().End()
 
-			Expect(tracingStore.Store(ctx, "trace-store-token", "trace-user", time.Now().Add(time.Hour), nil)).To(Succeed())
+			Expect(tracingStore.Store(ctx, "trace-store-token", "trace-user", nil, time.Now().Add(time.Hour), nil)).To(Succeed())
 		})
 	})
 

--- a/pkg/storage/redis.go
+++ b/pkg/storage/redis.go
@@ -115,7 +115,7 @@ func (r *RedisRefreshStore) startSpan(ctx context.Context, operation string) (co
 //
 // A defensive copy of metadata is made so later mutations to the caller's map
 // do not affect the stored token.
-func (r *RedisRefreshStore) Store(ctx context.Context, tokenID, userID string, expiresAt time.Time, metadata map[string]interface{}) error {
+func (r *RedisRefreshStore) Store(ctx context.Context, tokenID, userID string, audience []string, expiresAt time.Time, metadata map[string]interface{}) error {
 	ctx, span := r.startSpan(ctx, "Store")
 	defer span.End()
 	span.SetAttribute("token_id", tokenID)
@@ -204,6 +204,20 @@ func (r *RedisRefreshStore) Store(ctx context.Context, tokenID, userID string, e
 	}
 
 	// ===== STEP 4: Build Token Data Map =====
+	var audienceJSON string
+	if len(audience) > 0 {
+		ab, err := json.Marshal(audience)
+		if err != nil {
+			r.logger.Error("store failed: audience marshal error", ctx,
+				"tokenID", tokenID, "error", err)
+			wrapped := fmt.Errorf("failed to marshal audience: %w", err)
+			span.RecordError(wrapped)
+			span.SetStatus(tracing.StatusError, wrapped.Error())
+			return wrapped
+		}
+		audienceJSON = string(ab)
+	}
+
 	now := time.Now()
 	tokenData := map[string]interface{}{
 		"userID":    userID,
@@ -211,6 +225,7 @@ func (r *RedisRefreshStore) Store(ctx context.Context, tokenID, userID string, e
 		"createdAt": now.UnixMilli(),
 		"revoked":   "false",
 		"metadata":  metadataJSON,
+		"audience":  audienceJSON,
 	}
 
 	// ===== STEP 5: Execute Atomic Write via Pipeline =====
@@ -387,6 +402,19 @@ func (r *RedisRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Refr
 		ExpiresAt: expiresAt,
 		CreatedAt: createdAt,
 		Revoked:   revoked,
+	}
+
+	if audJSON, exists := hash["audience"]; exists && audJSON != "" {
+		var aud []string
+		if err := json.Unmarshal([]byte(audJSON), &aud); err != nil {
+			r.logger.Error("retrieve failed: audience unmarshal error", ctx,
+				"tokenID", tokenID, "error", err)
+			wrapped := fmt.Errorf("failed to unmarshal audience: %w", err)
+			span.RecordError(wrapped)
+			span.SetStatus(tracing.StatusError, wrapped.Error())
+			return nil, wrapped
+		}
+		safeToken.Audience = aud
 	}
 
 	if metadataJSON, exists := hash["metadata"]; exists && metadataJSON != "" {
@@ -976,6 +1004,15 @@ func (r *RedisRefreshStore) fetchTokensByIDs(ctx context.Context, tokenIDs []str
 			ExpiresAt: time.UnixMilli(expiresAtMillis),
 			CreatedAt: time.UnixMilli(createdAtMillis),
 			Revoked:   hash["revoked"] == "true",
+		}
+		if audJSON, ok := hash["audience"]; ok && audJSON != "" {
+			var aud []string
+			if err := json.Unmarshal([]byte(audJSON), &aud); err != nil {
+				r.logger.Warn("fetchTokensByIDs: skipping audience for token", ctx,
+					"tokenID", tokenIDs[i], "error", err)
+			} else {
+				t.Audience = aud
+			}
 		}
 		if metadataJSON, ok := hash["metadata"]; ok && metadataJSON != "" {
 			var meta map[string]interface{}

--- a/pkg/storage/redis_test.go
+++ b/pkg/storage/redis_test.go
@@ -80,7 +80,7 @@ var _ = Describe("RedisRefreshStore — Constructor", func() {
 		store, err := storage.NewRedisRefreshStore(storage.RedisRefreshStoreConfig{Client: client})
 		Expect(err).NotTo(HaveOccurred())
 		ctx := context.Background()
-		Expect(store.Store(ctx, "defaults-token", "defaults-user", time.Now().Add(time.Hour), nil)).To(Succeed())
+		Expect(store.Store(ctx, "defaults-token", "defaults-user", nil, time.Now().Add(time.Hour), nil)).To(Succeed())
 		_, err = store.Retrieve(ctx, "defaults-token")
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -103,7 +103,7 @@ var _ = Describe("RedisRefreshStore — Constructor", func() {
 		store, err := storage.NewRedisRefreshStore(storage.RedisRefreshStoreConfig{Client: client, Tracer: mockTracer})
 		Expect(err).NotTo(HaveOccurred())
 		ctx := context.Background()
-		Expect(store.Store(ctx, "tracer-token", "tracer-user", time.Now().Add(time.Hour), nil)).To(Succeed())
+		Expect(store.Store(ctx, "tracer-token", "tracer-user", nil, time.Now().Add(time.Hour), nil)).To(Succeed())
 	})
 })
 
@@ -138,7 +138,7 @@ var _ = Describe("RedisRefreshStore — Phase 11: KeyPrefix Namespace Isolation"
 			store := newStore("tenant:abc:")
 			client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 
-			Expect(store.Store(ctx, "tok1", "user1", time.Now().Add(time.Hour), nil)).To(Succeed())
+			Expect(store.Store(ctx, "tok1", "user1", nil, time.Now().Add(time.Hour), nil)).To(Succeed())
 
 			storedKeys, err := client.Keys(ctx, "*").Result()
 			Expect(err).NotTo(HaveOccurred())
@@ -153,7 +153,7 @@ var _ = Describe("RedisRefreshStore — Phase 11: KeyPrefix Namespace Isolation"
 			store := newStore("")
 			client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 
-			Expect(store.Store(ctx, "tok1", "user1", time.Now().Add(time.Hour), nil)).To(Succeed())
+			Expect(store.Store(ctx, "tok1", "user1", nil, time.Now().Add(time.Hour), nil)).To(Succeed())
 
 			storedKeys, err := client.Keys(ctx, "*").Result()
 			Expect(err).NotTo(HaveOccurred())
@@ -168,7 +168,7 @@ var _ = Describe("RedisRefreshStore — Phase 11: KeyPrefix Namespace Isolation"
 			storeA := newStore("ns:a:")
 			storeB := newStore("ns:b:")
 
-			Expect(storeA.Store(ctx, "shared-token", "user1", time.Now().Add(time.Hour), nil)).To(Succeed())
+			Expect(storeA.Store(ctx, "shared-token", "user1", nil, time.Now().Add(time.Hour), nil)).To(Succeed())
 
 			_, err := storeB.Retrieve(ctx, "shared-token")
 			Expect(err).To(MatchError(storage.ErrTokenNotFound))
@@ -178,8 +178,8 @@ var _ = Describe("RedisRefreshStore — Phase 11: KeyPrefix Namespace Isolation"
 			storeA := newStore("ns:a:")
 			storeB := newStore("ns:b:")
 
-			Expect(storeA.Store(ctx, "tok-a", "user1", time.Now().Add(time.Hour), nil)).To(Succeed())
-			Expect(storeB.Store(ctx, "tok-b", "user1", time.Now().Add(time.Hour), nil)).To(Succeed())
+			Expect(storeA.Store(ctx, "tok-a", "user1", nil, time.Now().Add(time.Hour), nil)).To(Succeed())
+			Expect(storeB.Store(ctx, "tok-b", "user1", nil, time.Now().Add(time.Hour), nil)).To(Succeed())
 
 			Expect(storeA.RevokeAllForUser(ctx, "user1")).To(Succeed())
 
@@ -199,11 +199,11 @@ var _ = Describe("RedisRefreshStore — Phase 11: KeyPrefix Namespace Isolation"
 
 			// Store an already-expired token directly via miniredis manipulation:
 			// Store with a 1-second TTL, then fast-forward time.
-			Expect(storeB.Store(ctx, "expired-b", "user2", time.Now().Add(time.Hour), nil)).To(Succeed())
+			Expect(storeB.Store(ctx, "expired-b", "user2", nil, time.Now().Add(time.Hour), nil)).To(Succeed())
 			mr.FastForward(2 * time.Hour)
 
 			// Store a live token in A so A has something to scan
-			Expect(storeA.Store(ctx, "live-a", "user2", time.Now().Add(time.Hour), nil)).To(Succeed())
+			Expect(storeA.Store(ctx, "live-a", "user2", nil, time.Now().Add(time.Hour), nil)).To(Succeed())
 
 			// Cleanup on A must not touch B's expired token (it's outside A's scan pattern)
 			removed, err := storeA.Cleanup(ctx)
@@ -254,7 +254,7 @@ var _ = Describe("RedisRefreshStore — Phase 10: Tracing", func() {
 			mockSpan.EXPECT().SetStatus(tracing.StatusOK, "")
 			mockSpan.EXPECT().End()
 
-			Expect(tracingStore.Store(ctx, "trace-store-token", "trace-user", time.Now().Add(time.Hour), nil)).To(Succeed())
+			Expect(tracingStore.Store(ctx, "trace-store-token", "trace-user", nil, time.Now().Add(time.Hour), nil)).To(Succeed())
 		})
 	})
 

--- a/pkg/storage/suite_test.go
+++ b/pkg/storage/suite_test.go
@@ -88,12 +88,12 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 		// ============================================================
 		Describe("Phase 2: Store - Happy Path", func() {
 			It("should store token successfully", func() {
-				err := store.Store(ctx, tokenID, userID, expiresAt, metadata)
+				err := store.Store(ctx, tokenID, userID, nil, expiresAt, metadata)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should allow retrieval after storing", func() {
-				err := store.Store(ctx, tokenID, userID, expiresAt, metadata)
+				err := store.Store(ctx, tokenID, userID, nil, expiresAt, metadata)
 				Expect(err).NotTo(HaveOccurred())
 
 				token, err := store.Retrieve(ctx, tokenID)
@@ -104,7 +104,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 			})
 
 			It("should store metadata correctly", func() {
-				err := store.Store(ctx, tokenID, userID, expiresAt, metadata)
+				err := store.Store(ctx, tokenID, userID, nil, expiresAt, metadata)
 				Expect(err).NotTo(HaveOccurred())
 
 				token, err := store.Retrieve(ctx, tokenID)
@@ -113,7 +113,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 			})
 
 			It("should store expiration time correctly", func() {
-				err := store.Store(ctx, tokenID, userID, expiresAt, metadata)
+				err := store.Store(ctx, tokenID, userID, nil, expiresAt, metadata)
 				Expect(err).NotTo(HaveOccurred())
 
 				token, err := store.Retrieve(ctx, tokenID)
@@ -123,7 +123,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 			It("should store creation time", func() {
 				before := time.Now()
-				err := store.Store(ctx, tokenID, userID, expiresAt, metadata)
+				err := store.Store(ctx, tokenID, userID, nil, expiresAt, metadata)
 				Expect(err).NotTo(HaveOccurred())
 
 				token, err := store.Retrieve(ctx, tokenID)
@@ -134,7 +134,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 			})
 
 			It("should initialize revoked as false", func() {
-				err := store.Store(ctx, tokenID, userID, expiresAt, metadata)
+				err := store.Store(ctx, tokenID, userID, nil, expiresAt, metadata)
 				Expect(err).NotTo(HaveOccurred())
 
 				token, err := store.Retrieve(ctx, tokenID)
@@ -149,39 +149,39 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 		// ============================================================
 		Describe("Phase 3: Store - Input Validation", func() {
 			It("should reject empty tokenID", func() {
-				err := store.Store(ctx, "", userID, expiresAt, metadata)
+				err := store.Store(ctx, "", userID, nil, expiresAt, metadata)
 				Expect(err).To(MatchError(storage.ErrInvalidTokenID))
 			})
 
 			It("should reject whitespace-only tokenID", func() {
-				err := store.Store(ctx, "   ", userID, expiresAt, metadata)
+				err := store.Store(ctx, "   ", userID, nil, expiresAt, metadata)
 				Expect(err).To(MatchError(storage.ErrInvalidTokenID))
 			})
 
 			It("should reject empty userID", func() {
-				err := store.Store(ctx, tokenID, "", expiresAt, metadata)
+				err := store.Store(ctx, tokenID, "", nil, expiresAt, metadata)
 				Expect(err).To(MatchError(storage.ErrInvalidUserID))
 			})
 
 			It("should reject whitespace-only userID", func() {
-				err := store.Store(ctx, tokenID, "   ", expiresAt, metadata)
+				err := store.Store(ctx, tokenID, "   ", nil, expiresAt, metadata)
 				Expect(err).To(MatchError(storage.ErrInvalidUserID))
 			})
 
 			It("should reject expired token (past time)", func() {
 				past := time.Now().Add(-1 * time.Hour)
-				err := store.Store(ctx, tokenID, userID, past, metadata)
+				err := store.Store(ctx, tokenID, userID, nil, past, metadata)
 				Expect(err).To(MatchError(storage.ErrTokenExpired))
 			})
 
 			It("should reject expired token (exactly now)", func() {
 				now := time.Now()
-				err := store.Store(ctx, tokenID, userID, now, metadata)
+				err := store.Store(ctx, tokenID, userID, nil, now, metadata)
 				Expect(err).To(MatchError(storage.ErrTokenExpired))
 			})
 
 			It("should accept nil metadata", func() {
-				err := store.Store(ctx, tokenID, userID, expiresAt, nil)
+				err := store.Store(ctx, tokenID, userID, nil, expiresAt, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				token, err := store.Retrieve(ctx, tokenID)
@@ -190,7 +190,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 			})
 
 			It("should accept empty metadata", func() {
-				err := store.Store(ctx, tokenID, userID, expiresAt, map[string]interface{}{})
+				err := store.Store(ctx, tokenID, userID, nil, expiresAt, map[string]interface{}{})
 				Expect(err).NotTo(HaveOccurred())
 
 				token, err := store.Retrieve(ctx, tokenID)
@@ -209,7 +209,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 					"key": "original",
 				}
 
-				err := store.Store(ctx, tokenID, userID, expiresAt, originalMetadata)
+				err := store.Store(ctx, tokenID, userID, nil, expiresAt, originalMetadata)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Mutate original
@@ -222,7 +222,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 			})
 
 			It("should return deep copy of metadata on Retrieve", func() {
-				err := store.Store(ctx, tokenID, userID, expiresAt, metadata)
+				err := store.Store(ctx, tokenID, userID, nil, expiresAt, metadata)
 				Expect(err).NotTo(HaveOccurred())
 
 				token, err := store.Retrieve(ctx, tokenID)
@@ -244,7 +244,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 					},
 				}
 
-				err := store.Store(ctx, tokenID, userID, expiresAt, nestedMetadata)
+				err := store.Store(ctx, tokenID, userID, nil, expiresAt, nestedMetadata)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Top-level copy is defensive, but nested structures are shared
@@ -276,7 +276,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 			})
 
 			It("should return ErrTokenRevoked for revoked token", func() {
-				err := store.Store(ctx, tokenID, userID, expiresAt, metadata)
+				err := store.Store(ctx, tokenID, userID, nil, expiresAt, metadata)
 				Expect(err).NotTo(HaveOccurred())
 
 				err = store.Revoke(ctx, tokenID)
@@ -288,7 +288,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 			It("should return ErrTokenExpired for expired token", func() {
 				past := time.Now().Add(-1 * time.Hour)
-				err := store.Store(ctx, tokenID, userID, past, metadata)
+				err := store.Store(ctx, tokenID, userID, nil, past, metadata)
 				// Some stores might reject this at Store time, so check either way
 				if err != storage.ErrTokenExpired {
 					// If Store accepts it, Retrieve should reject it
@@ -304,7 +304,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 		// ============================================================
 		Describe("Phase 6: Revoke - Idempotent and State-Changing", func() {
 			It("should mark token as revoked", func() {
-				err := store.Store(ctx, tokenID, userID, expiresAt, metadata)
+				err := store.Store(ctx, tokenID, userID, nil, expiresAt, metadata)
 				Expect(err).NotTo(HaveOccurred())
 
 				err = store.Revoke(ctx, tokenID)
@@ -315,7 +315,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 			})
 
 			It("should be idempotent (revoke twice)", func() {
-				err := store.Store(ctx, tokenID, userID, expiresAt, metadata)
+				err := store.Store(ctx, tokenID, userID, nil, expiresAt, metadata)
 				Expect(err).NotTo(HaveOccurred())
 
 				err = store.Revoke(ctx, tokenID)
@@ -354,7 +354,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 				// Store 5 tokens for same user
 				for i := 0; i < 5; i++ {
 					tid := fmt.Sprintf("token-%d", i)
-					err := store.Store(ctx, tid, userID, expiresAt, metadata)
+					err := store.Store(ctx, tid, userID, nil, expiresAt, metadata)
 					Expect(err).NotTo(HaveOccurred())
 				}
 
@@ -374,10 +374,10 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 				user1ID := "user-1"
 				user2ID := "user-2"
 
-				err := store.Store(ctx, "token-1", user1ID, expiresAt, metadata)
+				err := store.Store(ctx, "token-1", user1ID, nil, expiresAt, metadata)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = store.Store(ctx, "token-2", user2ID, expiresAt, metadata)
+				err = store.Store(ctx, "token-2", user2ID, nil, expiresAt, metadata)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Revoke user1's tokens
@@ -410,7 +410,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 			})
 
 			It("should be idempotent", func() {
-				err := store.Store(ctx, tokenID, userID, expiresAt, metadata)
+				err := store.Store(ctx, tokenID, userID, nil, expiresAt, metadata)
 				Expect(err).NotTo(HaveOccurred())
 
 				err = store.RevokeAllForUser(ctx, userID)
@@ -430,7 +430,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 			It("should remove expired tokens", func() {
 				veryShortLived := time.Now().Add(100 * time.Millisecond)
 
-				err := store.Store(ctx, tokenID, userID, veryShortLived, metadata)
+				err := store.Store(ctx, tokenID, userID, nil, veryShortLived, metadata)
 				if err != nil {
 					Skip("Store rejected short-lived token")
 				}
@@ -454,7 +454,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 				// Store multiple short-lived tokens
 				for i := 0; i < 3; i++ {
 					tid := fmt.Sprintf("token-%d", i)
-					err := store.Store(ctx, tid, userID, veryShortLived, metadata)
+					err := store.Store(ctx, tid, userID, nil, veryShortLived, metadata)
 					if err != nil {
 						Skip("Store rejected short-lived tokens")
 					}
@@ -471,7 +471,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 			It("should not remove non-expired tokens", func() {
 				future := time.Now().Add(1 * time.Hour)
-				err := store.Store(ctx, tokenID, userID, future, metadata)
+				err := store.Store(ctx, tokenID, userID, nil, future, metadata)
 				Expect(err).NotTo(HaveOccurred())
 
 				count, err := store.Cleanup(ctx)
@@ -491,11 +491,11 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 			It("should handle mixed expiration states", func() {
 				future := time.Now().Add(1 * time.Hour)
-				err := store.Store(ctx, "future-token", userID, future, metadata)
+				err := store.Store(ctx, "future-token", userID, nil, future, metadata)
 				Expect(err).NotTo(HaveOccurred())
 
 				shortLived := time.Now().Add(50 * time.Millisecond)
-				err = store.Store(ctx, "short-token", userID, shortLived, metadata)
+				err = store.Store(ctx, "short-token", userID, nil, shortLived, metadata)
 				if err != nil {
 					Skip("Store rejected short-lived token")
 				}
@@ -519,7 +519,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 		Describe("Phase 8: Edge Cases - Unicode", func() {
 			It("should handle unicode in tokenID", func() {
 				uuidToken := "token-🔐-abc"
-				err := store.Store(ctx, uuidToken, userID, expiresAt, metadata)
+				err := store.Store(ctx, uuidToken, userID, nil, expiresAt, metadata)
 				Expect(err).NotTo(HaveOccurred())
 
 				token, err := store.Retrieve(ctx, uuidToken)
@@ -529,7 +529,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 			It("should handle unicode in userID", func() {
 				uuidUser := "user-🔐-xyz"
-				err := store.Store(ctx, tokenID, uuidUser, expiresAt, metadata)
+				err := store.Store(ctx, tokenID, uuidUser, nil, expiresAt, metadata)
 				Expect(err).NotTo(HaveOccurred())
 
 				token, err := store.Retrieve(ctx, tokenID)
@@ -546,7 +546,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 			It("should handle storing many tokens for one user", func() {
 				for i := 0; i < 100; i++ {
 					tid := fmt.Sprintf("token-%d", i)
-					err := store.Store(ctx, tid, userID, expiresAt, metadata)
+					err := store.Store(ctx, tid, userID, nil, expiresAt, metadata)
 					Expect(err).NotTo(HaveOccurred())
 				}
 
@@ -573,7 +573,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 					largeMeta[fmt.Sprintf("key-%d", i)] = fmt.Sprintf("value-%d", i)
 				}
 
-				err := store.Store(ctx, tokenID, userID, expiresAt, largeMeta)
+				err := store.Store(ctx, tokenID, userID, nil, expiresAt, largeMeta)
 				Expect(err).NotTo(HaveOccurred())
 
 				token, err := store.Retrieve(ctx, tokenID)
@@ -589,7 +589,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 		Describe("Phase 8: Edge Cases - Far Future", func() {
 			It("should handle tokens with very far future expiration", func() {
 				farFuture := time.Now().Add(100 * 365 * 24 * time.Hour)
-				err := store.Store(ctx, tokenID, userID, farFuture, metadata)
+				err := store.Store(ctx, tokenID, userID, nil, farFuture, metadata)
 				Expect(err).NotTo(HaveOccurred())
 
 				token, err := store.Retrieve(ctx, tokenID)
@@ -631,7 +631,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 					gomock.Any(),
 					map[string]string{"storage_backend": backend, "namespace": ""}).AnyTimes()
 
-				err := ms.Store(ctx, tokenID, userID, expiresAt, metadata)
+				err := ms.Store(ctx, tokenID, userID, nil, expiresAt, metadata)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -642,7 +642,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 					gomock.Any(),
 					map[string]string{"operation": "store", "storage_backend": backend, "namespace": ""})
 
-				err := ms.Store(ctx, "", userID, expiresAt, metadata)
+				err := ms.Store(ctx, "", userID, nil, expiresAt, metadata)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -656,7 +656,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 				mockM.EXPECT().SetGauge("jwtauth_storage_tokens_count",
 					gomock.Any(),
 					map[string]string{"storage_backend": backend, "namespace": ""}).AnyTimes()
-				Expect(ms.Store(ctx, tokenID, userID, expiresAt, metadata)).To(Succeed())
+				Expect(ms.Store(ctx, tokenID, userID, nil, expiresAt, metadata)).To(Succeed())
 
 				// Retrieve expectations
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
@@ -691,7 +691,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 				mockM.EXPECT().SetGauge("jwtauth_storage_tokens_count",
 					gomock.Any(),
 					map[string]string{"storage_backend": backend, "namespace": ""}).AnyTimes()
-				Expect(ms.Store(ctx, tokenID, userID, expiresAt, metadata)).To(Succeed())
+				Expect(ms.Store(ctx, tokenID, userID, nil, expiresAt, metadata)).To(Succeed())
 
 				// Revoke
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
@@ -722,7 +722,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 				mockM.EXPECT().SetGauge("jwtauth_storage_tokens_count",
 					gomock.Any(),
 					map[string]string{"storage_backend": backend, "namespace": ""}).AnyTimes()
-				Expect(ms.Store(ctx, tokenID, userID, expiresAt, metadata)).To(Succeed())
+				Expect(ms.Store(ctx, tokenID, userID, nil, expiresAt, metadata)).To(Succeed())
 
 				// Revoke
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
@@ -744,7 +744,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 				mockM.EXPECT().SetGauge("jwtauth_storage_tokens_count",
 					gomock.Any(),
 					map[string]string{"storage_backend": backend, "namespace": ""}).AnyTimes()
-				Expect(ms.Store(ctx, tokenID, userID, expiresAt, metadata)).To(Succeed())
+				Expect(ms.Store(ctx, tokenID, userID, nil, expiresAt, metadata)).To(Succeed())
 
 				// RevokeAllForUser
 				mockM.EXPECT().IncrementCounter("jwtauth_storage_operations_total",
@@ -769,7 +769,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 				mockM.EXPECT().SetGauge("jwtauth_storage_tokens_count",
 					float64(1),
 					map[string]string{"storage_backend": backend, "namespace": ""}).AnyTimes()
-				err := ms.Store(ctx, tokenID, userID, veryShortLived, metadata)
+				err := ms.Store(ctx, tokenID, userID, nil, veryShortLived, metadata)
 				if err != nil {
 					Skip("store rejected short-lived token")
 				}
@@ -815,7 +815,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 			It("should not panic when metrics is nil", func() {
 				nilMetricsStore := factory(mockLogger, nil)
 				Expect(func() {
-					_ = nilMetricsStore.Store(ctx, tokenID, userID, expiresAt, metadata)
+					_ = nilMetricsStore.Store(ctx, tokenID, userID, nil, expiresAt, metadata)
 					_, _ = nilMetricsStore.Retrieve(ctx, tokenID)
 					_ = nilMetricsStore.Revoke(ctx, tokenID)
 					_ = nilMetricsStore.RevokeAllForUser(ctx, userID)
@@ -833,7 +833,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 				cancelledCtx, cancel := context.WithCancel(context.Background())
 				cancel()
 
-				err := store.Store(cancelledCtx, tokenID, userID, expiresAt, metadata)
+				err := store.Store(cancelledCtx, tokenID, userID, nil, expiresAt, metadata)
 				Expect(err).To(MatchError(context.Canceled))
 			})
 
@@ -884,7 +884,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 			It("should return all tokens in a single page when count >= total", func() {
 				for i := 0; i < 3; i++ {
-					Expect(store.Store(ctx, fmt.Sprintf("tok-single-%d", i), userID, expiresAt, nil)).To(Succeed())
+					Expect(store.Store(ctx, fmt.Sprintf("tok-single-%d", i), userID, nil, expiresAt, nil)).To(Succeed())
 				}
 
 				tokens, next, err := store.ListTokens(ctx, "", 100)
@@ -896,7 +896,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 			It("should return all tokens across multiple pages with no gaps", func() {
 				const total = 7
 				for i := 0; i < total; i++ {
-					Expect(store.Store(ctx, fmt.Sprintf("tok-page-%02d", i), userID, expiresAt, nil)).To(Succeed())
+					Expect(store.Store(ctx, fmt.Sprintf("tok-page-%02d", i), userID, nil, expiresAt, nil)).To(Succeed())
 				}
 
 				var all []*storage.RefreshToken
@@ -922,7 +922,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 			It("should return empty cursor when iteration is exhausted", func() {
 				for i := 0; i < 2; i++ {
-					Expect(store.Store(ctx, fmt.Sprintf("tok-exhaust-%d", i), userID, expiresAt, nil)).To(Succeed())
+					Expect(store.Store(ctx, fmt.Sprintf("tok-exhaust-%d", i), userID, nil, expiresAt, nil)).To(Succeed())
 				}
 
 				_, finalCursor, err := store.ListTokens(ctx, "", 100)
@@ -932,7 +932,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 			It("should return non-overlapping pages on successive calls", func() {
 				for i := 0; i < 6; i++ {
-					Expect(store.Store(ctx, fmt.Sprintf("tok-overlap-%02d", i), userID, expiresAt, nil)).To(Succeed())
+					Expect(store.Store(ctx, fmt.Sprintf("tok-overlap-%02d", i), userID, nil, expiresAt, nil)).To(Succeed())
 				}
 
 				page1, cursor1, err := store.ListTokens(ctx, "", 3)
@@ -954,7 +954,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 			})
 
 			It("should return no error for count=0", func() {
-				Expect(store.Store(ctx, "tok-count0", userID, expiresAt, nil)).To(Succeed())
+				Expect(store.Store(ctx, "tok-count0", userID, nil, expiresAt, nil)).To(Succeed())
 				_, _, err := store.ListTokens(ctx, "", 0)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -972,13 +972,13 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 				revoked := "tok-revoked"
 				expired := "tok-expired"
 
-				Expect(store.Store(ctx, active, userID, expiresAt, nil)).To(Succeed())
-				Expect(store.Store(ctx, revoked, userID, expiresAt, nil)).To(Succeed())
+				Expect(store.Store(ctx, active, userID, nil, expiresAt, nil)).To(Succeed())
+				Expect(store.Store(ctx, revoked, userID, nil, expiresAt, nil)).To(Succeed())
 				Expect(store.Revoke(ctx, revoked)).To(Succeed())
 				// Store expired token: use far-future expiry then mutate via Cleanup-immune path.
 				// Memory: we can store with a short expiry but Cleanup hasn't run, so it's still present.
 				// Just verify all tokens stored and visible (Cleanup hasn't run yet).
-				Expect(store.Store(ctx, expired, userID, time.Now().Add(24*time.Hour), nil)).To(Succeed())
+				Expect(store.Store(ctx, expired, userID, nil, time.Now().Add(24*time.Hour), nil)).To(Succeed())
 
 				var all []*storage.RefreshToken
 				cursor := ""
@@ -1019,7 +1019,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 				user := "user-single-page"
 				ids := []string{"tok-a", "tok-b", "tok-c"}
 				for _, id := range ids {
-					Expect(store.Store(ctx, id, user, expiresAt, nil)).To(Succeed())
+					Expect(store.Store(ctx, id, user, nil, expiresAt, nil)).To(Succeed())
 				}
 
 				tokens, next, err := store.ListTokensForUser(ctx, user, "", 100)
@@ -1038,7 +1038,7 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 				user := "user-paginate"
 				total := 7
 				for i := 0; i < total; i++ {
-					Expect(store.Store(ctx, fmt.Sprintf("page-tok-%d", i), user, expiresAt, nil)).To(Succeed())
+					Expect(store.Store(ctx, fmt.Sprintf("page-tok-%d", i), user, nil, expiresAt, nil)).To(Succeed())
 				}
 
 				var all []*storage.RefreshToken
@@ -1058,9 +1058,9 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 			It("should isolate tokens between different users", func() {
 				userA := "user-isolation-a"
 				userB := "user-isolation-b"
-				Expect(store.Store(ctx, "tok-iso-a1", userA, expiresAt, nil)).To(Succeed())
-				Expect(store.Store(ctx, "tok-iso-a2", userA, expiresAt, nil)).To(Succeed())
-				Expect(store.Store(ctx, "tok-iso-b1", userB, expiresAt, nil)).To(Succeed())
+				Expect(store.Store(ctx, "tok-iso-a1", userA, nil, expiresAt, nil)).To(Succeed())
+				Expect(store.Store(ctx, "tok-iso-a2", userA, nil, expiresAt, nil)).To(Succeed())
+				Expect(store.Store(ctx, "tok-iso-b1", userB, nil, expiresAt, nil)).To(Succeed())
 
 				tokensA, _, err := store.ListTokensForUser(ctx, userA, "", 100)
 				Expect(err).NotTo(HaveOccurred())
@@ -1082,8 +1082,8 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 
 			It("should return empty next cursor when iteration is exhausted", func() {
 				user := "user-exhaust"
-				Expect(store.Store(ctx, "tok-exhaust-1", user, expiresAt, nil)).To(Succeed())
-				Expect(store.Store(ctx, "tok-exhaust-2", user, expiresAt, nil)).To(Succeed())
+				Expect(store.Store(ctx, "tok-exhaust-1", user, nil, expiresAt, nil)).To(Succeed())
+				Expect(store.Store(ctx, "tok-exhaust-2", user, nil, expiresAt, nil)).To(Succeed())
 
 				_, finalCursor, err := store.ListTokensForUser(ctx, user, "", 100)
 				Expect(err).NotTo(HaveOccurred())
@@ -1103,8 +1103,8 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 				active := "tok-user-active"
 				revoked := "tok-user-revoked"
 
-				Expect(store.Store(ctx, active, user, expiresAt, nil)).To(Succeed())
-				Expect(store.Store(ctx, revoked, user, expiresAt, nil)).To(Succeed())
+				Expect(store.Store(ctx, active, user, nil, expiresAt, nil)).To(Succeed())
+				Expect(store.Store(ctx, revoked, user, nil, expiresAt, nil)).To(Succeed())
 				Expect(store.Revoke(ctx, revoked)).To(Succeed())
 
 				var all []*storage.RefreshToken

--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -805,6 +805,7 @@ func (m *Manager) IssueRefreshToken(ctx context.Context, userID string) (string,
 		ctx,          // Context for cancellation
 		refreshToken, // Token ID (the token itself is the ID)
 		userID,       // Who owns the token
+		m.audience,   // Audience — overridden per-call in Phase 3
 		expiresAt,    // When it expires
 		nil,          // No claims (use IssueRefreshTokenWithClaims to attach claims)
 	)
@@ -927,6 +928,7 @@ func (m *Manager) IssueRefreshTokenWithClaims(ctx context.Context, userID string
 		ctx,          // Context for cancellation
 		refreshToken, // Token ID (the token itself is the ID)
 		userID,       // Who owns the token
+		m.audience,   // Audience — overridden per-call in Phase 3
 		expiresAt,    // When it expires
 		claims,       // Custom claims
 	)
@@ -1108,6 +1110,7 @@ func (m *Manager) IssueTokenPair(ctx context.Context, userID string) (string, st
 		ctx,          // Context for cancellation
 		refreshToken, // Token ID (the token itself is the ID)
 		userID,       // Who owns the token
+		m.audience,   // Audience — overridden per-call in Phase 3
 		expiresAt,    // When it expires
 		nil,          // No claims (use IssueRefreshTokenWithClaims to attach claims)
 	)
@@ -1290,6 +1293,7 @@ func (m *Manager) IssueTokenPairWithClaims(ctx context.Context, userID string, a
 		ctx,
 		refreshToken,
 		userID,
+		m.audience,   // Audience — overridden per-call in Phase 3
 		expiresAt,
 		refreshClaims,
 	)

--- a/pkg/tokens/manager_metrics_test.go
+++ b/pkg/tokens/manager_metrics_test.go
@@ -167,7 +167,7 @@ var _ = Describe("TokenManager Metrics", func() {
 	Describe("IssueRefreshToken", func() {
 		It("records success counter and duration on successful issuance", func() {
 			startService()
-			mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), "user-1", gomock.Any(), gomock.Any()).Return(nil)
+			mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), "user-1", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			mockM.EXPECT().IncrementCounter("jwtauth_tokens_issued_total", map[string]string{
 				"status":     "success",
 				"error_type": "",

--- a/pkg/tokens/manager_test.go
+++ b/pkg/tokens/manager_test.go
@@ -393,7 +393,8 @@ var _ = Describe("TokenManager", func() {
 					gomock.Any(), // ctx
 					gomock.Any(), // tokenID (generated)
 					testUserID,   // userID
-					gomock.Any(), // expireAt
+					gomock.Any(), // audience
+					gomock.Any(), // expiresAt
 					gomock.Any(), // metadata
 				).Return(nil).
 					Times(1)
@@ -407,7 +408,7 @@ var _ = Describe("TokenManager", func() {
 			It("should store refresh token", func() {
 					// Verify Store is called
 				mockStore.EXPECT().
-					Store(gomock.Any(), gomock.Any(), testUserID, gomock.Any(), gomock.Any()).
+					Store(gomock.Any(), gomock.Any(), testUserID, gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil).
 					Times(1)
 
@@ -415,7 +416,7 @@ var _ = Describe("TokenManager", func() {
 			})
 
 			It("should log token issuance", func() {
-				mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 				service.IssueRefreshToken(ctx, testUserID)
 
@@ -432,7 +433,7 @@ var _ = Describe("TokenManager", func() {
 
 				// Verify claims are passed to Store
 				mockStore.EXPECT().
-					Store(gomock.Any(), gomock.Any(), testUserID, gomock.Any(), claims).
+					Store(gomock.Any(), gomock.Any(), testUserID, gomock.Any(), gomock.Any(), claims).
 					Return(nil)
 
 				service.IssueRefreshTokenWithClaims(ctx, testUserID, claims)
@@ -447,10 +448,11 @@ var _ = Describe("TokenManager", func() {
 						gomock.Any(),
 						gomock.Any(),
 						testUserID,
+						gomock.Any(),
 						gomock.AssignableToTypeOf(time.Time{}),
 						gomock.Any(),
 					).
-					Do(func(_ context.Context, tokenID, userID string, expiresAt time.Time, metadata map[string]interface{}) {
+					Do(func(_ context.Context, tokenID, userID string, audience []string, expiresAt time.Time, metadata map[string]interface{}) {
 						// Verify expiration is within 2 seconds of expected
 						Expect(expiresAt).To(BeTemporally("~", expectedExpiry, 2*time.Second))
 					}).
@@ -463,7 +465,7 @@ var _ = Describe("TokenManager", func() {
 		Context("when storage fails", func() {
 			It("should return error", func() {
 				mockStore.EXPECT().
-					Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(errors.New("storage failure"))
 
 				_, err := service.IssueRefreshToken(ctx, testUserID)
@@ -474,7 +476,7 @@ var _ = Describe("TokenManager", func() {
 
 			It("should log error", func() {
 				mockStore.EXPECT().
-					Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(errors.New("storage error"))
 
 				service.IssueRefreshToken(ctx, testUserID)
@@ -524,7 +526,7 @@ var _ = Describe("TokenManager", func() {
 			})
 
 			It("should return error when storage fails", func() {
-				mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(errors.New("storage failure"))
 
 				_, err := service.IssueRefreshTokenWithClaims(ctx, testUserID, nil)
@@ -550,7 +552,7 @@ var _ = Describe("TokenManager", func() {
 				// Expect all dependencies called in order
 				gomock.InOrder(
 					mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil),
-					mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), testUserID, gomock.Any(), gomock.Any()).Return(nil),
+					mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), testUserID, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 				)
 
 				accessToken, refreshToken, err := service.IssueTokenPair(ctx, testUserID)
@@ -566,7 +568,7 @@ var _ = Describe("TokenManager", func() {
 					Return(testKey, testKeyID, nil).
 					Times(1)
 
-				mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 				service.IssueTokenPair(ctx, testUserID)
 			})
@@ -575,7 +577,7 @@ var _ = Describe("TokenManager", func() {
 				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
 
 				mockStore.EXPECT().
-					Store(gomock.Any(), gomock.Any(), testUserID, gomock.Any(), gomock.Any()).
+					Store(gomock.Any(), gomock.Any(), testUserID, gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil).
 					Times(1)
 
@@ -584,7 +586,7 @@ var _ = Describe("TokenManager", func() {
 
 			It("should log both issuances", func() {
 				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
-				mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 				service.IssueTokenPair(ctx, testUserID)
 
@@ -601,7 +603,7 @@ var _ = Describe("TokenManager", func() {
 					Return(nil, "", errors.New("key error"))
 
 				// Store should NOT be called
-				mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+				mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
 				_, _, err := service.IssueTokenPair(ctx, testUserID)
 
@@ -613,7 +615,7 @@ var _ = Describe("TokenManager", func() {
 			It("should return error", func() {
 				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
 				mockStore.EXPECT().
-					Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(errors.New("storage error"))
 
 				_, _, err := service.IssueTokenPair(ctx, testUserID)
@@ -662,7 +664,7 @@ var _ = Describe("TokenManager", func() {
 
 				gomock.InOrder(
 					mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil),
-					mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), testUserID, gomock.Any(), refreshClaims).Return(nil),
+					mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), testUserID, gomock.Any(), gomock.Any(), refreshClaims).Return(nil),
 				)
 
 				accessToken, refreshToken, err := service.IssueTokenPairWithClaims(ctx, testUserID, accessClaims, refreshClaims)
@@ -675,7 +677,7 @@ var _ = Describe("TokenManager", func() {
 			It("should embed access claims into the access token", func() {
 				accessClaims := tokens.CustomClaims{"role": "editor", "tenant": "org-456"}
 				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
-				mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 				accessToken, _, err := service.IssueTokenPairWithClaims(ctx, testUserID, accessClaims, nil)
 				Expect(err).NotTo(HaveOccurred())
@@ -689,7 +691,7 @@ var _ = Describe("TokenManager", func() {
 				refreshClaims := tokens.CustomClaims{"device_id": "device-001"}
 				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
 				mockStore.EXPECT().
-					Store(gomock.Any(), gomock.Any(), testUserID, gomock.Any(), refreshClaims).
+					Store(gomock.Any(), gomock.Any(), testUserID, gomock.Any(), gomock.Any(), refreshClaims).
 					Return(nil)
 
 				service.IssueTokenPairWithClaims(ctx, testUserID, nil, refreshClaims)
@@ -698,7 +700,7 @@ var _ = Describe("TokenManager", func() {
 			It("should not override reserved claims in the access token", func() {
 				accessClaims := tokens.CustomClaims{"sub": "hacker", "role": "admin"}
 				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
-				mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 				accessToken, _, err := service.IssueTokenPairWithClaims(ctx, testUserID, accessClaims, nil)
 				Expect(err).NotTo(HaveOccurred())
@@ -713,7 +715,7 @@ var _ = Describe("TokenManager", func() {
 
 			It("should behave like IssueTokenPair when both claims are nil", func() {
 				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
-				mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), testUserID, gomock.Any(), nil).Return(nil)
+				mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), testUserID, gomock.Any(), gomock.Any(), nil).Return(nil)
 
 				accessToken, refreshToken, err := service.IssueTokenPairWithClaims(ctx, testUserID, nil, nil)
 				Expect(err).NotTo(HaveOccurred())
@@ -723,7 +725,7 @@ var _ = Describe("TokenManager", func() {
 
 			It("should log token pair issuance", func() {
 				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
-				mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 				service.IssueTokenPairWithClaims(ctx, testUserID, nil, nil)
 
@@ -739,7 +741,7 @@ var _ = Describe("TokenManager", func() {
 					GetCurrentSigningKey(gomock.Any()).
 					Return(nil, "", errors.New("key error"))
 
-				mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+				mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
 				_, _, err := service.IssueTokenPairWithClaims(ctx, testUserID, nil, nil)
 
@@ -751,7 +753,7 @@ var _ = Describe("TokenManager", func() {
 			It("should return error", func() {
 				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
 				mockStore.EXPECT().
-					Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(errors.New("storage error"))
 
 				_, _, err := service.IssueTokenPairWithClaims(ctx, testUserID, nil, nil)
@@ -1138,7 +1140,7 @@ var _ = Describe("TokenManager", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Then issue a refresh token
-			mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), testUserID, gomock.Any(), gomock.Any()).Return(nil)
+			mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), testUserID, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			validRefreshToken, _ = service.IssueRefreshToken(ctx, testUserID)
 		})
 
@@ -1291,7 +1293,7 @@ var _ = Describe("TokenManager", func() {
 			err := service.Start(ctx)
 			Expect(err).NotTo(HaveOccurred())
 
-			mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), testUserID, gomock.Any(), gomock.Any()).Return(nil)
+			mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), testUserID, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			validRefreshToken, _ = service.IssueRefreshToken(ctx, testUserID)
 		})
 
@@ -1599,7 +1601,7 @@ var _ = Describe("TokenManager", func() {
 			mockKM.EXPECT().Start(gomock.Any()).Return(nil)
 			Expect(service.Start(ctx)).To(Succeed())
 
-			mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			refreshToken, _ = service.IssueRefreshToken(ctx, testUserID)
 		})
 
@@ -2176,7 +2178,7 @@ var _ = Describe("TokenManager — Phase N: Tracing", func() {
 			testSpan.EXPECT().End()
 
 			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
-			mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			mockStore.EXPECT().Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 			_, _, err := manager.IssueTokenPairWithClaims(ctx, "tracing-user", nil, nil)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary

- Adds `Audience []string` to `RefreshToken` struct
- Inserts `audience []string` into `Store()` between `userID` and `expiresAt` on the `RefreshStore` interface and both implementations
- `MemoryRefreshStore`: defensive copy at `Store()`; `Audience` propagated in `Retrieve`, `ListTokens`, and `ListTokensForUser` return copies
- `RedisRefreshStore`: audience serialised as JSON field `"audience"` at `Store()`; deserialised in `Retrieve` and `fetchTokensByIDs`
- Regenerated `MockRefreshStore` via `go generate ./pkg/storage/`
- `tokens.Manager`: all 4 `Store()` call sites pass `m.audience` as interim — overridden per-call in Phase 3 when `IssueOption` is wired into method signatures
- All callers updated atomically — build is never broken in this commit

**Breaking change:** `Store()` signature now requires `audience []string` in position 4. Existing callers that pass `nil` will use the manager's configured audience once Phase 3 wires `WithAudience` through.

## Phase tracker

| Phase | Description | Branch | Status |
|---|---|---|---|
| 1 | `IssueOption` type + `WithAudience` + `resolveAudience` | `feat/124-issue-option-type` | Merged ✓ |
| **2** | `Store()` signature + `RefreshToken.Audience` + all callers + mock regen | `feat/124-store-audience-field` | **This PR** |
| 3 | Wire `opts ...IssueOption` into all 6 issuing methods + observability + tests | `feat/124-wire-with-audience` | Pending |
| 4 | `RefreshAccessToken` audience propagation fix + `TokenMetadata.Audience` | `feat/124-refresh-propagation` | Pending |
| 5 | Atomic `operation` → `revocation_scope` rename on `tokens_revoked_total` | `feat/124-revocation-scope-metric` | Pending |
| 6 | Docs, UPGRADING.md, CHANGELOG.md, README, ARCHITECTURE.md, chi-example | `docs/124-audience` | Pending |

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `./run-ci-locally.sh` — 788 unit + 34 integration specs, 0 lint issues, no vulnerabilities

Part of #124