### PR TITLE
feat(metrics): rename operation label to revocation_scope on tokens_revoked_total (#124 Phase 5)

### DIFF
--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -89,7 +89,7 @@ func (pm *PrometheusMetrics) registerAllMetrics(namespace string) {
 
 	pm.registerCounter(namespace, "tokens_revoked_total",
 		"Total number of tokens revoked",
-		[]string{"operation", "status", "namespace"})
+		[]string{"revocation_scope", "status", "namespace"})
 
 	pm.registerCounter(namespace, "tokens_introspected_total",
 		"Total number of token introspections",

--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -1900,9 +1900,9 @@ func (m *Manager) RevokeRefreshToken(ctx context.Context, tokenID string) error 
 	status := "error"
 	defer func() {
 		m.metrics.IncrementCounter(metricTokensRevokedTotal, map[string]string{
-			"operation": "single",
-			"status":    status,
-			"namespace":  m.namespace,
+			"revocation_scope": "single",
+			"status":           status,
+			"namespace":        m.namespace,
 		})
 		m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 			"operation": "revoke_token",
@@ -1972,9 +1972,9 @@ func (m *Manager) RevokeAllUserTokens(ctx context.Context, userID string) error 
 	status := "error"
 	defer func() {
 		m.metrics.IncrementCounter(metricTokensRevokedTotal, map[string]string{
-			"operation": "all_user",
-			"status":    status,
-			"namespace":  m.namespace,
+			"revocation_scope": "all_user",
+			"status":           status,
+			"namespace":        m.namespace,
 		})
 		m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 			"operation": "revoke_all_user_tokens",

--- a/pkg/tokens/manager_metrics_test.go
+++ b/pkg/tokens/manager_metrics_test.go
@@ -293,13 +293,13 @@ var _ = Describe("TokenManager Metrics", func() {
 	// ====================================================================
 
 	Describe("RevokeRefreshToken", func() {
-		It("records success counter with operation=single on successful revocation", func() {
+		It("records success counter with revocation_scope=single on successful revocation", func() {
 			startService()
 			mockStore.EXPECT().Revoke(gomock.Any(), "rt-1").Return(nil)
 			mockM.EXPECT().IncrementCounter("jwtauth_tokens_revoked_total", map[string]string{
-				"operation": "single",
-				"status":    "success",
-				"namespace": "",
+				"revocation_scope": "single",
+				"status":           "success",
+				"namespace":        "",
 			})
 			mockM.EXPECT().RecordDuration("jwtauth_operation_duration_seconds", gomock.Any(), map[string]string{
 				"operation": "revoke_token",
@@ -311,9 +311,9 @@ var _ = Describe("TokenManager Metrics", func() {
 		It("records invalid_input counter for empty token ID", func() {
 			startService()
 			mockM.EXPECT().IncrementCounter("jwtauth_tokens_revoked_total", map[string]string{
-				"operation": "single",
-				"status":    "invalid_input",
-				"namespace": "",
+				"revocation_scope": "single",
+				"status":           "invalid_input",
+				"namespace":        "",
 			})
 			mockM.EXPECT().RecordDuration("jwtauth_operation_duration_seconds", gomock.Any(), map[string]string{
 				"operation": "revoke_token",
@@ -328,13 +328,13 @@ var _ = Describe("TokenManager Metrics", func() {
 	// ====================================================================
 
 	Describe("RevokeAllUserTokens", func() {
-		It("records success counter with operation=all_user on successful bulk revocation", func() {
+		It("records success counter with revocation_scope=all_user on successful bulk revocation", func() {
 			startService()
 			mockStore.EXPECT().RevokeAllForUser(gomock.Any(), "user-1").Return(nil)
 			mockM.EXPECT().IncrementCounter("jwtauth_tokens_revoked_total", map[string]string{
-				"operation": "all_user",
-				"status":    "success",
-				"namespace": "",
+				"revocation_scope": "all_user",
+				"status":           "success",
+				"namespace":        "",
 			})
 			mockM.EXPECT().RecordDuration("jwtauth_operation_duration_seconds", gomock.Any(), map[string]string{
 				"operation": "revoke_all_user_tokens",


### PR DESCRIPTION
## Summary

Renames the `operation` label to `revocation_scope` on the `jwtauth_tokens_revoked_total` counter. This is the last functional change for issue #124 before the docs phase.

**Motivation:** `operation` is already used across all other token manager metrics to describe the method name (e.g. `revoke_token`, `issue_access_token`). On `tokens_revoked_total`, the label tracked the _scope_ of the revocation — not which method was called — making it semantically inconsistent. `revocation_scope` is unambiguous and aligns with the upcoming `audience` and `user_audience` values planned in #135.

**Label value mapping (unchanged):**
- `single` — single token revoked via `RevokeRefreshToken`
- `all_user` — all tokens for a user revoked via `RevokeAllUserTokens`

## Files changed

- `pkg/metrics/prometheus.go` — label registration: `"operation"` → `"revocation_scope"`
- `pkg/tokens/manager.go` — two `IncrementCounter` emit sites updated
- `pkg/tokens/manager_metrics_test.go` — three gomock expectations updated to assert the new label key

## Test plan

- [x] All 232 unit specs pass under `-race`
- [x] All 36 integration specs pass under `-race`
- [x] `golangci-lint`, `go vet`, `govulncheck` clean
- [x] No other metrics are affected — `operation` label retained on all other counters/histograms

**Part of #124 — Phase 5 of 6**