### PR TITLE
docs: document WithAudience IssueOption for v0.5.0 (#124 Phase 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [Unreleased — v0.5.0]
+
+### Breaking
+
+- **`storage.RefreshStore.Store()` gains `audience []string` parameter** — all custom `RefreshStore` implementations must update their `Store()` method signature. `MemoryRefreshStore` and `RedisRefreshStore` are already updated. Add a compile-time assertion to catch the gap early: `var _ storage.RefreshStore = (*MyStore)(nil)`. See #124 and `UPGRADING.md`.
+
+- **`jwtauth_tokens_revoked_total` label `operation` renamed to `revocation_scope`** — update any Prometheus alert rules, recording rules, or dashboards that filter or group by the old label name. Existing label values (`"single"`, `"all_user"`) are unchanged. See #124.
+
+### Added
+
+- **`IssueOption` type and `WithAudience` functional option** — all six issuance methods (`IssueAccessToken`, `IssueAccessTokenWithClaims`, `IssueRefreshToken`, `IssueRefreshTokenWithClaims`, `IssueTokenPair`, `IssueTokenPairWithClaims`) now accept a variadic `...tokens.IssueOption` parameter. All existing call sites compile unchanged — the parameter is optional and defaults to the manager's configured audience. Use `tokens.WithAudience("svc-payments")` to target a specific audience for a single call. See #124.
+
+- **`RefreshToken.Audience []string`** — the stored refresh token record now carries the audience slice resolved at issuance time. `RefreshAccessToken` and `RefreshAccessTokenWithClaims` propagate this stored audience into the new access token so the refreshed token targets the same audience as the original. See #124.
+
+- **`TokenMetadata.Audience []string`** — `IntrospectToken` now populates the `Audience` field on active, revoked, and expired paths. The not-found path leaves the field nil. See #124.
+
+---
+
 ## [v0.4.0] — 2026-04-30
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **You verify identity. jwtauth manages everything after:** zero-downtime key rotation, access token issuance, refresh token lifecycle, and instant revocation across horizontal scale.
 
-> **API Stability (pre-v1.0)**: All components are production-quality with comprehensive test coverage. The API surface is still evolving before v1.0.0. **v0.5.0 planned changes:** `IssueOption` / `WithAudience` for per-call audience targeting (#124) — additive, all existing call sites compile unchanged. Audience-based token revocation `RevokeAllForAudience` (#135) — adds `Audience string` to `RefreshToken` and two new methods to `RefreshStore`; custom implementations must be updated (see `UPGRADING.md`).
+> **API Stability (pre-v1.0)**: All components are production-quality with comprehensive test coverage. The API surface is still evolving before v1.0.0. **v0.5.0 shipped:** `IssueOption` / `WithAudience` for per-call audience targeting (#124) — all six issuing methods accept `...tokens.IssueOption`; existing call sites compile unchanged. **v0.5.0 planned:** Audience-based token revocation `RevokeAllForAudience` (#135) — adds `Audience []string` to `RefreshToken` and two new methods to `RefreshStore`; custom implementations must be updated (see `UPGRADING.md`).
 
 ## Overview
 

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -236,7 +236,7 @@ type Metrics interface {
 | `jwtauth_tokens_issued_total` | Counter | status, error_type |
 | `jwtauth_tokens_validated_total` | Counter | status, error_type |
 | `jwtauth_tokens_refreshed_total` | Counter | status, error_type |
-| `jwtauth_tokens_revoked_total` | Counter | operation, status |
+| `jwtauth_tokens_revoked_total` | Counter | revocation_scope, status |
 | `jwtauth_tokens_introspected_total` | Counter | status |
 | `jwtauth_tokens_list_total` | Counter | namespace, error_type |
 | `jwtauth_tokens_list_duration_seconds` | Histogram | namespace |

--- a/doc/UPGRADING.md
+++ b/doc/UPGRADING.md
@@ -6,26 +6,62 @@ This document describes breaking changes and the mechanical steps required to up
 
 ## v0.4.x → v0.5.0
 
-v0.5.0 introduces two sets of changes to `storage.RefreshStore`. Code that only
-*calls* jwtauth is unaffected. Code that provides a custom `RefreshStore` implementation
-must add the new members or it will not compile.
+v0.5.0 introduces breaking changes to `storage.RefreshStore` and the Prometheus metric
+`jwtauth_tokens_revoked_total`. Code that only *calls* jwtauth is unaffected, except for
+Prometheus consumers that query by the renamed label. Code that provides a custom
+`RefreshStore` implementation must update the `Store()` method signature or it will not compile.
 
 ### 1. `storage.RefreshToken` — new `Audience` field
 
-A new `Audience string` field is added to `RefreshToken`. Custom serialization or
+A new `Audience []string` field is added to `RefreshToken`. Custom serialization or
 storage backends that persist `RefreshToken` structs must handle the new field.
 
 ```go
 type RefreshToken struct {
     // ... existing fields unchanged ...
-    Audience string // NEW — audience of the paired access token at issuance time
+    Audience []string // NEW — audience resolved at issuance time
 }
 ```
 
 The value is populated from the per-call `WithAudience` IssueOption when provided,
 or from the manager's configured `TokenManagerConfig.Audience` otherwise.
 
-### 2. `storage.RefreshStore` — two new revocation methods
+### 2. `storage.RefreshStore.Store()` — new `audience []string` parameter
+
+The `Store()` method gains an `audience []string` parameter:
+
+```go
+// Before
+Store(ctx context.Context, userID string, expiresAt time.Time) (*RefreshToken, error)
+
+// After
+Store(ctx context.Context, userID string, expiresAt time.Time, audience []string) (*RefreshToken, error)
+```
+
+All custom `RefreshStore` implementations must update this signature. Add a compile-time
+assertion to catch the gap early:
+
+```go
+var _ storage.RefreshStore = (*MyRefreshStore)(nil)
+```
+
+### 3. `jwtauth_tokens_revoked_total` — label `operation` renamed to `revocation_scope`
+
+The `operation` label on `jwtauth_tokens_revoked_total` is renamed to `revocation_scope`.
+Update any Prometheus alert rules, recording rules, or dashboards that filter or group
+by the old label name. Existing label values (`"single"`, `"all_user"`) are unchanged.
+
+```promql
+# Before
+jwtauth_tokens_revoked_total{operation="single"}
+
+# After
+jwtauth_tokens_revoked_total{revocation_scope="single"}
+```
+
+### 4. `storage.RefreshStore` — two new revocation methods (planned, #135)
+
+The following methods will be added in a later v0.5.0 patch. Listed here for early awareness.
 
 ```go
 // RevokeAllForAudience marks all non-expired refresh tokens targeting the given
@@ -37,16 +73,10 @@ RevokeAllForAudience(ctx context.Context, audience string) (int, error)
 RevokeAllForUserAndAudience(ctx context.Context, userID, audience string) (int, error)
 ```
 
-Add compile-time assertions to catch missed methods early:
-
-```go
-var _ storage.RefreshStore = (*MyRefreshStore)(nil)
-```
-
 ### Additive changes (no action required)
 
 `IssueOption` / `WithAudience` (#124) adds a variadic `...tokens.IssueOption` parameter
-to four issuance methods. All existing call sites compile and behave unchanged — the
+to all six issuance methods. All existing call sites compile and behave unchanged — the
 parameter is optional and defaults to the manager's configured audience.
 
 ---

--- a/doc/adr/008-reserved-claims-at-issuance.md
+++ b/doc/adr/008-reserved-claims-at-issuance.md
@@ -70,9 +70,30 @@ and does not require callers to know which claim keys are reserved.
   they will issue tokens without their intended custom claim. This is the standard
   tradeoff for reserved-key guards in extensible claim maps.
 
+## Addendum — v0.5.0 (#124)
+
+`WithAudience` has been implemented as described in the Decision section above. All six
+issuing methods now accept a variadic `...IssueOption` parameter:
+
+```go
+IssueAccessToken(ctx, userID, tokens.WithAudience("svc-payments"))
+IssueTokenPair(ctx, userID, tokens.WithAudience("svc-payments"))
+// and IssueAccessTokenWithClaims, IssueRefreshToken, IssueRefreshTokenWithClaims, IssueTokenPairWithClaims
+```
+
+`WithAudience` overrides the manager's configured audience for a single call. Passing no
+arguments to `WithAudience` is a no-op — the manager's configured audience is used.
+`RefreshAccessToken` and `RefreshAccessTokenWithClaims` propagate the stored audience
+from the refresh token record into the new access token, so the refreshed token targets
+the same audience as the original without requiring the caller to re-specify it.
+
+The negative consequence noted above — "callers who need per-call audience targeting cannot
+do so today" — is resolved.
+
 ## References
 
 - Related: ADR-005 (Security Boundaries — Attacker-Controlled Token Fields) — covers
   the validation-side gate for `aud` and other claims
 - Issue #109 — identified the missing `aud` entry in the reserved claims guard
+- Issue #124 — implemented `WithAudience` IssueOption
 - RFC 7519 §4.1 — Registered Claim Names

--- a/examples/chi-example/main.go
+++ b/examples/chi-example/main.go
@@ -94,6 +94,7 @@ func main() {
 	// Public endpoints
 	r.Post("/login", issueTokensHandler(mgr))
 	r.Post("/login/rich", issueTokensWithClaimsHandler(mgr))
+	r.Post("/login/service", issueTokensForServiceHandler(mgr))
 	r.Post("/refresh", refreshHandler(mgr))
 	r.Post("/refresh/claims", refreshWithClaimsHandler(mgr))
 
@@ -161,6 +162,45 @@ func issueTokensHandler(mgr *tokens.Manager) http.HandlerFunc {
 			AccessToken:  accessToken,
 			RefreshToken: refreshToken,
 			ExpiresIn:    900, // 15 minutes
+		})
+	}
+}
+
+// ServiceLoginRequest is the request body for service-scoped token issuance.
+type ServiceLoginRequest struct {
+	UserID  string `json:"user_id"`
+	Service string `json:"service"`
+}
+
+// issueTokensForServiceHandler issues a token pair scoped to a specific downstream
+// service — demonstrating WithAudience for per-call audience targeting.
+func issueTokensForServiceHandler(mgr *tokens.Manager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req ServiceLoginRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+
+		if req.UserID == "" || req.Service == "" {
+			http.Error(w, "user_id and service are required", http.StatusBadRequest)
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
+
+		accessToken, refreshToken, err := mgr.IssueTokenPair(ctx, req.UserID, tokens.WithAudience(req.Service))
+		if err != nil {
+			http.Error(w, "failed to issue tokens", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(TokenResponse{
+			AccessToken:  accessToken,
+			RefreshToken: refreshToken,
+			ExpiresIn:    900,
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Documentation pass for issue #124 — covers all five phases of `WithAudience` / `IssueOption` in the docs layer.

- **CHANGELOG** — adds `[Unreleased v0.5.0]` section with two breaking entries (`Store()` signature change, `tokens_revoked_total` label rename to `revocation_scope`) and three added entries (`IssueOption`/`WithAudience`, `RefreshToken.Audience`, `TokenMetadata.Audience`)
- **UPGRADING.md** — expands the v0.4.x → v0.5.0 section: documents `Store()` signature change as breaking, documents `revocation_scope` label rename with before/after PromQL examples, corrects `Audience` field type (`string` → `[]string`), fixes additive section to say all six methods (not four)
- **README.md** — updates API Stability note: #124 marked as shipped, #135 remains planned; corrects `Audience []string` type reference
- **ARCHITECTURE.md** — updates `jwtauth_tokens_revoked_total` label column from `operation, status` to `revocation_scope, status`
- **ADR-008** — adds addendum noting `WithAudience` shipped in v0.5.0 and resolves the "not supported today" negative consequence
- **chi-example** — adds `/login/service` route with `issueTokensForServiceHandler` demonstrating `WithAudience` per-call audience targeting

## Test plan

- [x] `go vet`, `golangci-lint`, `govulncheck` clean
- [x] `go build ./...` clean (includes chi-example build check)
- [x] 232 unit + 36 integration specs passing under `-race`
- [x] UPGRADING.md PromQL examples match actual label names in `prometheus.go`

**Part of #124 — Phase 6 of 6 (final)**