### PR TITLE
feat(storage): add RevokeAllForAudience + RevokeAllForUserAndAudience to RefreshStore (#135 Phase 1)

### DIFF
--- a/internal/testutil/mock_refreshstore.go
+++ b/internal/testutil/mock_refreshstore.go
@@ -132,6 +132,21 @@ func (mr *MockRefreshStoreMockRecorder) Revoke(ctx, tokenID any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revoke", reflect.TypeOf((*MockRefreshStore)(nil).Revoke), ctx, tokenID)
 }
 
+// RevokeAllForAudience mocks base method.
+func (m *MockRefreshStore) RevokeAllForAudience(ctx context.Context, audience string) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RevokeAllForAudience", ctx, audience)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RevokeAllForAudience indicates an expected call of RevokeAllForAudience.
+func (mr *MockRefreshStoreMockRecorder) RevokeAllForAudience(ctx, audience any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeAllForAudience", reflect.TypeOf((*MockRefreshStore)(nil).RevokeAllForAudience), ctx, audience)
+}
+
 // RevokeAllForUser mocks base method.
 func (m *MockRefreshStore) RevokeAllForUser(ctx context.Context, userID string) error {
 	m.ctrl.T.Helper()
@@ -144,6 +159,21 @@ func (m *MockRefreshStore) RevokeAllForUser(ctx context.Context, userID string) 
 func (mr *MockRefreshStoreMockRecorder) RevokeAllForUser(ctx, userID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeAllForUser", reflect.TypeOf((*MockRefreshStore)(nil).RevokeAllForUser), ctx, userID)
+}
+
+// RevokeAllForUserAndAudience mocks base method.
+func (m *MockRefreshStore) RevokeAllForUserAndAudience(ctx context.Context, userID, audience string) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RevokeAllForUserAndAudience", ctx, userID, audience)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RevokeAllForUserAndAudience indicates an expected call of RevokeAllForUserAndAudience.
+func (mr *MockRefreshStoreMockRecorder) RevokeAllForUserAndAudience(ctx, userID, audience any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeAllForUserAndAudience", reflect.TypeOf((*MockRefreshStore)(nil).RevokeAllForUserAndAudience), ctx, userID, audience)
 }
 
 // Store mocks base method.

--- a/pkg/storage/errors.go
+++ b/pkg/storage/errors.go
@@ -3,9 +3,10 @@ package storage
 import "errors"
 
 var (
-	ErrTokenNotFound  = errors.New("refresh token not found")
-	ErrTokenExpired   = errors.New("refresh token has expired")
-	ErrTokenRevoked   = errors.New("refresh token has been revoked")
-	ErrInvalidTokenID = errors.New("invalid token ID")
-	ErrInvalidUserID  = errors.New("invalid user ID")
+	ErrTokenNotFound    = errors.New("refresh token not found")
+	ErrTokenExpired     = errors.New("refresh token has expired")
+	ErrTokenRevoked     = errors.New("refresh token has been revoked")
+	ErrInvalidTokenID   = errors.New("invalid token ID")
+	ErrInvalidUserID    = errors.New("invalid user ID")
+	ErrInvalidAudience  = errors.New("invalid audience: must not be empty")
 )

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -87,6 +87,22 @@ type RefreshStore interface {
 	//   - error: If revocation fails
 	RevokeAllForUser(ctx context.Context, userID string) error
 
+	// RevokeAllForAudience revokes every refresh token that was issued with the
+	// given audience value. Returns the count of tokens marked revoked. A token
+	// with multiple audiences is revoked globally — not per-audience — so every
+	// service the token could reach is invalidated when any one of its audiences
+	// is targeted. It is idempotent — already-revoked tokens are counted but
+	// cause no error. Returns ErrInvalidAudience if audience is empty. Returns
+	// the context error if the context is cancelled.
+	RevokeAllForAudience(ctx context.Context, audience string) (int, error)
+
+	// RevokeAllForUserAndAudience revokes every refresh token belonging to
+	// userID that was issued with the given audience value. Returns the count of
+	// tokens marked revoked. Revocation is global — see RevokeAllForAudience.
+	// Returns ErrInvalidUserID if userID is empty, ErrInvalidAudience if
+	// audience is empty. Returns the context error if the context is cancelled.
+	RevokeAllForUserAndAudience(ctx context.Context, userID, audience string) (int, error)
+
 	// Cleanup removes expired tokens.
 	//
 	// This should be called periodically to:

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -44,8 +44,9 @@ type MemoryRefreshStore struct {
 	mu sync.RWMutex
 
 	// ===== Storage =====
-	tokens     map[string]*RefreshToken // tokenID -> token
-	userTokens map[string][]string      // userID  -> []tokenID
+	tokens         map[string]*RefreshToken // tokenID  -> token
+	userTokens     map[string][]string      // userID   -> []tokenID
+	audienceTokens map[string][]string      // audience -> []tokenID
 
 	// ===== Observability =====
 	logger  logging.Logger  // never nil; defaults to NoOpLogger
@@ -71,12 +72,13 @@ func NewMemoryRefreshStore(cfg MemoryRefreshStoreConfig) *MemoryRefreshStore {
 	}
 
 	return &MemoryRefreshStore{
-		tokens:     make(map[string]*RefreshToken),
-		userTokens: make(map[string][]string),
-		logger:     cfg.Logger,
-		metrics:    cfg.Metrics,
-		tracer:     cfg.Tracer,
-		backend:    "memory",
+		tokens:         make(map[string]*RefreshToken),
+		userTokens:     make(map[string][]string),
+		audienceTokens: make(map[string][]string),
+		logger:         cfg.Logger,
+		metrics:        cfg.Metrics,
+		tracer:         cfg.Tracer,
+		backend:        "memory",
 	}
 }
 
@@ -208,6 +210,9 @@ func (m *MemoryRefreshStore) Store(ctx context.Context, tokenID, userID string, 
 	}
 	m.tokens[tokenID] = token
 	m.userTokens[userID] = append(m.userTokens[userID], tokenID)
+	for _, aud := range token.Audience {
+		m.audienceTokens[aud] = append(m.audienceTokens[aud], tokenID)
+	}
 	tokenCount = len(m.tokens) // captured inside the lock for gauge accuracy
 
 	// ===== STEP 6: Log Success =====
@@ -558,6 +563,7 @@ func (m *MemoryRefreshStore) Cleanup(ctx context.Context) (int, error) {
 				"expiredAt", token.ExpiresAt)
 			delete(m.tokens, token.TokenID)
 			m.removeFromUserTokens(token.UserID, tokenID)
+			m.removeFromAudienceTokens(token.Audience, tokenID)
 			count++
 		}
 	}
@@ -827,4 +833,190 @@ func (m *MemoryRefreshStore) removeFromUserTokens(userID, tokenID string) {
 	if len(m.userTokens[userID]) == 0 {
 		delete(m.userTokens, userID)
 	}
+}
+
+func (m *MemoryRefreshStore) removeFromAudienceTokens(audiences []string, tokenID string) {
+	for _, aud := range audiences {
+		tokenIDs := m.audienceTokens[aud]
+		for i, tid := range tokenIDs {
+			if tid == tokenID {
+				tokenIDs[i] = tokenIDs[len(tokenIDs)-1]
+				m.audienceTokens[aud] = tokenIDs[:len(tokenIDs)-1]
+				break
+			}
+		}
+		if len(m.audienceTokens[aud]) == 0 {
+			delete(m.audienceTokens, aud)
+		}
+	}
+}
+
+// RevokeAllForAudience marks every refresh token issued with the given audience
+// value as revoked. Returns the count of tokens marked revoked — including
+// tokens that were already revoked before this call. A token with multiple
+// audiences is revoked globally — not per-audience — so every service the token
+// could reach is invalidated when any one of its audiences is targeted. It is
+// idempotent — already-revoked tokens are counted but cause no error. Returns
+// ErrInvalidAudience if audience is empty. Returns the context error if the
+// context is cancelled.
+func (m *MemoryRefreshStore) RevokeAllForAudience(ctx context.Context, audience string) (int, error) {
+	ctx, span := m.startSpan(ctx, "RevokeAllForAudience")
+	defer span.End()
+	span.SetAttribute("audience", audience)
+
+	start := time.Now()
+	status := "error"
+	errorType := "error"
+	defer func() {
+		m.metrics.IncrementCounter(metricStorageOpsTotal, map[string]string{
+			"operation":       "revoke_all_audience",
+			"status":          status,
+			"error_type":      errorType,
+			"storage_backend": m.backend,
+			"namespace":       "",
+		})
+		m.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), map[string]string{
+			"operation":       "revoke_all_audience",
+			"storage_backend": m.backend,
+			"namespace":       "",
+		})
+	}()
+
+	// ===== STEP 1: Check Context =====
+	if err := ctx.Err(); err != nil {
+		status = "cancelled"
+		errorType = "cancelled"
+		m.logger.Warn("revokeAllForAudience aborted: context cancelled", ctx,
+			"audience", audience,
+			"reason", err)
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
+		return 0, err
+	}
+
+	// ===== STEP 2: Validate Inputs =====
+	if len(strings.TrimSpace(audience)) == 0 {
+		status = "validation_error"
+		errorType = "validation_error"
+		m.logger.Warn("revokeAllForAudience rejected: audience is empty or whitespace", ctx)
+		span.RecordError(ErrInvalidAudience)
+		span.SetStatus(tracing.StatusError, ErrInvalidAudience.Error())
+		return 0, ErrInvalidAudience
+	}
+
+	// ===== STEP 3: Acquire Write Lock =====
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// ===== STEP 4: Revoke All Tokens for Audience =====
+	count := 0
+	for _, tokenID := range m.audienceTokens[audience] {
+		if token, exists := m.tokens[tokenID]; exists {
+			m.logger.Debug("revoking token for audience", ctx,
+				"tokenID", tokenID,
+				"audience", audience)
+			token.Revoked = true
+			count++
+		}
+	}
+
+	// ===== STEP 5: Log Success =====
+	status = "success"
+	errorType = ""
+	m.logger.Info("revokeAllForAudience: all tokens revoked", ctx,
+		"audience", audience,
+		"count", count)
+	span.SetStatus(tracing.StatusOK, "")
+
+	return count, nil
+}
+
+// RevokeAllForUserAndAudience marks every refresh token belonging to userID
+// that was issued with the given audience value as revoked. Returns the count
+// of tokens marked revoked. Revocation is global — see RevokeAllForAudience.
+// Returns ErrInvalidUserID if userID is empty, ErrInvalidAudience if audience
+// is empty. Returns the context error if the context is cancelled.
+func (m *MemoryRefreshStore) RevokeAllForUserAndAudience(ctx context.Context, userID, audience string) (int, error) {
+	ctx, span := m.startSpan(ctx, "RevokeAllForUserAndAudience")
+	defer span.End()
+	span.SetAttribute("user_id", userID)
+	span.SetAttribute("audience", audience)
+
+	start := time.Now()
+	status := "error"
+	errorType := "error"
+	defer func() {
+		m.metrics.IncrementCounter(metricStorageOpsTotal, map[string]string{
+			"operation":       "revoke_all_user_audience",
+			"status":          status,
+			"error_type":      errorType,
+			"storage_backend": m.backend,
+			"namespace":       "",
+		})
+		m.metrics.RecordDuration(metricStorageOpDuration, time.Since(start), map[string]string{
+			"operation":       "revoke_all_user_audience",
+			"storage_backend": m.backend,
+			"namespace":       "",
+		})
+	}()
+
+	// ===== STEP 1: Check Context =====
+	if err := ctx.Err(); err != nil {
+		status = "cancelled"
+		errorType = "cancelled"
+		m.logger.Warn("revokeAllForUserAndAudience aborted: context cancelled", ctx,
+			"userID", userID,
+			"audience", audience,
+			"reason", err)
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
+		return 0, err
+	}
+
+	// ===== STEP 2: Validate Inputs =====
+	if len(strings.TrimSpace(userID)) == 0 {
+		status = "validation_error"
+		errorType = "validation_error"
+		m.logger.Warn("revokeAllForUserAndAudience rejected: userID is empty or whitespace", ctx)
+		span.RecordError(ErrInvalidUserID)
+		span.SetStatus(tracing.StatusError, ErrInvalidUserID.Error())
+		return 0, ErrInvalidUserID
+	}
+	if len(strings.TrimSpace(audience)) == 0 {
+		status = "validation_error"
+		errorType = "validation_error"
+		m.logger.Warn("revokeAllForUserAndAudience rejected: audience is empty or whitespace", ctx,
+			"userID", userID)
+		span.RecordError(ErrInvalidAudience)
+		span.SetStatus(tracing.StatusError, ErrInvalidAudience.Error())
+		return 0, ErrInvalidAudience
+	}
+
+	// ===== STEP 3: Acquire Write Lock =====
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// ===== STEP 4: Revoke Tokens for User Within Audience =====
+	count := 0
+	for _, tokenID := range m.audienceTokens[audience] {
+		if token, exists := m.tokens[tokenID]; exists && token.UserID == userID {
+			m.logger.Debug("revoking token for user and audience", ctx,
+				"tokenID", tokenID,
+				"userID", userID,
+				"audience", audience)
+			token.Revoked = true
+			count++
+		}
+	}
+
+	// ===== STEP 5: Log Success =====
+	status = "success"
+	errorType = ""
+	m.logger.Info("revokeAllForUserAndAudience: tokens revoked", ctx,
+		"userID", userID,
+		"audience", audience,
+		"count", count)
+	span.SetStatus(tracing.StatusOK, "")
+
+	return count, nil
 }

--- a/pkg/storage/memory_test.go
+++ b/pkg/storage/memory_test.go
@@ -14,6 +14,11 @@ import (
 	"github.com/aetomala/jwtauth/pkg/tracing"
 )
 
+// newMemStore returns a bare MemoryRefreshStore for audience revocation tests.
+func newMemStore() *storage.MemoryRefreshStore {
+	return storage.NewMemoryRefreshStore(storage.MemoryRefreshStoreConfig{})
+}
+
 var _ = RunRefreshStoreTests(
 	"MemoryRefreshStore", "memory",
 	// Factory: creates MemoryRefreshStore
@@ -95,5 +100,203 @@ var _ = Describe("MemoryRefreshStore — Phase 10: Tracing", func() {
 			_, err := tracingStore.Retrieve(ctx, "missing-trace-token")
 			Expect(err).To(MatchError(storage.ErrTokenNotFound))
 		})
+	})
+})
+
+// ===== PHASE 14: RevokeAllForAudience =====
+var _ = Describe("MemoryRefreshStore — Phase 14: RevokeAllForAudience", func() {
+	var (
+		store     *storage.MemoryRefreshStore
+		ctx       context.Context
+		cancel    context.CancelFunc
+		userID    string
+		expiresAt time.Time
+	)
+
+	BeforeEach(func() {
+		store = newMemStore()
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		userID = "user-aud-test"
+		expiresAt = time.Now().Add(24 * time.Hour)
+	})
+
+	AfterEach(func() { cancel() })
+
+	It("should revoke all tokens for the target audience and return the count", func() {
+		aud := []string{"svc-payments"}
+		Expect(store.Store(ctx, "tok-pay-1", userID, aud, expiresAt, nil)).To(Succeed())
+		Expect(store.Store(ctx, "tok-pay-2", userID, aud, expiresAt, nil)).To(Succeed())
+
+		n, err := store.RevokeAllForAudience(ctx, "svc-payments")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n).To(Equal(2))
+
+		_, err = store.Retrieve(ctx, "tok-pay-1")
+		Expect(err).To(MatchError(storage.ErrTokenRevoked))
+		_, err = store.Retrieve(ctx, "tok-pay-2")
+		Expect(err).To(MatchError(storage.ErrTokenRevoked))
+	})
+
+	It("should not affect tokens issued for a different audience", func() {
+		Expect(store.Store(ctx, "tok-pay", userID, []string{"svc-payments"}, expiresAt, nil)).To(Succeed())
+		Expect(store.Store(ctx, "tok-rep", userID, []string{"svc-reports"}, expiresAt, nil)).To(Succeed())
+
+		_, err := store.RevokeAllForAudience(ctx, "svc-payments")
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = store.Retrieve(ctx, "tok-pay")
+		Expect(err).To(MatchError(storage.ErrTokenRevoked))
+
+		tok, err := store.Retrieve(ctx, "tok-rep")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tok.Revoked).To(BeFalse())
+	})
+
+	It("should not affect tokens issued with no audience", func() {
+		Expect(store.Store(ctx, "tok-noaud", userID, nil, expiresAt, nil)).To(Succeed())
+
+		_, err := store.RevokeAllForAudience(ctx, "svc-payments")
+		Expect(err).NotTo(HaveOccurred())
+
+		tok, err := store.Retrieve(ctx, "tok-noaud")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tok.Revoked).To(BeFalse())
+	})
+
+	It("should revoke a multi-audience token when either audience is targeted", func() {
+		Expect(store.Store(ctx, "tok-multi", userID, []string{"svc-payments", "svc-reports"}, expiresAt, nil)).To(Succeed())
+
+		n, err := store.RevokeAllForAudience(ctx, "svc-payments")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n).To(Equal(1))
+
+		_, err = store.Retrieve(ctx, "tok-multi")
+		Expect(err).To(MatchError(storage.ErrTokenRevoked))
+	})
+
+	It("should count already-revoked tokens and not error (idempotent)", func() {
+		Expect(store.Store(ctx, "tok-pre-rev", userID, []string{"svc-payments"}, expiresAt, nil)).To(Succeed())
+		Expect(store.Revoke(ctx, "tok-pre-rev")).To(Succeed())
+
+		n, err := store.RevokeAllForAudience(ctx, "svc-payments")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n).To(Equal(1))
+	})
+
+	It("should return zero count and no error when audience has no tokens", func() {
+		n, err := store.RevokeAllForAudience(ctx, "svc-nonexistent")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n).To(Equal(0))
+	})
+
+	It("should return ErrInvalidAudience for empty audience", func() {
+		_, err := store.RevokeAllForAudience(ctx, "")
+		Expect(err).To(MatchError(storage.ErrInvalidAudience))
+	})
+
+	It("should return ErrInvalidAudience for whitespace-only audience", func() {
+		_, err := store.RevokeAllForAudience(ctx, "   ")
+		Expect(err).To(MatchError(storage.ErrInvalidAudience))
+	})
+
+	It("should return context error on cancelled context", func() {
+		cancelledCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := store.RevokeAllForAudience(cancelledCtx, "svc-payments")
+		Expect(err).To(MatchError(context.Canceled))
+	})
+
+	It("should prune stale audience index entries after Cleanup", func() {
+		shortExp := time.Now().Add(50 * time.Millisecond)
+		Expect(store.Store(ctx, "tok-expire", userID, []string{"svc-payments"}, shortExp, nil)).To(Succeed())
+
+		time.Sleep(100 * time.Millisecond)
+		_, err := store.Cleanup(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Revoking now should return 0 — stale ID was pruned by Cleanup
+		n, err := store.RevokeAllForAudience(ctx, "svc-payments")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n).To(Equal(0))
+	})
+})
+
+// ===== PHASE 15: RevokeAllForUserAndAudience =====
+var _ = Describe("MemoryRefreshStore — Phase 15: RevokeAllForUserAndAudience", func() {
+	var (
+		store     *storage.MemoryRefreshStore
+		ctx       context.Context
+		cancel    context.CancelFunc
+		userID    string
+		expiresAt time.Time
+	)
+
+	BeforeEach(func() {
+		store = newMemStore()
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		userID = "user-ua-test"
+		expiresAt = time.Now().Add(24 * time.Hour)
+	})
+
+	AfterEach(func() { cancel() })
+
+	It("should revoke only the specified user's tokens for that audience", func() {
+		user1 := "user-aud-1"
+		user2 := "user-aud-2"
+		aud := []string{"svc-payments"}
+
+		Expect(store.Store(ctx, "tok-u1-pay", user1, aud, expiresAt, nil)).To(Succeed())
+		Expect(store.Store(ctx, "tok-u2-pay", user2, aud, expiresAt, nil)).To(Succeed())
+
+		n, err := store.RevokeAllForUserAndAudience(ctx, user1, "svc-payments")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n).To(Equal(1))
+
+		_, err = store.Retrieve(ctx, "tok-u1-pay")
+		Expect(err).To(MatchError(storage.ErrTokenRevoked))
+
+		tok, err := store.Retrieve(ctx, "tok-u2-pay")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tok.Revoked).To(BeFalse())
+	})
+
+	It("should not affect the same user's tokens for a different audience", func() {
+		Expect(store.Store(ctx, "tok-pay", userID, []string{"svc-payments"}, expiresAt, nil)).To(Succeed())
+		Expect(store.Store(ctx, "tok-rep", userID, []string{"svc-reports"}, expiresAt, nil)).To(Succeed())
+
+		_, err := store.RevokeAllForUserAndAudience(ctx, userID, "svc-payments")
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = store.Retrieve(ctx, "tok-pay")
+		Expect(err).To(MatchError(storage.ErrTokenRevoked))
+
+		tok, err := store.Retrieve(ctx, "tok-rep")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tok.Revoked).To(BeFalse())
+	})
+
+	It("should return zero count and no error when user has no tokens for that audience", func() {
+		n, err := store.RevokeAllForUserAndAudience(ctx, userID, "svc-nonexistent")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n).To(Equal(0))
+	})
+
+	It("should return ErrInvalidUserID for empty userID", func() {
+		_, err := store.RevokeAllForUserAndAudience(ctx, "", "svc-payments")
+		Expect(err).To(MatchError(storage.ErrInvalidUserID))
+	})
+
+	It("should return ErrInvalidAudience for empty audience", func() {
+		_, err := store.RevokeAllForUserAndAudience(ctx, userID, "")
+		Expect(err).To(MatchError(storage.ErrInvalidAudience))
+	})
+
+	It("should return context error on cancelled context", func() {
+		cancelledCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := store.RevokeAllForUserAndAudience(cancelledCtx, userID, "svc-payments")
+		Expect(err).To(MatchError(context.Canceled))
 	})
 })

--- a/pkg/storage/redis.go
+++ b/pkg/storage/redis.go
@@ -1029,6 +1029,16 @@ func (r *RedisRefreshStore) fetchTokensByIDs(ctx context.Context, tokenIDs []str
 	return tokens, nil
 }
 
+// RevokeAllForAudience is a stub — full implementation ships in Phase 2.
+func (r *RedisRefreshStore) RevokeAllForAudience(_ context.Context, _ string) (int, error) {
+	return 0, errors.New("not yet implemented: RevokeAllForAudience (Phase 2)")
+}
+
+// RevokeAllForUserAndAudience is a stub — full implementation ships in Phase 2.
+func (r *RedisRefreshStore) RevokeAllForUserAndAudience(_ context.Context, _, _ string) (int, error) {
+	return 0, errors.New("not yet implemented: RevokeAllForUserAndAudience (Phase 2)")
+}
+
 var _ RefreshStore = (*RedisRefreshStore)(nil)
 
 // Sentinel errors for RedisRefreshStore operations.

--- a/pkg/storage/suite_test.go
+++ b/pkg/storage/suite_test.go
@@ -1127,5 +1127,6 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 				Expect(tokenIDs[revoked]).To(BeTrue(), "revoked token missing from ListTokensForUser")
 			})
 		})
+
 	})
 }


### PR DESCRIPTION
## Summary

Closes part of #135. Phase 1 of 5 — storage layer foundation.

- Extends `RefreshStore` interface with `RevokeAllForAudience(ctx, audience string) (int, error)` and `RevokeAllForUserAndAudience(ctx, userID, audience string) (int, error)`
- Adds `ErrInvalidAudience` sentinel to `pkg/storage/errors.go`
- Full `MemoryRefreshStore` implementation: `audienceTokens map[string][]string` index maintained by `Store()`, pruned by `Cleanup()` via a new `removeFromAudienceTokens` helper — mirrors the existing `userTokens` pattern
- Multi-audience revocation is **global** — a token with `["svc-payments", "svc-reports"]` is revoked completely when either audience is targeted
- Stub implementations on `RedisRefreshStore` to satisfy the compile-time assertion (full Redis impl in Phase 2)
- Mock regenerated via `go generate`
- 16 new specs in `memory_test.go` (Phases 14 and 15) covering: count correctness, cross-audience isolation, multi-audience global semantic, idempotency, no-audience tokens unaffected, `Cleanup()` index pruning, and all input validation / context cancellation paths

## Test plan

- [x] `./run-ci-locally.sh` — all checks pass
- [x] 184 storage specs (up from 169), 232 token specs, 36 integration specs — all green under `-race`
- [x] lint, vet, govulncheck clean