### PR TITLE
feat(tokens): wire RevokeAllForAudience + RevokeAllForUserAndAudience into Manager (#135 Phase 3)

### DIFF
--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -12,7 +12,7 @@
 //   - Access token issuance (short-lived, typically 15 minutes)
 //   - Refresh token issuance and rotation (long-lived, typically 30 days)
 //   - Token validation with signature verification and claims enforcement
-//   - Instant revocation (RevokeRefreshToken, RevokeAllUserTokens)
+//   - Instant revocation (RevokeRefreshToken, RevokeAllUserTokens, RevokeAllForAudience, RevokeAllForUserAndAudience)
 //   - Token introspection per RFC 7662 (IntrospectToken)
 //   - Background cleanup of expired refresh tokens
 //   - Clock skew tolerance for distributed deployments (ClockSkew field)
@@ -2030,6 +2030,174 @@ func (m *Manager) RevokeAllUserTokens(ctx context.Context, userID string) error 
 	status = "success"
 	m.logger.Info("all refresh tokens revoked for user", ctx,
 		"userID", userID)
+	span.SetStatus(tracing.StatusOK, "")
+	return nil
+}
+
+// RevokeAllForAudience revokes every active refresh token that was issued with
+// the given audience value. Use this for service compromise scenarios — e.g., if
+// svc-payments credentials are leaked, revoke every token that can reach it.
+//
+// A token with multiple audiences is revoked globally, not per-audience — every
+// service the token could reach is invalidated when any one of its audiences is
+// targeted.
+//
+// Returns ErrManagerNotRunning, storage.ErrInvalidAudience for empty audience,
+// or the context error.
+func (m *Manager) RevokeAllForAudience(ctx context.Context, audience string) error {
+	ctx, span := m.startSpan(ctx, "RevokeAllForAudience")
+	defer span.End()
+
+	start := time.Now()
+	status := "error"
+	defer func() {
+		m.metrics.IncrementCounter(metricTokensRevokedTotal, map[string]string{
+			"revocation_scope": "audience",
+			"status":           status,
+			"namespace":        m.namespace,
+		})
+		m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
+			"operation": "revoke_all_for_audience",
+			"namespace": m.namespace,
+		})
+	}()
+
+	// ===== STEP 1: Service State Check =====
+	if !m.isRunning.Load() {
+		status = "not_running"
+		m.logger.Warn("attempted to revoke audience tokens while service stopped", ctx)
+		span.RecordError(ErrManagerNotRunning)
+		span.SetStatus(tracing.StatusError, ErrManagerNotRunning.Error())
+		return ErrManagerNotRunning
+	}
+
+	// ===== STEP 2: Context Check =====
+	if err := ctx.Err(); err != nil {
+		status = "cancelled"
+		m.logger.Info("context cancelled during audience token revocation", ctx,
+			"error", err)
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
+		return err
+	}
+
+	// ===== STEP 3: Input Validation =====
+	if audience == "" {
+		status = "invalid_input"
+		m.logger.Warn("empty audience provided for revocation", ctx)
+		span.RecordError(storage.ErrInvalidAudience)
+		span.SetStatus(tracing.StatusError, storage.ErrInvalidAudience.Error())
+		return storage.ErrInvalidAudience
+	}
+
+	span.SetAttribute("audience", audience)
+
+	// ===== STEP 4: Revoke All Tokens For Audience =====
+	// storage.ErrInvalidAudience cannot surface here — audience is validated above.
+	n, err := m.refreshStore.RevokeAllForAudience(ctx, audience)
+	if err != nil {
+		m.logger.Error("failed to revoke all audience tokens", ctx,
+			"audience", audience,
+			"error", err)
+		wrapped := fmt.Errorf("failed to revoke all audience tokens: %w", err)
+		span.RecordError(wrapped)
+		span.SetStatus(tracing.StatusError, wrapped.Error())
+		return wrapped
+	}
+
+	// ===== STEP 5: Record Success and Log =====
+	status = "success"
+	m.logger.Info("all refresh tokens revoked for audience", ctx,
+		"audience", audience, "count", n)
+	span.SetStatus(tracing.StatusOK, "")
+	return nil
+}
+
+// RevokeAllForUserAndAudience revokes every active refresh token belonging to
+// userID that was issued with the given audience value. Use this for targeted
+// revocation — e.g., revoking one user's access to a specific service without
+// affecting other users or the user's tokens for other services.
+//
+// Revocation is global — a token with multiple audiences is revoked completely,
+// not just for the targeted audience. See RevokeAllForAudience for details.
+//
+// Returns ErrManagerNotRunning, ErrInvalidUserID for empty userID,
+// storage.ErrInvalidAudience for empty audience, or the context error.
+func (m *Manager) RevokeAllForUserAndAudience(ctx context.Context, userID, audience string) error {
+	ctx, span := m.startSpan(ctx, "RevokeAllForUserAndAudience")
+	defer span.End()
+
+	start := time.Now()
+	status := "error"
+	defer func() {
+		m.metrics.IncrementCounter(metricTokensRevokedTotal, map[string]string{
+			"revocation_scope": "user_audience",
+			"status":           status,
+			"namespace":        m.namespace,
+		})
+		m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
+			"operation": "revoke_all_for_user_and_audience",
+			"namespace": m.namespace,
+		})
+	}()
+
+	// ===== STEP 1: Service State Check =====
+	if !m.isRunning.Load() {
+		status = "not_running"
+		m.logger.Warn("attempted to revoke user+audience tokens while service stopped", ctx)
+		span.RecordError(ErrManagerNotRunning)
+		span.SetStatus(tracing.StatusError, ErrManagerNotRunning.Error())
+		return ErrManagerNotRunning
+	}
+
+	// ===== STEP 2: Context Check =====
+	if err := ctx.Err(); err != nil {
+		status = "cancelled"
+		m.logger.Info("context cancelled during user+audience token revocation", ctx,
+			"error", err)
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
+		return err
+	}
+
+	// ===== STEP 3: Input Validation =====
+	if userID == "" {
+		status = "invalid_input"
+		m.logger.Warn("empty user ID provided for user+audience revocation", ctx)
+		span.RecordError(ErrInvalidUserID)
+		span.SetStatus(tracing.StatusError, ErrInvalidUserID.Error())
+		return ErrInvalidUserID
+	}
+	if audience == "" {
+		status = "invalid_input"
+		m.logger.Warn("empty audience provided for user+audience revocation", ctx)
+		span.RecordError(storage.ErrInvalidAudience)
+		span.SetStatus(tracing.StatusError, storage.ErrInvalidAudience.Error())
+		return storage.ErrInvalidAudience
+	}
+
+	span.SetAttribute("user_id", userID)
+	span.SetAttribute("audience", audience)
+
+	// ===== STEP 4: Revoke All Tokens For User and Audience =====
+	// storage.ErrInvalidUserID and storage.ErrInvalidAudience cannot surface here —
+	// both inputs are validated above before this call.
+	n, err := m.refreshStore.RevokeAllForUserAndAudience(ctx, userID, audience)
+	if err != nil {
+		m.logger.Error("failed to revoke all user+audience tokens", ctx,
+			"userID", userID,
+			"audience", audience,
+			"error", err)
+		wrapped := fmt.Errorf("failed to revoke all user+audience tokens: %w", err)
+		span.RecordError(wrapped)
+		span.SetStatus(tracing.StatusError, wrapped.Error())
+		return wrapped
+	}
+
+	// ===== STEP 5: Record Success and Log =====
+	status = "success"
+	m.logger.Info("all refresh tokens revoked for user and audience", ctx,
+		"userID", userID, "audience", audience, "count", n)
 	span.SetStatus(tracing.StatusOK, "")
 	return nil
 }

--- a/pkg/tokens/manager_test.go
+++ b/pkg/tokens/manager_test.go
@@ -1587,6 +1587,133 @@ var _ = Describe("TokenManager", func() {
 		})
 	})
 
+	// ==========================
+	// AUDIENCE TOKEN REVOCATION
+	// ==========================
+
+	Describe("RevokeAllForAudience", func() {
+		BeforeEach(func() {
+			service = newTestManager(mockKM, mockStore, mockLogger)
+
+			mockKM.EXPECT().Start(gomock.Any()).Return(nil)
+			mockStore.EXPECT().Cleanup(gomock.Any()).Return(0, nil).AnyTimes()
+			err := service.Start(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should revoke all tokens for audience", func() {
+			mockStore.EXPECT().
+				RevokeAllForAudience(gomock.Any(), "svc-payments").
+				Return(3, nil).
+				Times(1)
+
+			err := service.RevokeAllForAudience(ctx, "svc-payments")
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should log bulk audience revocation", func() {
+			mockStore.EXPECT().RevokeAllForAudience(gomock.Any(), gomock.Any()).Return(3, nil)
+
+			service.RevokeAllForAudience(ctx, "svc-payments")
+
+			Eventually(func() bool {
+				return mockLogger.HasLog("info", "all refresh tokens revoked for audience")
+			}).Should(BeTrue())
+		})
+
+		It("should return wrapped error when store fails", func() {
+			mockStore.EXPECT().RevokeAllForAudience(gomock.Any(), "svc-payments").Return(0, errors.New("db error"))
+			err := service.RevokeAllForAudience(ctx, "svc-payments")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("db error"))
+		})
+
+		Context("guard conditions", func() {
+			It("should return ErrManagerNotRunning when manager is not running", func() {
+				mgr := newTestManager(mockKM, mockStore, mockLogger)
+				err := mgr.RevokeAllForAudience(ctx, "svc-payments")
+				Expect(err).To(Equal(tokens.ErrManagerNotRunning))
+			})
+
+			It("should return context error when context is cancelled", func() {
+				cancelledCtx, cancel := context.WithCancel(ctx)
+				cancel()
+				err := service.RevokeAllForAudience(cancelledCtx, "svc-payments")
+				Expect(err).To(Equal(context.Canceled))
+			})
+
+			It("should return ErrInvalidAudience for empty audience", func() {
+				err := service.RevokeAllForAudience(ctx, "")
+				Expect(err).To(Equal(storage.ErrInvalidAudience))
+			})
+		})
+	})
+
+	Describe("RevokeAllForUserAndAudience", func() {
+		BeforeEach(func() {
+			service = newTestManager(mockKM, mockStore, mockLogger)
+
+			mockKM.EXPECT().Start(gomock.Any()).Return(nil)
+			mockStore.EXPECT().Cleanup(gomock.Any()).Return(0, nil).AnyTimes()
+			err := service.Start(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should revoke all tokens for user and audience", func() {
+			mockStore.EXPECT().
+				RevokeAllForUserAndAudience(gomock.Any(), testUserID, "svc-payments").
+				Return(2, nil).
+				Times(1)
+
+			err := service.RevokeAllForUserAndAudience(ctx, testUserID, "svc-payments")
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should log user+audience revocation", func() {
+			mockStore.EXPECT().RevokeAllForUserAndAudience(gomock.Any(), gomock.Any(), gomock.Any()).Return(2, nil)
+
+			service.RevokeAllForUserAndAudience(ctx, testUserID, "svc-payments")
+
+			Eventually(func() bool {
+				return mockLogger.HasLog("info", "all refresh tokens revoked for user and audience")
+			}).Should(BeTrue())
+		})
+
+		It("should return wrapped error when store fails", func() {
+			mockStore.EXPECT().RevokeAllForUserAndAudience(gomock.Any(), testUserID, "svc-payments").Return(0, errors.New("db error"))
+			err := service.RevokeAllForUserAndAudience(ctx, testUserID, "svc-payments")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("db error"))
+		})
+
+		Context("guard conditions", func() {
+			It("should return ErrManagerNotRunning when manager is not running", func() {
+				mgr := newTestManager(mockKM, mockStore, mockLogger)
+				err := mgr.RevokeAllForUserAndAudience(ctx, testUserID, "svc-payments")
+				Expect(err).To(Equal(tokens.ErrManagerNotRunning))
+			})
+
+			It("should return context error when context is cancelled", func() {
+				cancelledCtx, cancel := context.WithCancel(ctx)
+				cancel()
+				err := service.RevokeAllForUserAndAudience(cancelledCtx, testUserID, "svc-payments")
+				Expect(err).To(Equal(context.Canceled))
+			})
+
+			It("should return ErrInvalidUserID for empty userID", func() {
+				err := service.RevokeAllForUserAndAudience(ctx, "", "svc-payments")
+				Expect(err).To(Equal(tokens.ErrInvalidUserID))
+			})
+
+			It("should return ErrInvalidAudience for empty audience", func() {
+				err := service.RevokeAllForUserAndAudience(ctx, testUserID, "")
+				Expect(err).To(Equal(storage.ErrInvalidAudience))
+			})
+		})
+	})
+
 	// ==================
 	// TOKEN INTROSPECTION
 	// ===================


### PR DESCRIPTION
## Summary

- Adds `RevokeAllForAudience(ctx context.Context, audience string) error` and `RevokeAllForUserAndAudience(ctx context.Context, userID, audience string) error` to `tokens.Manager`
- Both methods follow the `RevokeAllUserTokens` template exactly — span, deferred metrics with `revocation_scope: "audience"` / `"user_audience"`, service-state check, context check, input validation, storage delegation, success log with count
- Empty audience returns `storage.ErrInvalidAudience` (semantically distinct from the tokens-pkg `ErrInvalidAudience`, which covers aud-mismatch during token validation)
- Storage-layer revocation count is used only for the log line; manager methods return `error` only

## Test plan

- [x] `RevokeAllForAudience` — success path, log verification, storage error wrapping, guard conditions (not running, cancelled ctx, empty audience)
- [x] `RevokeAllForUserAndAudience` — success path, log verification, storage error wrapping, guard conditions (not running, cancelled ctx, empty userID, empty audience)
- [x] All 245 token unit specs + 200 storage specs + 36 integration specs green under `-race`
- [x] golangci-lint, govulncheck, go vet clean

## Phase context

Part of [#135](https://github.com/aetomala/jwtauth/issues/135) — `RevokeAllForAudience` + `RevokeAllForUserAndAudience`. Depends on Phase 2 (#154, merged).

| Phase | Description | Status |
|---|---|---|
| 1 | RefreshStore interface + MemoryStore + mock regen | Done (#153) |
| 2 | RedisStore implementation | Done (#154) |
| **3** | **tokens.Manager wiring + observability** | **This PR** |
| 4 | Integration tests | Next |
| 5 | Docs | Pending |