### PR TITLE
docs: document audience-scoped revocation for v0.5.0 (#135 Phase 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to this project will be documented in this file.
 
 - **`storage.RefreshStore.Store()` gains `audience []string` parameter** — all custom `RefreshStore` implementations must update their `Store()` method signature. `MemoryRefreshStore` and `RedisRefreshStore` are already updated. Add a compile-time assertion to catch the gap early: `var _ storage.RefreshStore = (*MyStore)(nil)`. See #124 and `UPGRADING.md`.
 
+- **`storage.RefreshStore` gains `RevokeAllForAudience` and `RevokeAllForUserAndAudience`** — all custom `RefreshStore` implementations must add both methods or they will not compile. `MemoryRefreshStore` and `RedisRefreshStore` are already updated. See #135 and `UPGRADING.md`.
+
 - **`jwtauth_tokens_revoked_total` label `operation` renamed to `revocation_scope`** — update any Prometheus alert rules, recording rules, or dashboards that filter or group by the old label name. Existing label values (`"single"`, `"all_user"`) are unchanged. See #124.
 
 ### Added
@@ -25,6 +27,12 @@ All notable changes to this project will be documented in this file.
 - **`RefreshToken.Audience []string`** — the stored refresh token record now carries the audience slice resolved at issuance time. `RefreshAccessToken` and `RefreshAccessTokenWithClaims` propagate this stored audience into the new access token so the refreshed token targets the same audience as the original. See #124.
 
 - **`TokenMetadata.Audience []string`** — `IntrospectToken` now populates the `Audience` field on active, revoked, and expired paths. The not-found path leaves the field nil. See #124.
+
+- **`tokens.Manager.RevokeAllForAudience(ctx, audience) error`** — revokes all non-expired refresh tokens targeting the given audience across all users. Multi-audience tokens are revoked globally — a token carrying the targeted audience is fully revoked regardless of its other audiences. Emits `revocation_scope="audience"` on `jwtauth_tokens_revoked_total`. See #135.
+
+- **`tokens.Manager.RevokeAllForUserAndAudience(ctx, userID, audience) error`** — revokes all non-expired refresh tokens for a specific user and audience. Tokens for other users in the same audience are not affected. Emits `revocation_scope="user_audience"`. See #135.
+
+- **`storage.ErrInvalidAudience`** — sentinel returned when an empty string is passed as the audience argument to the new revocation methods. See #135.
 
 ---
 

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -410,6 +410,44 @@ See `examples/token-audit/` for a runnable reference.
 
 ---
 
+## Audience-Scoped Revocation
+
+`RevokeAllForAudience` and `RevokeAllForUserAndAudience` on `tokens.Manager` mark all
+non-expired refresh tokens scoped to a given audience as revoked. The primary use case is
+instant containment after a service-side credential compromise — for example, revoking every
+token that can reach `svc-payments` without touching tokens issued for unrelated services.
+
+```go
+// Revoke all tokens for all users that can reach svc-payments.
+if err := mgr.RevokeAllForAudience(ctx, "svc-payments"); err != nil {
+    return err
+}
+
+// Revoke only tokens for a specific user in the svc-payments audience.
+if err := mgr.RevokeAllForUserAndAudience(ctx, userID, "svc-payments"); err != nil {
+    return err
+}
+```
+
+**Revocation is global for multi-audience tokens.** A token issued with
+`WithAudience("svc-payments", "svc-reports")` is revoked completely when either audience is
+targeted — the token is not partially invalidated. Callers should treat every token that
+carries the targeted audience as fully revoked, regardless of its other audiences.
+
+**Empty audience strings** are rejected with `storage.ErrInvalidAudience` before any storage
+operation is attempted.
+
+**Index maintenance** — both `MemoryRefreshStore` and `RedisRefreshStore` maintain an
+audience index that is pruned by `CleanupExpiredTokens`. Stale entries from expired tokens
+do not accumulate indefinitely. Issuing a fresh token after cleanup restores the index
+correctly, so subsequent revocations target only live tokens.
+
+**Revocation scope metric** — both operations emit `revocation_scope` labels (`"audience"`
+and `"user_audience"`) on the `jwtauth_tokens_revoked_total` counter, consistent with the
+existing `"single"` and `"all_user"` scopes.
+
+---
+
 ## Reserved Claims
 
 The fields `sub`, `iss`, `aud`, `exp`, `nbf`, `iat`, and `jti` are silently removed from any

--- a/doc/UPGRADING.md
+++ b/doc/UPGRADING.md
@@ -59,25 +59,42 @@ jwtauth_tokens_revoked_total{operation="single"}
 jwtauth_tokens_revoked_total{revocation_scope="single"}
 ```
 
-### 4. `storage.RefreshStore` — two new revocation methods (planned, #135)
+### 4. `storage.RefreshStore` — two new revocation methods (#135)
 
-The following methods will be added in a later v0.5.0 patch. Listed here for early awareness.
+Two new methods are added to the `RefreshStore` interface:
 
 ```go
-// RevokeAllForAudience marks all non-expired refresh tokens targeting the given
-// audience as revoked. Returns the count of tokens revoked.
 RevokeAllForAudience(ctx context.Context, audience string) (int, error)
-
-// RevokeAllForUserAndAudience marks all refresh tokens for the given user and
-// audience as revoked. Returns the count of tokens revoked.
 RevokeAllForUserAndAudience(ctx context.Context, userID, audience string) (int, error)
 ```
+
+`MemoryRefreshStore` and `RedisRefreshStore` are already updated. All custom `RefreshStore`
+implementations must add both methods or they will not compile. Add a compile-time assertion
+to catch the gap early:
+
+```go
+var _ storage.RefreshStore = (*MyRefreshStore)(nil)
+```
+
+`tokens.Manager` exposes audience-scoped revocation at the manager level — callers use
+`mgr.RevokeAllForAudience` and `mgr.RevokeAllForUserAndAudience` directly. Both manager
+methods return `error` only; the storage-layer count is used internally for logging.
+
+**Multi-audience revocation is global.** A token issued with `WithAudience("svc-payments",
+"svc-reports")` is revoked completely when either audience is targeted — not partially. See
+[Audience-Scoped Revocation](../doc/DEPLOYMENT.md#audience-scoped-revocation) in
+`DEPLOYMENT.md` for the full semantic and use cases.
 
 ### Additive changes (no action required)
 
 `IssueOption` / `WithAudience` (#124) adds a variadic `...tokens.IssueOption` parameter
 to all six issuance methods. All existing call sites compile and behave unchanged — the
 parameter is optional and defaults to the manager's configured audience.
+
+`storage.ErrInvalidAudience` is a new sentinel returned when an empty string is passed to
+`RevokeAllForAudience` or `RevokeAllForUserAndAudience`. Code that only calls these methods
+via `tokens.Manager` does not need to import `storage` — the error is not wrapped and can
+be compared directly with `errors.Is`.
 
 ---
 


### PR DESCRIPTION
## Summary

- **DEPLOYMENT.md** — new "Audience-Scoped Revocation" section covering `RevokeAllForAudience`, `RevokeAllForUserAndAudience`, the global multi-audience revocation semantic (fully revoked when any audience is targeted), `ErrInvalidAudience`, index maintenance / cleanup correctness, and `revocation_scope` metric labels
- **UPGRADING.md** — replaces the "planned, #135" stub (section 4) with a full migration guide; adds `ErrInvalidAudience` to the additive changes list with a note that callers using `tokens.Manager` do not need to import `storage`
- **CHANGELOG.md** — breaking entry for two new `RefreshStore` interface methods; `### Added` entries for both `tokens.Manager` methods and `storage.ErrInvalidAudience`

## Part of

Issue #135 — Phase 5 of 5. Phases 1–4 are merged.

## Test plan

- [ ] Build passes (`go build ./...`)
- [ ] No code changes — documentation only
- [ ] UPGRADING.md stub removed; no "planned" language remains
- [ ] DEPLOYMENT.md section cross-links correctly to `#audience-scoped-revocation` anchor