### PR TITLE
feat(storage): add ListTokensForAudience to RefreshStore interface and MemoryRefreshStore (#143 Phase 1)

### DIFF
--- a/internal/testutil/mock_refreshstore.go
+++ b/internal/testutil/mock_refreshstore.go
@@ -73,6 +73,22 @@ func (mr *MockRefreshStoreMockRecorder) ListTokens(ctx, cursor, count any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTokens", reflect.TypeOf((*MockRefreshStore)(nil).ListTokens), ctx, cursor, count)
 }
 
+// ListTokensForAudience mocks base method.
+func (m *MockRefreshStore) ListTokensForAudience(ctx context.Context, audience, cursor string, count int) ([]*storage.RefreshToken, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTokensForAudience", ctx, audience, cursor, count)
+	ret0, _ := ret[0].([]*storage.RefreshToken)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ListTokensForAudience indicates an expected call of ListTokensForAudience.
+func (mr *MockRefreshStoreMockRecorder) ListTokensForAudience(ctx, audience, cursor, count any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTokensForAudience", reflect.TypeOf((*MockRefreshStore)(nil).ListTokensForAudience), ctx, audience, cursor, count)
+}
+
 // ListTokensForUser mocks base method.
 func (m *MockRefreshStore) ListTokensForUser(ctx context.Context, userID, cursor string, count int) ([]*storage.RefreshToken, string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -167,6 +167,15 @@ func (pm *PrometheusMetrics) registerAllMetrics(namespace string) {
 		[]string{"storage_backend", "namespace"},
 		[]float64{.0001, .0005, .001, .0025, .005, .01, .025, .05, .1, .25})
 
+	pm.registerCounter(namespace, "storage_list_tokens_for_audience_total",
+		"Total number of list-tokens-for-audience operations",
+		[]string{"storage_backend", "namespace", "error_type"})
+
+	pm.registerHistogram(namespace, "storage_list_tokens_for_audience_duration_seconds",
+		"Duration of list-tokens-for-audience operations in seconds",
+		[]string{"storage_backend", "namespace"},
+		[]float64{.0001, .0005, .001, .0025, .005, .01, .025, .05, .1, .25})
+
 	// ===== KeyStore Metrics =====
 
 	pm.registerCounter(namespace, "keystore_operations_total",

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -144,6 +144,22 @@ type RefreshStore interface {
 	// userID is empty. Returns the context error if the context is cancelled.
 	ListTokensForUser(ctx context.Context, userID string, cursor string, count int) ([]*RefreshToken, string, error)
 
+	// ListTokensForAudience returns a page of refresh tokens that were issued
+	// with the given audience value, starting from cursor. Pass an empty string
+	// for cursor to begin from the start. Returns the next cursor and a nil
+	// error on success. Returns an empty next cursor when iteration is
+	// exhausted. Count is a hint — actual page size may vary.
+	//
+	// All tokens are returned regardless of revocation or expiry status — the
+	// caller is responsible for filtering. A token issued with multiple
+	// audiences appears in the listing for each of its audience values —
+	// callers enumerating across multiple audiences should de-duplicate.
+	//
+	// Cursor semantics are best-effort and share the same guarantees as
+	// ListTokens. Returns ErrInvalidAudience if audience is empty. Returns the
+	// context error if the context is cancelled.
+	ListTokensForAudience(ctx context.Context, audience string, cursor string, count int) ([]*RefreshToken, string, error)
+
 	// Namespace returns the namespace this store is operating in. For Redis-backed
 	// stores this matches the configured KeyPrefix. Implementations that do not
 	// support namespacing return empty string.

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -816,6 +816,133 @@ func (m *MemoryRefreshStore) ListTokensForUser(ctx context.Context, userID strin
 	return tokens, nextCursor, nil
 }
 
+// ListTokensForAudience returns a page of refresh tokens that were issued with
+// the given audience value, starting from cursor. Pass an empty string for
+// cursor to begin from the start. Returns the next cursor and a nil error on
+// success. Returns an empty next cursor when iteration is exhausted.
+//
+// All tokens are returned regardless of revocation or expiry status — the
+// caller is responsible for filtering. A token issued with multiple audiences
+// appears in the listing for each of its audience values. The cursor is an
+// integer offset into the stable insertion-order slice for audience —
+// best-effort when tokens are added or removed between pages. Returns
+// ErrInvalidAudience if audience is empty. Returns the context error if the
+// context is cancelled.
+func (m *MemoryRefreshStore) ListTokensForAudience(ctx context.Context, audience string, cursor string, count int) ([]*RefreshToken, string, error) {
+	ctx, span := m.startSpan(ctx, "ListTokensForAudience")
+	defer span.End()
+	span.SetAttribute("storage.audience", audience)
+	span.SetAttribute("storage.cursor", cursor)
+	span.SetAttribute("storage.count", count)
+
+	start := time.Now()
+	errorType := "error"
+	resultCount := 0
+	defer func() {
+		m.metrics.IncrementCounter(metricListTokensForAudienceTotal, map[string]string{
+			"storage_backend": m.backend,
+			"namespace":       "",
+			"error_type":      errorType,
+		})
+		m.metrics.RecordDuration(metricListTokensForAudienceDuration, time.Since(start), map[string]string{
+			"storage_backend": m.backend,
+			"namespace":       "",
+		})
+	}()
+
+	// ===== STEP 1: Check Context =====
+	if err := ctx.Err(); err != nil {
+		errorType = "cancelled"
+		m.logger.Warn("listTokensForAudience aborted: context cancelled", ctx, "reason", err)
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
+		return nil, "", err
+	}
+
+	// ===== STEP 2: Validate Inputs =====
+	if len(strings.TrimSpace(audience)) == 0 {
+		errorType = "validation_error"
+		m.logger.Warn("listTokensForAudience rejected: audience is empty or whitespace", ctx)
+		span.RecordError(ErrInvalidAudience)
+		span.SetStatus(tracing.StatusError, ErrInvalidAudience.Error())
+		return nil, "", ErrInvalidAudience
+	}
+
+	// ===== STEP 3: Acquire Read Lock =====
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	// ===== STEP 4: Parse Cursor as Integer Offset =====
+	offset := 0
+	if cursor != "" {
+		if parsed, err := strconv.Atoi(cursor); err == nil && parsed > 0 {
+			offset = parsed
+		}
+	}
+
+	// ===== STEP 5: Build Page from Audience's Token Slice =====
+	tokenIDs := m.audienceTokens[audience]
+	if offset >= len(tokenIDs) {
+		errorType = ""
+		span.SetStatus(tracing.StatusOK, "")
+		m.logger.Info("listTokensForAudience: page returned", ctx,
+			"audience", audience,
+			"result_count", 0,
+			"next_cursor", "")
+		return nil, "", nil
+	}
+
+	end := offset + count
+	if count <= 0 || end > len(tokenIDs) {
+		end = len(tokenIDs)
+	}
+	page := tokenIDs[offset:end]
+
+	tokens := make([]*RefreshToken, 0, len(page))
+	for _, id := range page {
+		t, ok := m.tokens[id]
+		if !ok {
+			continue
+		}
+		cp := &RefreshToken{
+			TokenID:   t.TokenID,
+			UserID:    t.UserID,
+			ExpiresAt: t.ExpiresAt,
+			CreatedAt: t.CreatedAt,
+			Revoked:   t.Revoked,
+		}
+		if len(t.Audience) > 0 {
+			cp.Audience = make([]string, len(t.Audience))
+			copy(cp.Audience, t.Audience)
+		}
+		if t.Metadata != nil {
+			cp.Metadata = make(map[string]interface{}, len(t.Metadata))
+			for k, v := range t.Metadata {
+				cp.Metadata[k] = v
+			}
+		}
+		tokens = append(tokens, cp)
+	}
+
+	// ===== STEP 6: Compute Next Cursor =====
+	nextCursor := ""
+	if end < len(tokenIDs) {
+		nextCursor = strconv.Itoa(end)
+	}
+
+	// ===== STEP 7: Log and Return =====
+	errorType = ""
+	resultCount = len(tokens)
+	span.SetAttribute("storage.result_count", resultCount)
+	span.SetStatus(tracing.StatusOK, "")
+	m.logger.Info("listTokensForAudience: page returned", ctx,
+		"audience", audience,
+		"result_count", resultCount,
+		"next_cursor", nextCursor)
+
+	return tokens, nextCursor, nil
+}
+
 func (m *MemoryRefreshStore) removeFromUserTokens(userID, tokenID string) {
 	tokenIDs := m.userTokens[userID]
 

--- a/pkg/storage/memory_test.go
+++ b/pkg/storage/memory_test.go
@@ -2,6 +2,7 @@ package storage_test
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -50,6 +51,160 @@ var _ = Describe("MemoryRefreshStore — Constructor", func() {
 		tokenID := "tracer-token"
 		userID := "tracer-user"
 		Expect(store.Store(ctx, tokenID, userID, nil, time.Now().Add(time.Hour), nil)).To(Succeed())
+	})
+})
+
+// PHASE 16: ListTokensForAudience — Memory-only specs.
+//
+// These specs cover the MemoryRefreshStore implementation. The shared suite
+// (suite_test.go Phase 16) is promoted here once the Redis implementation
+// ships in Phase 2.
+var _ = Describe("MemoryRefreshStore — Phase 16: ListTokensForAudience", func() {
+	var (
+		store     *storage.MemoryRefreshStore
+		ctx       context.Context
+		expiresAt time.Time
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		expiresAt = time.Now().Add(24 * time.Hour)
+		store = storage.NewMemoryRefreshStore(storage.MemoryRefreshStoreConfig{})
+	})
+
+	It("should return empty result for an audience with no tokens", func() {
+		tokens, next, err := store.ListTokensForAudience(ctx, "svc-ghost", "", 10)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tokens).To(BeEmpty())
+		Expect(next).To(BeEmpty())
+	})
+
+	It("should return all tokens for an audience in a single page", func() {
+		aud := "svc-payments-single"
+		ids := []string{"aud-tok-a", "aud-tok-b", "aud-tok-c"}
+		for _, id := range ids {
+			Expect(store.Store(ctx, id, "user-aud", []string{aud}, expiresAt, nil)).To(Succeed())
+		}
+
+		tokens, next, err := store.ListTokensForAudience(ctx, aud, "", 100)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(next).To(BeEmpty())
+		got := make(map[string]bool)
+		for _, t := range tokens {
+			got[t.TokenID] = true
+		}
+		for _, id := range ids {
+			Expect(got[id]).To(BeTrue(), "expected token %s in result", id)
+		}
+	})
+
+	It("should paginate across multiple pages and exhaust the set", func() {
+		aud := "svc-paginate-aud"
+		total := 7
+		for i := 0; i < total; i++ {
+			Expect(store.Store(ctx, fmt.Sprintf("aud-page-tok-%d", i), "user-p", []string{aud}, expiresAt, nil)).To(Succeed())
+		}
+
+		var all []*storage.RefreshToken
+		cursor := ""
+		for {
+			page, next, err := store.ListTokensForAudience(ctx, aud, cursor, 3)
+			Expect(err).NotTo(HaveOccurred())
+			all = append(all, page...)
+			cursor = next
+			if cursor == "" {
+				break
+			}
+		}
+		Expect(all).To(HaveLen(total))
+	})
+
+	It("should not include tokens from a different audience", func() {
+		audA := "svc-iso-aud-a"
+		audB := "svc-iso-aud-b"
+		Expect(store.Store(ctx, "aud-iso-tok-a1", "user-ia", []string{audA}, expiresAt, nil)).To(Succeed())
+		Expect(store.Store(ctx, "aud-iso-tok-a2", "user-ia", []string{audA}, expiresAt, nil)).To(Succeed())
+		Expect(store.Store(ctx, "aud-iso-tok-b1", "user-ib", []string{audB}, expiresAt, nil)).To(Succeed())
+
+		tokensA, _, err := store.ListTokensForAudience(ctx, audA, "", 100)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tokensA).To(HaveLen(2))
+		for _, t := range tokensA {
+			Expect(t.Audience).To(ContainElement(audA))
+		}
+
+		tokensB, _, err := store.ListTokensForAudience(ctx, audB, "", 100)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tokensB).To(HaveLen(1))
+		Expect(tokensB[0].TokenID).To(Equal("aud-iso-tok-b1"))
+	})
+
+	It("should return ErrInvalidAudience for empty audience", func() {
+		_, _, err := store.ListTokensForAudience(ctx, "", "", 10)
+		Expect(err).To(MatchError(storage.ErrInvalidAudience))
+	})
+
+	It("should return empty next cursor when iteration is exhausted", func() {
+		aud := "svc-exhaust-aud"
+		Expect(store.Store(ctx, "aud-exhaust-1", "user-e", []string{aud}, expiresAt, nil)).To(Succeed())
+		Expect(store.Store(ctx, "aud-exhaust-2", "user-e", []string{aud}, expiresAt, nil)).To(Succeed())
+
+		_, finalCursor, err := store.ListTokensForAudience(ctx, aud, "", 100)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(finalCursor).To(BeEmpty())
+	})
+
+	It("should return context error on cancelled context", func() {
+		cancelledCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, _, err := store.ListTokensForAudience(cancelledCtx, "svc-payments", "", 10)
+		Expect(err).To(MatchError(context.Canceled))
+	})
+
+	It("should return revoked and active tokens for the audience", func() {
+		aud := "svc-mixed-aud"
+		active := "aud-tok-active"
+		revoked := "aud-tok-revoked"
+
+		Expect(store.Store(ctx, active, "user-m", []string{aud}, expiresAt, nil)).To(Succeed())
+		Expect(store.Store(ctx, revoked, "user-m", []string{aud}, expiresAt, nil)).To(Succeed())
+		Expect(store.Revoke(ctx, revoked)).To(Succeed())
+
+		var all []*storage.RefreshToken
+		cursor := ""
+		for {
+			page, next, err := store.ListTokensForAudience(ctx, aud, cursor, 100)
+			Expect(err).NotTo(HaveOccurred())
+			all = append(all, page...)
+			cursor = next
+			if cursor == "" {
+				break
+			}
+		}
+
+		tokenIDs := map[string]bool{}
+		for _, t := range all {
+			tokenIDs[t.TokenID] = true
+		}
+		Expect(tokenIDs[active]).To(BeTrue(), "active token missing from ListTokensForAudience")
+		Expect(tokenIDs[revoked]).To(BeTrue(), "revoked token missing from ListTokensForAudience")
+	})
+
+	It("should return a multi-audience token in listings for each of its audiences", func() {
+		audA := "svc-multi-a"
+		audB := "svc-multi-b"
+		Expect(store.Store(ctx, "aud-multi-tok", "user-multi", []string{audA, audB}, expiresAt, nil)).To(Succeed())
+
+		tokensA, _, err := store.ListTokensForAudience(ctx, audA, "", 100)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tokensA).To(HaveLen(1))
+		Expect(tokensA[0].TokenID).To(Equal("aud-multi-tok"))
+
+		tokensB, _, err := store.ListTokensForAudience(ctx, audB, "", 100)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tokensB).To(HaveLen(1))
+		Expect(tokensB[0].TokenID).To(Equal("aud-multi-tok"))
 	})
 })
 

--- a/pkg/storage/observability.go
+++ b/pkg/storage/observability.go
@@ -14,4 +14,7 @@ const (
 
 	metricListTokensForUserTotal    = "jwtauth_storage_list_tokens_for_user_total"
 	metricListTokensForUserDuration = "jwtauth_storage_list_tokens_for_user_duration_seconds"
+
+	metricListTokensForAudienceTotal    = "jwtauth_storage_list_tokens_for_audience_total"
+	metricListTokensForAudienceDuration = "jwtauth_storage_list_tokens_for_audience_duration_seconds"
 )

--- a/pkg/storage/redis.go
+++ b/pkg/storage/redis.go
@@ -1265,6 +1265,10 @@ func (r *RedisRefreshStore) RevokeAllForUserAndAudience(ctx context.Context, use
 	return count, nil
 }
 
+func (r *RedisRefreshStore) ListTokensForAudience(_ context.Context, _ string, _ string, _ int) ([]*RefreshToken, string, error) {
+	return nil, "", errors.New("not implemented")
+}
+
 var _ RefreshStore = (*RedisRefreshStore)(nil)
 
 // Sentinel errors for RedisRefreshStore operations.


### PR DESCRIPTION
## What

Adds `ListTokensForAudience` as the first step of issue #143. Phase 1 covers the `RefreshStore` interface, `MemoryRefreshStore` implementation, mock regen, and memory-only unit specs.

## Changes

- `pkg/storage/interface.go` — `ListTokensForAudience(ctx, audience, cursor, count)` added after `ListTokensForUser`; doc comment calls out the multi-audience visibility property and `ErrInvalidAudience` contract
- `pkg/storage/memory.go` — full implementation mirroring `ListTokensForUser`: integer-offset cursor over `audienceTokens[aud]` slice, defensive copies of `Audience` and `Metadata`, span attrs (`storage.audience`, `storage.cursor`, `storage.count`, `storage.result_count`), deferred metrics, structured Info/Warn logs
- `pkg/storage/observability.go` — `metricListTokensForAudienceTotal` + `metricListTokensForAudienceDuration` constants
- `pkg/metrics/prometheus.go` — 2 new metrics registered (counter + histogram, same label set as `list_tokens_for_user`)
- `pkg/storage/redis.go` — stub returning `errors.New("not implemented")` so the `var _ RefreshStore` compile-time assertion passes; replaced by the real implementation in Phase 2
- `internal/testutil/mock_refreshstore.go` — regenerated via `go generate`
- `pkg/storage/memory_test.go` — 9 Phase 16 specs (empty audience, single page, pagination, isolation, `ErrInvalidAudience`, cursor exhaustion, context cancel, revoked+active, multi-audience visibility); promoted to `suite_test.go` once Redis ships

## Test results

```
Ran 209 of 209 Specs in ~1.7s — PASS (race detector enabled)
```

200 pre-existing specs unaffected. 9 new Phase 16 memory specs all green.

## Notes

- `suite_test.go` Phase 16 is intentionally deferred — the shared suite runs against both backends; the Redis stub would fail all 9 specs. Phase 2 replaces the stub and promotes the specs into the shared suite.
- No new production dependencies.

## Phase tracker

| Phase | Description | Status |
|---|---|---|
| **1** | `RefreshStore` interface + `MemoryRefreshStore` + mock regen | **This PR** |
| 2 | `RedisRefreshStore` | Pending |
| 3 | `tokens.Manager` wiring + observability | Pending |
| 4 | Integration tests | Pending |
| 5 | Docs | Pending |