### PR TITLE
feat(tokens): wire ListTokensForAudience into Manager (#143 Phase 3)

### DIFF
--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -122,6 +122,15 @@ func (pm *PrometheusMetrics) registerAllMetrics(namespace string) {
 		[]string{"namespace"},
 		[]float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10})
 
+	pm.registerCounter(namespace, "tokens_list_for_audience_total",
+		"Total number of list-tokens-for-audience operations on the token manager",
+		[]string{"namespace", "error_type"})
+
+	pm.registerHistogram(namespace, "tokens_list_for_audience_duration_seconds",
+		"Duration of list-tokens-for-audience operations on the token manager in seconds",
+		[]string{"namespace"},
+		[]float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10})
+
 	pm.registerGauge(namespace, "active_tokens",
 		"Number of active tokens",
 		[]string{"storage_backend", "namespace"})

--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -2522,6 +2522,70 @@ func (m *Manager) ListTokensForUser(ctx context.Context, userID string, cursor s
 	return tokens, nextCursor, nil
 }
 
+// ListTokensForAudience returns a page of refresh tokens that were issued
+// with the given audience value from the underlying store. See
+// storage.RefreshStore.ListTokensForAudience for cursor and filtering
+// semantics. Returns storage.ErrInvalidAudience if audience is empty. Returns
+// the context error if the context is cancelled.
+func (m *Manager) ListTokensForAudience(ctx context.Context, audience string, cursor string, count int) ([]*storage.RefreshToken, string, error) {
+	ctx, span := m.startSpan(ctx, "ListTokensForAudience")
+	defer span.End()
+	span.SetAttribute("token.namespace", m.namespace)
+	span.SetAttribute("token.audience", audience)
+	span.SetAttribute("token.cursor", cursor)
+	span.SetAttribute("token.count", count)
+
+	start := time.Now()
+	errorType := "error"
+	defer func() {
+		m.metrics.IncrementCounter(metricTokensListForAudienceTotal, map[string]string{
+			"namespace":  m.namespace,
+			"error_type": errorType,
+		})
+		m.metrics.RecordDuration(metricTokensListForAudienceDuration, time.Since(start), map[string]string{
+			"namespace": m.namespace,
+		})
+	}()
+
+	// ===== STEP 1: Service State Check =====
+	if !m.isRunning.Load() {
+		errorType = "not_running"
+		m.logger.Warn("attempted listTokensForAudience while service stopped", ctx)
+		span.RecordError(ErrManagerNotRunning)
+		span.SetStatus(tracing.StatusError, ErrManagerNotRunning.Error())
+		return nil, "", ErrManagerNotRunning
+	}
+
+	// ===== STEP 2: Context Check =====
+	if err := ctx.Err(); err != nil {
+		errorType = "cancelled"
+		m.logger.Info("context cancelled during listTokensForAudience", ctx, "error", err)
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
+		return nil, "", err
+	}
+
+	// ===== STEP 3: Delegate to Store =====
+	tokens, nextCursor, err := m.refreshStore.ListTokensForAudience(ctx, audience, cursor, count)
+	if err != nil {
+		m.logger.Error("failed to list tokens for audience", ctx, "audience", audience, "error", err)
+		wrapped := fmt.Errorf("list tokens for audience failed: %w", err)
+		span.RecordError(wrapped)
+		span.SetStatus(tracing.StatusError, wrapped.Error())
+		return nil, "", wrapped
+	}
+
+	// ===== STEP 4: Record Success and Log =====
+	errorType = ""
+	span.SetAttribute("token.result_count", len(tokens))
+	span.SetStatus(tracing.StatusOK, "")
+	m.logger.Info("tokens listed for audience", ctx,
+		"audience", audience,
+		"result_count", len(tokens),
+		"next_cursor", nextCursor)
+	return tokens, nextCursor, nil
+}
+
 // generateTokenID creates a cryptographically random token identifier.
 //
 // The token ID (jti claim) is used for:

--- a/pkg/tokens/manager_list_tokens_test.go
+++ b/pkg/tokens/manager_list_tokens_test.go
@@ -242,4 +242,100 @@ var _ = Describe("TokenManager ListTokens", func() {
 			})
 		})
 	})
+
+	Describe("ListTokensForAudience", func() {
+		It("should return page from store on success", func() {
+			expected := []*storage.RefreshToken{
+				{TokenID: "tok-1", Audience: []string{"svc-payments"}},
+				{TokenID: "tok-2", Audience: []string{"svc-payments"}},
+			}
+			mockStore.EXPECT().
+				ListTokensForAudience(gomock.Any(), "svc-payments", "", 10).
+				Return(expected, "", nil)
+
+			page, next, err := service.ListTokensForAudience(ctx, "svc-payments", "", 10)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(page).To(Equal(expected))
+			Expect(next).To(BeEmpty())
+		})
+
+		It("should propagate audience, cursor, and count to store", func() {
+			mockStore.EXPECT().
+				ListTokensForAudience(gomock.Any(), "svc-payments", "cursor-abc", 5).
+				Return(nil, "", nil)
+
+			service.ListTokensForAudience(ctx, "svc-payments", "cursor-abc", 5)
+		})
+
+		It("should return next cursor from store", func() {
+			mockStore.EXPECT().
+				ListTokensForAudience(gomock.Any(), "svc-payments", "", 2).
+				Return([]*storage.RefreshToken{{TokenID: "tok-1"}}, "cursor-xyz", nil)
+
+			_, next, err := service.ListTokensForAudience(ctx, "svc-payments", "", 2)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(next).To(Equal("cursor-xyz"))
+		})
+
+		It("should log success with audience, result count, and next cursor", func() {
+			mockStore.EXPECT().
+				ListTokensForAudience(gomock.Any(), "svc-payments", "", 10).
+				Return([]*storage.RefreshToken{{TokenID: "tok-1"}}, "next", nil)
+
+			service.ListTokensForAudience(ctx, "svc-payments", "", 10)
+
+			Eventually(func() bool {
+				return mockLogger.HasLog("info", "tokens listed for audience")
+			}).Should(BeTrue())
+		})
+
+		Context("when store returns an error", func() {
+			It("should return wrapped error", func() {
+				storeErr := errors.New("redis unavailable")
+				mockStore.EXPECT().
+					ListTokensForAudience(gomock.Any(), "svc-payments", "", 10).
+					Return(nil, "", storeErr)
+
+				_, _, err := service.ListTokensForAudience(ctx, "svc-payments", "", 10)
+
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, storeErr)).To(BeTrue())
+			})
+
+			It("should log the error", func() {
+				mockStore.EXPECT().
+					ListTokensForAudience(gomock.Any(), "svc-payments", "", 10).
+					Return(nil, "", errors.New("store error"))
+
+				service.ListTokensForAudience(ctx, "svc-payments", "", 10)
+
+				Eventually(func() bool {
+					return mockLogger.HasLog("error", "failed to list tokens for audience")
+				}).Should(BeTrue())
+			})
+		})
+
+		Context("when service is not running", func() {
+			It("should return ErrManagerNotRunning", func() {
+				stoppedService := newTestManager(mockKM, mockStore, mockLogger)
+
+				_, _, err := stoppedService.ListTokensForAudience(ctx, "svc-payments", "", 10)
+
+				Expect(err).To(MatchError(tokens.ErrManagerNotRunning))
+			})
+		})
+
+		Context("when context is cancelled", func() {
+			It("should return context error", func() {
+				cancelledCtx, cancel := context.WithCancel(ctx)
+				cancel()
+
+				_, _, err := service.ListTokensForAudience(cancelledCtx, "svc-payments", "", 10)
+
+				Expect(err).To(MatchError(context.Canceled))
+			})
+		})
+	})
 })

--- a/pkg/tokens/observability.go
+++ b/pkg/tokens/observability.go
@@ -18,4 +18,7 @@ const (
 
 	metricTokensListForUserTotal    = "jwtauth_tokens_list_for_user_total"
 	metricTokensListForUserDuration = "jwtauth_tokens_list_for_user_duration_seconds"
+
+	metricTokensListForAudienceTotal    = "jwtauth_tokens_list_for_audience_total"
+	metricTokensListForAudienceDuration = "jwtauth_tokens_list_for_audience_duration_seconds"
 )


### PR DESCRIPTION
## Summary

- Adds `ListTokensForAudience` to `tokens.Manager`, mirroring `ListTokensForUser` exactly — delegates to `refreshStore.ListTokensForAudience` with full observability wired throughout
- Span attributes: `token.namespace`, `token.audience`, `token.cursor`, `token.count`, `token.result_count`
- 2 new metric constants in `pkg/tokens/observability.go`: `jwtauth_tokens_list_for_audience_total` / `jwtauth_tokens_list_for_audience_duration_seconds`
- Registers the 2 new Prometheus metrics in `pkg/metrics/prometheus.go` (counter with `namespace`+`error_type` labels; histogram with `namespace` label)
- 8 new unit specs in `manager_list_tokens_test.go` covering: success, cursor propagation, next cursor, success logging, store error (wrapped + logged), not-running guard, cancelled context

## Test plan

- [ ] `go test -race ./pkg/tokens/... ./pkg/metrics/...` — 253 tokens specs + metrics specs passing
- [ ] Verify 8 new `ListTokensForAudience` specs appear under `TokenManager ListTokens`
- [ ] Confirm `jwtauth_tokens_list_for_audience_total` and `_duration_seconds` are registered in `PrometheusMetrics`

## Depends on

- #158 (Phase 1) and #159 (Phase 2) — both merged to `dev`

## Part of

Issue #143 — `ListTokensForAudience` (5-phase plan)

| Phase | Description | Status |
|---|---|---|
| 1 | `RefreshStore` interface + `MemoryRefreshStore` + mock regen | Merged (#158) |
| 2 | `RedisRefreshStore` implementation | Merged (#159) |
| **3** | **`tokens.Manager` wiring + observability** | **This PR** |
| 4 | Integration tests | Pending |
| 5 | Docs | Pending |