### PR TITLE
test(integration): add audience revocation specs to shared integration suite (#135 Phase 4)

### DIFF
--- a/pkg/tokens/integration/integration_suite_test.go
+++ b/pkg/tokens/integration/integration_suite_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -12,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/aetomala/jwtauth/pkg/keys"
+	"github.com/aetomala/jwtauth/pkg/storage"
 	"github.com/aetomala/jwtauth/pkg/tokens"
 )
 
@@ -339,6 +341,116 @@ func RunTokenManagerIntegrationTests(description string, factory ManagerFactory)
 			Expect(cursor).To(Equal(""))
 			Expect(len(userBTokens)).To(Equal(1))
 			Expect(userBTokens[0].UserID).To(Equal("list-user-b"))
+		})
+
+		It("should list tokens scoped to the target audience", func() {
+			_, err := mgr.IssueRefreshToken(ctx, "list-aud-user-a", tokens.WithAudience("svc-list-payments"))
+			Expect(err).NotTo(HaveOccurred())
+			_, err = mgr.IssueRefreshToken(ctx, "list-aud-user-b", tokens.WithAudience("svc-list-payments"))
+			Expect(err).NotTo(HaveOccurred())
+			_, err = mgr.IssueRefreshToken(ctx, "list-aud-user-c", tokens.WithAudience("svc-list-reports"))
+			Expect(err).NotTo(HaveOccurred())
+
+			paymentsTokens, cursor, err := mgr.ListTokensForAudience(ctx, "svc-list-payments", "", 10)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cursor).To(Equal(""))
+			Expect(len(paymentsTokens)).To(Equal(2))
+			for _, t := range paymentsTokens {
+				Expect(t.Audience).To(ContainElement("svc-list-payments"))
+			}
+
+			reportsTokens, cursor, err := mgr.ListTokensForAudience(ctx, "svc-list-reports", "", 10)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cursor).To(Equal(""))
+			Expect(len(reportsTokens)).To(Equal(1))
+			Expect(reportsTokens[0].Audience).To(ContainElement("svc-list-reports"))
+		})
+
+		It("should paginate audience tokens with a cursor", func() {
+			audience := "svc-list-paginate"
+			_, err := mgr.IssueRefreshToken(ctx, "paginate-user", tokens.WithAudience(audience))
+			Expect(err).NotTo(HaveOccurred())
+			_, err = mgr.IssueRefreshToken(ctx, "paginate-user", tokens.WithAudience(audience))
+			Expect(err).NotTo(HaveOccurred())
+			_, err = mgr.IssueRefreshToken(ctx, "paginate-user", tokens.WithAudience(audience))
+			Expect(err).NotTo(HaveOccurred())
+
+			page1, cursor, err := mgr.ListTokensForAudience(ctx, audience, "", 2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(page1)).To(Equal(2))
+			Expect(cursor).NotTo(BeEmpty())
+
+			page2, cursor, err := mgr.ListTokensForAudience(ctx, audience, cursor, 2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(page2)).To(Equal(1))
+			Expect(cursor).To(Equal(""))
+
+			allIDs := make(map[string]bool)
+			for _, t := range append(page1, page2...) {
+				allIDs[t.TokenID] = true
+			}
+			Expect(len(allIDs)).To(Equal(3))
+		})
+
+		It("should return ErrInvalidAudience for an empty audience string", func() {
+			_, _, err := mgr.ListTokensForAudience(ctx, "", "", 10)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, storage.ErrInvalidAudience)).To(BeTrue())
+		})
+
+		It("should return an empty result for a non-existent audience", func() {
+			result, cursor, err := mgr.ListTokensForAudience(ctx, "nonexistent-audience-xyz", "", 10)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cursor).To(Equal(""))
+			Expect(result).To(BeEmpty())
+		})
+
+		It("should list a multi-audience token under each of its audiences", func() {
+			_, err := mgr.IssueRefreshToken(ctx, "multi-aud-user",
+				tokens.WithAudience("svc-multi-list-a", "svc-multi-list-b"))
+			Expect(err).NotTo(HaveOccurred())
+
+			tokensA, _, err := mgr.ListTokensForAudience(ctx, "svc-multi-list-a", "", 10)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(tokensA)).To(Equal(1))
+
+			tokensB, _, err := mgr.ListTokensForAudience(ctx, "svc-multi-list-b", "", 10)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(tokensB)).To(Equal(1))
+
+			Expect(tokensA[0].TokenID).To(Equal(tokensB[0].TokenID))
+		})
+
+		It("should return an empty listing after expired tokens are cleaned up", func() {
+			audience := "svc-list-cleanup-audit"
+
+			mgr2, _, cleanup2 := factory(tokens.TokenManagerConfig{
+				AccessTokenDuration:  5 * time.Minute,
+				RefreshTokenDuration: 100 * time.Millisecond,
+				CleanupInterval:      10 * time.Second,
+				Issuer:               "integration-test",
+				Audience:             []string{"integration-test"},
+			})
+			Expect(mgr2.Start(ctx)).To(Succeed())
+			DeferCleanup(func() {
+				shutdownCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
+				defer c()
+				_ = mgr2.Shutdown(shutdownCtx)
+				cleanup2()
+			})
+
+			_, err := mgr2.IssueRefreshToken(ctx, "cleanup-list-user", tokens.WithAudience(audience))
+			Expect(err).NotTo(HaveOccurred())
+
+			time.Sleep(150 * time.Millisecond)
+
+			_, err = mgr2.CleanupExpiredTokens(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			result, cursor, err := mgr2.ListTokensForAudience(ctx, audience, "", 10)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cursor).To(Equal(""))
+			Expect(result).To(BeEmpty())
 		})
 
 		It("should preserve custom claims through issuance and validation", func() {


### PR DESCRIPTION
## Summary

- Adds 6 `ListTokensForAudience` specs to `RunTokenManagerIntegrationTests`, which runs against both the disk+memory and Redis backends
- New imports: `"errors"` and `pkg/storage` (for `storage.ErrInvalidAudience` assertion)

## Specs added

| # | Description |
|---|---|
| 1 | Audience scoping — tokens for `svc-list-payments` do not appear in `svc-list-reports` listing |
| 2 | Cursor-based pagination — 3 tokens fetched in pages of 2; all token IDs unique across pages |
| 3 | `ErrInvalidAudience` propagated through Manager wrapping for empty audience string |
| 4 | Empty result (no error) for a non-existent audience |
| 5 | Multi-audience visibility — a token issued with two audiences appears in both listings |
| 6 | Post-cleanup pruning — expired tokens removed from index return an empty listing |

## Test plan

- [x] `go test -tags integration -race ./pkg/tokens/integration/...` — passes (both backends)
- [x] `go test -race ./pkg/...` — all 253 unit specs + 6 new integration specs passing
- [x] No new production dependencies

## Part of #143