### PR TITLE
docs: document audience-scoped enumeration for v0.5.0 (#143 Phase 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be documented in this file.
 
 - **`storage.RefreshStore` gains `RevokeAllForAudience` and `RevokeAllForUserAndAudience`** — all custom `RefreshStore` implementations must add both methods or they will not compile. `MemoryRefreshStore` and `RedisRefreshStore` are already updated. See #135 and `UPGRADING.md`.
 
+- **`storage.RefreshStore` gains `ListTokensForAudience(ctx, audience, cursor, count)`** — all custom `RefreshStore` implementations must add this method or they will not compile. `MemoryRefreshStore` and `RedisRefreshStore` are already updated. Add a compile-time assertion to catch the gap early: `var _ storage.RefreshStore = (*MyStore)(nil)`. See #143 and `UPGRADING.md`.
+
 - **`jwtauth_tokens_revoked_total` label `operation` renamed to `revocation_scope`** — update any Prometheus alert rules, recording rules, or dashboards that filter or group by the old label name. Existing label values (`"single"`, `"all_user"`) are unchanged. See #124.
 
 ### Added
@@ -32,7 +34,13 @@ All notable changes to this project will be documented in this file.
 
 - **`tokens.Manager.RevokeAllForUserAndAudience(ctx, userID, audience) error`** — revokes all non-expired refresh tokens for a specific user and audience. Tokens for other users in the same audience are not affected. Emits `revocation_scope="user_audience"`. See #135.
 
-- **`storage.ErrInvalidAudience`** — sentinel returned when an empty string is passed as the audience argument to the new revocation methods. See #135.
+- **`storage.ErrInvalidAudience`** — sentinel returned when an empty string is passed as the audience argument to the new revocation or enumeration methods. See #135 and #143.
+
+- **`ListTokensForAudience(ctx, audience, cursor, count)` added to `RefreshStore` interface and both implementations** — audience-scoped cursor-based token iteration for the audit-before-revoke workflow. `MemoryRefreshStore` uses an integer offset cursor; `RedisRefreshStore` uses Redis SSCAN cursor passthrough on the `audience_tokens:<aud>` set, hydrating tokens via the existing `fetchTokensByIDs` pipeline helper. Returns `ErrInvalidAudience` if `audience` is empty. Tokens issued with multiple audiences appear in the listing for each of their audiences. All other cursor and filtering semantics are identical to `ListTokensForUser`. `MockRefreshStore` regenerated. See #143.
+
+- **`tokens.Manager.ListTokensForAudience(ctx, audience, cursor, count)`** — thin delegation to `RefreshStore.ListTokensForAudience`. Emits a `token.list_tokens_for_audience` span (attrs: `token.namespace`, `token.audience`, `token.cursor`, `token.count`, `token.result_count`), logs success and failure, and records `jwtauth_tokens_list_for_audience_total` counter and `jwtauth_tokens_list_for_audience_duration_seconds` histogram with `namespace` and `error_type` labels. See #143.
+
+- **4 additional Prometheus metrics registered in `PrometheusMetrics`** — storage-layer metrics (`jwtauth_storage_list_tokens_for_audience_total`, `jwtauth_storage_list_tokens_for_audience_duration_seconds`) and token-manager-layer metrics (`jwtauth_tokens_list_for_audience_total`, `jwtauth_tokens_list_for_audience_duration_seconds`); all carry `namespace` and `error_type` labels. See #143.
 
 ---
 

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -403,6 +403,18 @@ To enumerate tokens for a specific user, replace the first line of the loop body
 page, next, err := mgr.ListTokensForUser(ctx, userID, cursor, 100)
 ```
 
+To enumerate tokens scoped to a specific audience:
+
+```go
+page, next, err := mgr.ListTokensForAudience(ctx, "svc-payments", cursor, 100)
+```
+
+Tokens issued with multiple audiences (e.g. `WithAudience("svc-payments", "svc-reports")`) appear
+in the listing for **each** of their audiences — a token is not double-counted within a single
+audience listing, but it will appear once in the `svc-payments` listing and once in the
+`svc-reports` listing. The primary use case for `ListTokensForAudience` is the audit-before-revoke
+workflow described in [Audience-Scoped Revocation](#audience-scoped-revocation).
+
 `count` is a hint — the actual page size may vary. Cursor semantics are best-effort under
 concurrent mutation: tokens created or deleted between pages may appear, disappear, or shift.
 
@@ -445,6 +457,42 @@ correctly, so subsequent revocations target only live tokens.
 **Revocation scope metric** — both operations emit `revocation_scope` labels (`"audience"`
 and `"user_audience"`) on the `jwtauth_tokens_revoked_total` counter, consistent with the
 existing `"single"` and `"all_user"` scopes.
+
+### Audit before revoke
+
+`ListTokensForAudience` lets you enumerate the sessions that would be affected before
+committing to a revocation — useful for compliance logging, dry-run validation, or building
+a confirmation step into an admin workflow:
+
+```go
+// Enumerate active sessions for svc-payments.
+var cursor string
+for {
+    page, next, err := mgr.ListTokensForAudience(ctx, "svc-payments", cursor, 100)
+    if err != nil {
+        return err
+    }
+    for _, t := range page {
+        if t.ExpiresAt.After(time.Now()) {
+            log.Printf("will revoke token %s for user %s", t.TokenID, t.UserID)
+        }
+    }
+    if next == "" {
+        break
+    }
+    cursor = next
+}
+
+// Revoke all tokens for svc-payments.
+if err := mgr.RevokeAllForAudience(ctx, "svc-payments"); err != nil {
+    return err
+}
+```
+
+Tokens issued with multiple audiences (e.g. `WithAudience("svc-payments", "svc-reports")`)
+appear in the `ListTokensForAudience` listing for **each** of their audiences. The token is
+stored and revoked as a single record — appearing in multiple listings does not cause it to
+be revoked multiple times.
 
 ---
 

--- a/doc/UPGRADING.md
+++ b/doc/UPGRADING.md
@@ -85,6 +85,41 @@ methods return `error` only; the storage-layer count is used internally for logg
 [Audience-Scoped Revocation](../doc/DEPLOYMENT.md#audience-scoped-revocation) in
 `DEPLOYMENT.md` for the full semantic and use cases.
 
+### 5. `storage.RefreshStore` — one new enumeration method (#143)
+
+One new method is added to the `RefreshStore` interface:
+
+```go
+ListTokensForAudience(ctx context.Context, audience string, cursor string, count int) ([]*RefreshToken, string, error)
+```
+
+`MemoryRefreshStore` and `RedisRefreshStore` are already updated. All custom `RefreshStore`
+implementations must add this method or they will not compile. Add a compile-time assertion
+to catch the gap early:
+
+```go
+var _ storage.RefreshStore = (*MyRefreshStore)(nil)
+```
+
+Returns a page of refresh tokens whose stored audience slice contains `audience`, starting
+from `cursor`. Pass `""` to begin from the start; returns `""` as the next cursor when
+iteration is exhausted. Returns `storage.ErrInvalidAudience` if `audience` is empty.
+`count` is a hint — actual page size may vary.
+
+`tokens.Manager` exposes audience-scoped enumeration at the manager level — callers use
+`mgr.ListTokensForAudience` directly. The primary use case is the audit-before-revoke
+workflow: enumerate tokens for an audience, log or validate them, then call
+`mgr.RevokeAllForAudience`. See
+[Audience-Scoped Revocation](../doc/DEPLOYMENT.md#audience-scoped-revocation) in
+`DEPLOYMENT.md`.
+
+**Multi-audience visibility** — a token issued with `WithAudience("svc-payments",
+"svc-reports")` appears in the listing for **each** of its audiences. The same token will
+appear once in the `svc-payments` listing and once in the `svc-reports` listing; it is not
+double-counted within either listing.
+
+---
+
 ### Additive changes (no action required)
 
 `IssueOption` / `WithAudience` (#124) adds a variadic `...tokens.IssueOption` parameter
@@ -92,9 +127,9 @@ to all six issuance methods. All existing call sites compile and behave unchange
 parameter is optional and defaults to the manager's configured audience.
 
 `storage.ErrInvalidAudience` is a new sentinel returned when an empty string is passed to
-`RevokeAllForAudience` or `RevokeAllForUserAndAudience`. Code that only calls these methods
-via `tokens.Manager` does not need to import `storage` — the error is not wrapped and can
-be compared directly with `errors.Is`.
+`RevokeAllForAudience`, `RevokeAllForUserAndAudience`, or `ListTokensForAudience`. Code that
+only calls these methods via `tokens.Manager` does not need to import `storage` — the error
+is wrapped by the manager and can be compared with `errors.Is`.
 
 ---
 


### PR DESCRIPTION
## Summary

- **`DEPLOYMENT.md`** — extends the Token Enumeration and Audience-Scoped Revocation sections with `ListTokensForAudience` coverage:
  - Token Enumeration: adds `ListTokensForAudience` snippet and a note on multi-audience token visibility (same token appears in each audience's listing)
  - Audience-Scoped Revocation: adds a new "Audit before revoke" subsection with the full enumerate-then-revoke code pattern
- **`UPGRADING.md`** — adds item 5 in the v0.4.x → v0.5.0 breaking-changes section documenting `ListTokensForAudience` as a required new `RefreshStore` interface method; updates "Additive changes" to reference `ErrInvalidAudience` for the enumeration path
- **`CHANGELOG.md`** — adds Breaking entry (`ListTokensForAudience` interface addition) and three Added entries (`RefreshStore` impl, `tokens.Manager` delegation, 4 new Prometheus metrics)

## Test plan

- [x] `go build ./...` and `go vet ./...` — clean
- [x] No new production or test dependencies
- [x] Docs-only change; no behavioral modification

## Part of #143