### PR TITLE
docs: document audience index key patterns in Redis keyspace documentation

### DIFF
--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -623,24 +623,32 @@ type MemoryRefreshStore struct {
 **Design**:
 ```go
 type RedisRefreshStore struct {
-    client  *redis.Client   // go-redis/v9 client (internally thread-safe)
-    logger  logging.Logger  // never nil; defaults to NoOpLogger
-    metrics metrics.Metrics // never nil; defaults to NoOpMetrics
-    backend string          // storage_backend label value; always "redis"
+    client               *redis.Client   // go-redis/v9 client (internally thread-safe)
+    logger               logging.Logger  // never nil; defaults to NoOpLogger
+    metrics              metrics.Metrics // never nil; defaults to NoOpMetrics
+    tracer               tracing.Tracer  // never nil; defaults to NoOpTracer
+    namespace            string          // KeyPrefix value; used as storage_namespace label
+    backend              string          // storage_backend label value; always "redis"
+    tokenPrefix          string          // KeyPrefix + "tokens:"
+    userSetPrefix        string          // KeyPrefix + "user_tokens:"
+    audienceSetPrefix    string          // KeyPrefix + "audience_tokens:"
+    audienceUserSetPrefix string         // KeyPrefix + "audience_user_tokens:"
 }
 ```
 
 **Redis Data Structure**:
 ```
-[KeyPrefix]tokens:{tokenID}        → Hash with fields: userID, expiresAt, createdAt, revoked, metadata
-[KeyPrefix]user_tokens:{userID}    → Set of tokenIDs for that user
+[KeyPrefix]tokens:<tokenID>                  → Hash with fields: userID, expiresAt, createdAt, revoked, metadata
+[KeyPrefix]user_tokens:<userID>              → Set of tokenIDs for that user
+[KeyPrefix]audience_tokens:<aud>             → Set of tokenIDs for that audience
+[KeyPrefix]audience_user_tokens:<aud>:<uid>  → Set of tokenIDs for that user+audience pair
 ```
 
-Keys are optionally prefixed by `RedisRefreshStoreConfig.KeyPrefix`. `Cleanup` scans only `{KeyPrefix}tokens:*` — expired tokens from other namespaces are not affected.
+All four patterns are prepended with `RedisRefreshStoreConfig.KeyPrefix` at construction time. `Cleanup` scans only `[KeyPrefix]tokens:*` — expired tokens from other namespaces are not affected.
 
 **Key Features**:
 - **Distributed**: Works across multiple instances (Redis is the shared backend)
-- **Cursor-based enumeration**: `ListTokens` uses `SCAN` over the token hash namespace; `ListTokensForUser` uses `SSCAN` over the per-user token set — both pass Redis cursors through directly for stable pagination without extra round-trips
+- **Cursor-based enumeration**: `ListTokens` uses `SCAN` over the token hash namespace; `ListTokensForUser` and `ListTokensForAudience` use `SSCAN` over their respective index sets — all three pass Redis cursors through directly for stable pagination without extra round-trips
 - **Pipeline atomicity**: Multi-operation transactions via Redis pipelines
 - **Millisecond-precision timestamps**: Stored as UnixMilli (preserves precision across serialization)
 - **Efficient cleanup**: SCAN-based key iteration for expired token sweeps

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -363,6 +363,28 @@ metric names or adding routing logic.
 See [ADR-006](adr/006-keyprefix-namespace-isolation.md) and
 [ADR-007](adr/007-namespace-consistency-contract.md).
 
+### Redis Key Schema
+
+Every key written by a store instance is prefixed by the configured `KeyPrefix`. The complete
+set of patterns for a deployment with `KeyPrefix: "myapp:"` is:
+
+**`RedisRefreshStore`**:
+```
+myapp:tokens:<tokenID>                  — token hash (HSet)
+myapp:user_tokens:<userID>              — set of tokenIDs for that user (SAdd)
+myapp:audience_tokens:<aud>             — set of tokenIDs for that audience (SAdd)
+myapp:audience_user_tokens:<aud>:<uid>  — set of tokenIDs for that user+audience (SAdd)
+```
+
+**`RedisKeyStore`**:
+```
+myapp:ks:pem:<keyID>   — PKCS#1 PEM private key (string)
+myapp:ks:meta:<keyID>  — JSON KeyMetadata (string)
+```
+
+An empty `KeyPrefix` omits the prefix entirely, preserving the pre-ADR-006 key layout. Use
+these patterns when writing Redis ACL rules or verifying namespace isolation with `SCAN`.
+
 ---
 
 ## Token Enumeration

--- a/doc/adr/006-keyprefix-namespace-isolation.md
+++ b/doc/adr/006-keyprefix-namespace-isolation.md
@@ -13,6 +13,24 @@ Add an optional `KeyPrefix string` field to `RedisKeyStoreConfig` and `RedisRefr
 
 The library treats the prefix as an **opaque namespace separator**. It enforces that every Redis operation within a store instance uses the configured prefix consistently — it does not interpret what the prefix means, does not validate its format, and does not prescribe any particular deployment model. What the prefix represents is entirely the consumer's decision.
 
+The full key schema for `RedisRefreshStore` under a given `KeyPrefix` is:
+
+```
+[KeyPrefix]tokens:<tokenID>                  — token hash (HSet)
+[KeyPrefix]user_tokens:<userID>              — set of tokenIDs for that user (SAdd)
+[KeyPrefix]audience_tokens:<aud>             — set of tokenIDs for that audience (SAdd)
+[KeyPrefix]audience_user_tokens:<aud>:<uid>  — set of tokenIDs for that user+audience (SAdd)
+```
+
+For `RedisKeyStore`:
+
+```
+[KeyPrefix]ks:pem:<keyID>   — PKCS#1 PEM private key (string)
+[KeyPrefix]ks:meta:<keyID>  — JSON KeyMetadata (string)
+```
+
+An empty `KeyPrefix` preserves the pre-ADR-006 key layout exactly — fully backward compatible.
+
 The other two implementations are out of scope for distinct reasons. `DiskKeyStore` uses a directory path as its natural namespace — two stores with different directories are structurally isolated at the filesystem level with no shared keyspace concern. `MemoryRefreshStore` is designed for development use only; multi-instance namespace isolation is a production deployment concern that does not apply to a development-only implementation.
 
 ## Consequences
@@ -21,4 +39,4 @@ The other two implementations are out of scope for distinct reasons. `DiskKeySto
 - `DiskKeyStore` is unaffected — the directory path already provides structural filesystem-level isolation
 - `MemoryRefreshStore` is unaffected — it is designed for development use only; the shared-Redis multi-instance namespace problem is a production concern that does not apply
 - Consumers using the empty default need no migration
-- `SCAN`-based operations (`LoadAll`, `Cleanup`) now scan only within the configured namespace — operations in one namespace do not observe or affect keys in another
+- `SCAN`-based and `SSCAN`-based operations (`LoadAll`, `Cleanup`, `ListTokens`, `ListTokensForUser`, `ListTokensForAudience`, `RevokeAllForAudience`) scan only within the configured namespace — operations in one namespace do not observe or affect keys in another


### PR DESCRIPTION
## Summary

PRs #135 and #143 added `audience_tokens:` and `audience_user_tokens:` index sets to
`RedisRefreshStore`, but three documentation files were not updated to reflect the expanded
keyspace. Operators reading docs to verify namespace isolation or write Redis ACLs saw an
incomplete key schema.

- **ADR-006** — added full key-schema block (four `RefreshStore` patterns, two `KeyStore`
  patterns) to the Decision section; expanded the Consequences SCAN bullet to cover SSCAN-based
  operations and enumerate all affected methods
- **ARCHITECTURE.md** — updated stale `RedisRefreshStore` struct definition (adds tracer,
  namespace, and all four prefix fields); added audience index patterns to the Redis Data
  Structure block; added `ListTokensForAudience` to the cursor-based enumeration note
- **DEPLOYMENT.md** — added "Redis Key Schema" subsection inside Namespace Isolation showing all
  six namespaced key patterns with a note that an empty `KeyPrefix` preserves the pre-ADR-006
  layout

No code changes. Namespace isolation was already fully intact — this is a documentation-only
fix.

## Test plan

- [x] `run-ci-locally.sh` passes — 253 unit + 218 storage + 60 integration specs, all green
- [x] `audience_tokens` appears in all three edited files
- [x] DEPLOYMENT.md "Redis Key Schema" subsection lists all six key patterns

closes #163