### PR TITLE
docs(perf): add PERFORMANCE.md + README Performance section + CHANGELOG (#141 Phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ All notable changes to this project will be documented in this file.
 
 - **4 additional Prometheus metrics registered in `PrometheusMetrics`** — storage-layer metrics (`jwtauth_storage_list_tokens_for_audience_total`, `jwtauth_storage_list_tokens_for_audience_duration_seconds`) and token-manager-layer metrics (`jwtauth_tokens_list_for_audience_total`, `jwtauth_tokens_list_for_audience_duration_seconds`); all carry `namespace` and `error_type` labels. See #143.
 
+- **Microbenchmark suite** — `testing.B` benchmarks in `pkg/storage/bench_test.go`, `pkg/keys/bench_test.go`, and `pkg/tokens/bench_test.go` covering all storage operations (MemoryRefreshStore + RedisRefreshStore via miniredis), key manager cache and rotation paths, token issuance and validation (serial and parallel), rotation-under-load concurrency, observability tax (NoOp vs PrometheusMetrics vs OtelTracer), and a baseline comparison against raw `golang-jwt/jwt`. Results and reproduction instructions in `doc/PERFORMANCE.md`. See #141.
+
 ---
 
 ## [v0.4.0] — 2026-04-30

--- a/README.md
+++ b/README.md
@@ -1048,6 +1048,29 @@ mgr, _ := tokens.NewManager(tokens.TokenManagerConfig{
 All spans set `StatusOK` on success and `RecordError` + `StatusError` on failure. For deployment setup and `TracerProvider` configuration, see [doc/DEPLOYMENT.md](doc/DEPLOYMENT.md).
 
 
+## Performance
+
+Measured on Apple M4 Max, Go 1.26.2, `GOMAXPROCS=16`. Redis numbers use in-process miniredis — add your Redis network RTT for real deployments.
+
+| Operation | ns/op | B/op | allocs/op |
+|---|---|---|---|
+| `IssueAccessToken` | 78,775 | 6,893 | 75 |
+| `ValidateAccessToken` | 5,580 | 7,384 | 109 |
+| `IssueTokenPair` | 69,436 | 8,612 | 90 |
+| `RefreshAccessToken` | 867,641 | 9,497 | 109 |
+| `Store` (Memory) | 797 | 2,034 | 23 |
+| `Store` (Redis/miniredis) | 37,031 | 6,083 | 137 |
+
+The rotation-under-load benchmark (`BenchmarkValidateAccessToken_DuringRotation`) runs parallel validators against a key manager rotating every 50 ms — quantifying validation latency variance during the key overlap window. This is the library's primary differentiator: zero-downtime key rotation cannot be reproduced by single-key JWT libraries.
+
+Reproduction:
+```bash
+go test -bench=. -benchmem ./pkg/storage/ ./pkg/keys/ ./pkg/tokens/
+```
+
+For full methodology, per-operation tables (all N variants, observability tax, and golang-jwt baseline comparison), and `benchstat` regression workflow, see [doc/PERFORMANCE.md](doc/PERFORMANCE.md).
+
+
 ## Project Structure
 
 See [doc/ARCHITECTURE.md](doc/ARCHITECTURE.md#project-structure) for the package layout and API stability status.

--- a/doc/PERFORMANCE.md
+++ b/doc/PERFORMANCE.md
@@ -1,0 +1,270 @@
+# Performance
+
+## Overview
+
+This document covers library-level performance baselines for jwtauth. All measurements
+isolate the library's own overhead — cryptographic cost, storage operations, and
+observability dispatch. Real Redis network RTT is not included; see
+[What These Numbers Don't Include](#what-these-numbers-dont-include).
+
+---
+
+## Reference Machine
+
+| Field | Value |
+|---|---|
+| Hardware | Apple M4 Max |
+| OS | macOS 15.x (darwin/arm64) |
+| Go | 1.26.2 |
+| `GOMAXPROCS` | 16 |
+| Redis (storage layer) | in-process miniredis (no network) |
+
+Reproduction command:
+```bash
+go test -bench=. -benchmem -run=^$ ./pkg/storage/ ./pkg/keys/ ./pkg/tokens/
+```
+
+> **Note:** Passing `-count=1` is required when running only benchmarks (no Ginkgo specs).
+> Ginkgo rejects `-count=N` for N > 1. Use `benchstat` with multiple `-count` runs if you
+> need statistical confidence intervals (see [Regression Detection](#regression-detection)).
+
+---
+
+## Results: Storage Layer
+
+All operations measured on `MemoryRefreshStore` and `RedisRefreshStore` (miniredis). The
+`WithAudience` variants include the two additional `SAdd` calls added in PR #135.
+
+### Single-token operations
+
+| Benchmark | Memory ns/op | Memory B/op | Memory allocs | Redis ns/op | Redis B/op | Redis allocs |
+|---|---|---|---|---|---|---|
+| `Store` | 797 | 2,034 | 23 | 37,031 | 6,083 | 137 |
+| `Store` (WithAudience) | 862 | 2,124 | 24 | 42,117 | 7,308 | 181 |
+| `Retrieve` | 492 | 1,352 | 16 | 28,269 | 2,883 | 74 |
+| `Revoke` | 1,147 | 1,160 | 13 | 52,430 | 2,119 | 54 |
+
+### Bulk revocation (N tokens per call)
+
+| Benchmark | N | Memory ns/op | Redis ns/op |
+|---|---|---|---|
+| `RevokeAllForUser` | 10 | 2,114 | 90,156 |
+| `RevokeAllForUser` | 100 | 11,104 | 420,295 |
+| `RevokeAllForUser` | 1,000 | 99,983 | 4,203,787 |
+| `RevokeAllForAudience` | 10 | 2,307 | 96,923 |
+| `RevokeAllForAudience` | 100 | 11,658 | 482,940 |
+| `RevokeAllForAudience` | 1,000 | 165,791 | 6,212,172 |
+| `RevokeAllForUserAndAudience` | 10 | 2,656 | 92,570 |
+| `RevokeAllForUserAndAudience` | 100 | 14,161 | 435,261 |
+| `RevokeAllForUserAndAudience` | 1,000 | 129,824 | 3,955,142 |
+
+### Cursor-based listing (full scan, page size 100)
+
+| Benchmark | N tokens | Memory ns/op | Redis ns/op |
+|---|---|---|---|
+| `ListTokens` | 100 | 8,165 | 569,111 |
+| `ListTokens` | 1,000 | 827,597 | 5,071,786 |
+| `ListTokens` | 10,000 | 92,270,139 | 49,281,907 |
+| `ListTokensForUser` | 100 | 4,543 | 600,595 |
+| `ListTokensForUser` | 1,000 | 50,824 | 7,588,131 |
+| `ListTokensForUser` | 10,000 | 502,806 | 223,654,758 |
+| `ListTokensForAudience` | 100 | 5,899 | 647,146 |
+| `ListTokensForAudience` | 1,000 | 68,953 | 7,887,236 |
+| `ListTokensForAudience` | 10,000 | 714,893 | 251,224,281 |
+
+### Cleanup (scan only, no deletions, N live tokens)
+
+| N | Memory ns/op | Redis ns/op |
+|---|---|---|
+| 100 | 1,275 | 2,553,852 |
+| 1,000 | 9,094 | 26,172,139 |
+| 10,000 | 82,225 | 269,240,656 |
+
+---
+
+## Results: Key Manager
+
+| Benchmark | ns/op | B/op | allocs/op | Notes |
+|---|---|---|---|---|
+| `GetPublicKey` (cache hit) | 243 | 800 | 10 | In-memory read-lock path — overwhelmingly common |
+| `GetPublicKey` (cache miss) | 188,334 | 16,659 | 119 | DiskKeyStore load on new instance startup |
+| `RotateKeys` | 44,941,655 | 552,318 | 5,026 | RSA 2048-bit key generation + disk write (~45 ms) |
+| `GetCurrentKeyInfo` | 193 | 528 | 7 | Metadata-only read, no private material |
+| `GetJWKS` | 205 | 520 | 8 | JWKS serialization for `/.well-known/jwks.json` |
+
+`RotateKeys` is intentionally expensive — it generates a fresh RSA 2048-bit key pair and
+writes two files to disk. In production, rotation happens at most once per
+`KeyRotationInterval` (default 30 days). It never runs on the request path.
+
+---
+
+## Results: Token Manager
+
+All token manager benchmarks use `MemoryRefreshStore` for deterministic crypto isolation.
+
+### Pure Crypto
+
+| Benchmark | ns/op | B/op | allocs/op |
+|---|---|---|---|
+| `IssueAccessToken` | 78,775 | 6,893 | 75 |
+| `IssueAccessToken` (WithAudience) | 71,341 | 6,991 | 78 |
+| `IssueAccessTokenWithClaims` — Small (2 fields) | 68,787 | 8,660 | 94 |
+| `IssueAccessTokenWithClaims` — Medium (10 fields) | 79,835 | 11,751 | 113 |
+| `IssueAccessTokenWithClaims` — Large (50 fields) | 106,376 | 30,066 | 202 |
+| `ValidateAccessToken` | 5,580 | 7,384 | 109 |
+| `ValidateAccessTokenWithClaims` | 7,116 | 11,752 | 194 |
+| `IssueTokenPair` | 69,436 | 8,612 | 90 |
+
+Issuance (~70–80 µs) is dominated by RSA 2048-bit signing. Validation (~5.6 µs) is PKCS#1
+v1.5 verification — roughly 14× faster than signing.
+
+`WithAudience` adds no measurable overhead — the functional-option closure dispatch is
+noise relative to RSA signing cost.
+
+### Token Lifecycle
+
+| Benchmark | ns/op | B/op | allocs/op | Notes |
+|---|---|---|---|---|
+| `RefreshAccessToken` | 867,641 | 9,497 | 109 | Full rotation: new access token + refresh token re-storage |
+| `RevokeRefreshToken` | 2,268 | 2,304 | 25 | Single-token revocation — in-memory store write |
+| `IntrospectToken` | 424 | 2,784 | 32 | Metadata read — no JWT re-parse |
+
+`RefreshAccessToken` is expensive (~868 µs) because it generates a new RSA-signed access
+token and a new opaque refresh token in a single call.
+
+### Bulk Revocation (N tokens per call, MemoryRefreshStore)
+
+| Benchmark | N | ns/op | B/op | allocs/op |
+|---|---|---|---|---|
+| `RevokeAllUserTokens` | 10 | 3,501 | 3,456 | 54 |
+| `RevokeAllUserTokens` | 100 | 13,920 | 13,536 | 324 |
+| `RevokeAllUserTokens` | 1,000 | 125,162 | 114,352 | 3,025 |
+| `RevokeAllForAudience` | 10 | 3,583 | 3,520 | 55 |
+| `RevokeAllForAudience` | 100 | 13,491 | 13,600 | 325 |
+| `RevokeAllForAudience` | 1,000 | 134,578 | 114,416 | 3,027 |
+| `RevokeAllForUserAndAudience` | 10 | 3,919 | 4,128 | 69 |
+| `RevokeAllForUserAndAudience` | 100 | 16,184 | 18,528 | 429 |
+| `RevokeAllForUserAndAudience` | 1,000 | 134,852 | 162,544 | 4,031 |
+
+### Audience-Scoped Listing (full scan, page size 100, MemoryRefreshStore)
+
+| N tokens | ns/op | B/op | allocs/op |
+|---|---|---|---|
+| 100 | 5,915 | 17,760 | 226 |
+| 1,000 | 68,193 | 178,204 | 2,305 |
+| 10,000 | 728,789 | 1,782,725 | 23,095 |
+
+---
+
+## Rotation-Under-Load
+
+| Benchmark | ns/op | B/op | allocs/op |
+|---|---|---|---|
+| `ValidateAccessToken` (steady state) | 5,580 | 7,384 | 109 |
+| `ValidateAccessToken` (during rotation) | 13,025 | 7,520 | 110 |
+
+`BenchmarkValidateAccessToken_DuringRotation` runs 16 parallel validator goroutines
+against a token signed with the initial key while a background goroutine calls
+`RotateKeys` every 50 ms. The key overlap window (5 minutes) keeps the original token
+valid throughout the run. The 2.3× slowdown (5.6 µs → 13.0 µs) reflects read-write mutex
+contention during the brief window when a rotation updates the key cache.
+
+This benchmark cannot be reproduced by single-key JWT libraries. It validates the
+library's zero-downtime rotation guarantee under concurrent validation load.
+
+---
+
+## Observability Tax
+
+All variants backed by `MemoryRefreshStore` and `DiskKeyStore`. OtelTracer uses
+`tracing.NewOtelTracer("bench")` wired to Go's global no-op `TracerProvider` — zero
+network calls.
+
+### Issuance (`IssueAccessToken`)
+
+| Variant | ns/op | B/op | allocs/op |
+|---|---|---|---|
+| NoOp (baseline) | 57,951 | 6,800 | 75 |
+| PrometheusMetrics | 57,979 | 6,800 | 75 |
+| OtelTracer | 59,058 | 7,632 | 87 |
+
+### Validation (`ValidateAccessToken`)
+
+| Variant | ns/op | B/op | allocs/op |
+|---|---|---|---|
+| NoOp (baseline) | 2,536 | 7,384 | 109 |
+| OtelTracer | 2,737 | 8,216 | 121 |
+
+Observability overhead is negligible — PrometheusMetrics adds < 0.1% to issuance; the
+OtelTracer dispatch (span start/end via the no-op provider) adds ~1.9% to issuance and
+~8% to validation. Both are noise relative to real Redis RTT in production.
+
+---
+
+## vs. golang-jwt/jwt Baseline
+
+| Benchmark | ns/op | B/op | allocs/op |
+|---|---|---|---|
+| `Sign` — raw `golang-jwt/jwt` | 56,472 | 3,384 | 30 |
+| `IssueAccessToken` — jwtauth | 58,340 | 6,801 | 75 |
+| `Verify` — raw `golang-jwt/jwt` | 2,271 | 4,288 | 62 |
+| `ValidateAccessToken` — jwtauth | 2,642 | 7,384 | 109 |
+
+jwtauth adds **3.3% overhead on signing** (58,340 vs 56,472 ns) and **16% on validation**
+(2,642 vs 2,271 ns) relative to raw `golang-jwt/jwt`. The extra cost covers:
+
+- Key manager cache lookup (read lock on the key map)
+- Refresh token storage and correlation-ID propagation
+- Logging, metrics, and tracing dispatch (no-op in these runs)
+- Claims validation (issuer, audience, expiry enforcement)
+
+The validation overhead in absolute terms is 371 ns — well within single-digit microsecond
+territory for any real-world workload.
+
+---
+
+## Regression Detection
+
+Use `benchstat` to compare two benchmark runs before releasing:
+
+```bash
+# Capture baseline (e.g., from current dev)
+go test -bench=. -benchmem -run=^$ -count=5 ./pkg/storage/ ./pkg/keys/ ./pkg/tokens/ > old.txt
+
+# Make changes, then capture new run
+go test -bench=. -benchmem -run=^$ -count=5 ./pkg/storage/ ./pkg/keys/ ./pkg/tokens/ > new.txt
+
+# Compare
+benchstat old.txt new.txt
+```
+
+Install `benchstat`:
+```bash
+go install golang.org/x/perf/cmd/benchstat@latest
+```
+
+`benchstat` reports statistically significant regressions with a p-value threshold. Any
+benchmark showing > 10% regression with p < 0.05 warrants investigation before merge.
+
+> The suite is designed to run with `-count=1` for quick smoke checks and `-count=5` for
+> release-gate comparisons.
+
+---
+
+## What These Numbers Don't Include
+
+- **Real Redis network RTT.** Storage benchmarks use in-process miniredis. In production,
+  add your observed Redis network RTT (typically 0.5–2 ms per round-trip on a local
+  network) to all Redis `ns/op` figures. For the storage layer, the library's own overhead
+  is the difference between the Memory and Redis columns.
+
+- **Real Redis persistence and replication latency.** AOF fsync and replica propagation
+  add latency beyond network RTT. These are deployment-specific and are the operator's
+  responsibility to benchmark in their environment.
+
+- **HTTP handler overhead.** The token manager is middleware — request parsing,
+  response encoding, and transport cost sit outside this suite.
+
+Real-Redis benchmarks against a known deployment will be published as a separate document
+when a stable infrastructure baseline is available (deferred from v0.5.0 — see
+`CLAUDE.md` Cloud-Dependent Activities).


### PR DESCRIPTION
## Summary

- **`doc/PERFORMANCE.md`** (new): complete benchmark methodology and results for all three library layers — storage (Memory + Redis/miniredis), key manager (cache hit/miss/rotation), and token manager (crypto, lifecycle, bulk revocation N-variants, rotation-under-load, observability tax, golang-jwt baseline). Includes `benchstat` regression-detection workflow and "What These Numbers Don't Include" section deferring real-Redis RTT to a future infrastructure-backed document.
- **`README.md`**: "Performance" section added after Observability Integration with a 6-row summary table, rotation-under-load call-out, and link to `doc/PERFORMANCE.md`.
- **`CHANGELOG.md`**: Microbenchmark suite `### Added` entry under `[Unreleased — v0.5.0]`.

## Reference numbers (Apple M4 Max, Go 1.26.2)

| Operation | ns/op |
|---|---|
| `IssueAccessToken` | 78,775 |
| `ValidateAccessToken` | 5,580 |
| `ValidateAccessToken` (during rotation) | 13,025 (2.3× baseline) |
| `IssueAccessToken` (jwtauth vs raw golang-jwt) | 58,340 vs 56,472 (+3.3%) |
| `ValidateAccessToken` (jwtauth vs raw golang-jwt) | 2,642 vs 2,271 (+16%) |
| `Store` (Memory) | 797 |
| `Store` (Redis/miniredis) | 37,031 |

## Test plan

- [ ] `doc/PERFORMANCE.md` exists and contains all sections from the plan
- [ ] README "Performance" section appears between Observability Integration and Project Structure
- [ ] CHANGELOG entry is present under `[Unreleased — v0.5.0] ### Added`
- [ ] No code changes — docs only, CI should pass without running benchmarks

closes #141