### PR TITLE
perf(tokens): validate hot-path quick-win alloc reductions (Phase 1, refs #142)

### DIFF
--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -153,6 +153,13 @@ var (
 	ErrTokenRevoked        = errors.New("token revoked")
 )
 
+// reservedJWTClaims is the set of standard JWT claim keys that Manager controls.
+// Hoisted to package scope so ValidateAccessTokenWithClaims does not allocate a
+// new map on every call.
+var reservedJWTClaims = map[string]struct{}{
+	"sub": {}, "exp": {}, "nbf": {}, "iat": {}, "jti": {}, "iss": {}, "aud": {},
+}
+
 // ErrInvalidConfig returns a configuration error with the given message.
 // Returned by NewManager when required fields are missing or values are invalid.
 func ErrInvalidConfig(msg string) error {
@@ -1403,12 +1410,10 @@ func (m *Manager) ValidateAccessToken(ctx context.Context, tokenString string) (
 		return nil, err
 	}
 
-	m.logger.Debug("validating access token", ctx)
-
 	// ===== STEP 3: Parse JWT Token =====
-	parseOpts := []jwt.ParserOption{}
+	var parseOpts []jwt.ParserOption
 	if m.clockSkew > 0 {
-		parseOpts = append(parseOpts, jwt.WithLeeway(m.clockSkew))
+		parseOpts = []jwt.ParserOption{jwt.WithLeeway(m.clockSkew)}
 	}
 
 	token, err := jwt.ParseWithClaims(
@@ -1439,9 +1444,6 @@ func (m *Manager) ValidateAccessToken(ctx context.Context, tokenString string) (
 					"error", err)
 				return nil, fmt.Errorf("failed to get public key: %w", err)
 			}
-			m.logger.Debug("public key retrieved for token validation", ctx,
-				"kid", kid)
-
 			return publicKey, nil
 		},
 		parseOpts...,
@@ -1600,12 +1602,9 @@ func (m *Manager) ValidateAccessTokenWithClaims(ctx context.Context, tokenString
 	}
 
 	// ===== STEP 3: Strip Reserved Claims =====
-	reserved := map[string]struct{}{
-		"sub": {}, "exp": {}, "nbf": {}, "iat": {}, "jti": {}, "iss": {}, "aud": {},
-	}
 	custom := make(map[string]interface{}, len(mapClaims))
 	for k, v := range mapClaims {
-		if _, isReserved := reserved[k]; !isReserved {
+		if _, isReserved := reservedJWTClaims[k]; !isReserved {
 			custom[k] = v
 		}
 	}


### PR DESCRIPTION
## Summary

Three no-structural-change optimizations that reduce allocations on the `ValidateAccessToken` and `ValidateAccessTokenWithClaims` hot paths:

- **Package-level `reservedJWTClaims` map** — the per-call map literal in `ValidateAccessTokenWithClaims` was allocated on every invocation; hoisting to `package var` initializes it once at program startup
- **Nil `parseOpts` slice** — `parseOpts := []jwt.ParserOption{}` allocated a slice header unconditionally; changed to `var parseOpts []jwt.ParserOption` (nil when clockSkew is 0, allocated only when needed)
- **Removed two Debug log calls from validate hot path** — `"validating access token"` and `"public key retrieved for token validation"` fired on every successful validation and boxed args into `[]interface{}`; these never contribute to production diagnosis on the success path

## Benchmark results (Apple M4 Max, Go 1.26.2, -count=3)

| Benchmark | Before | After | Delta |
|---|---|---|---|
| `ValidateAccessToken` allocs/op | 109 | 106 | −3 |
| `ValidateAccessTokenWithClaims` allocs/op | 194 | 191 | −3 |

## Verification

- 253 unit + 218 storage + 60 integration specs passing under `-race`
- `golangci-lint`, `go vet`, `govulncheck` all clean
- No interface changes, no new dependencies

## Phase tracker

| Phase | Description | Branch | Status |
|---|---|---|---|
| **1** | Quick wins — reserved map, nil parseOpts, remove Debug calls | `perf/phase-1-validate-quick-wins` | **This PR** |
| 2 | Direct payload extraction — eliminate second JWT parse | `perf/phase-2-payload-extraction` | Pending |
| 3 | Pre-built metric label maps for validation success path | `perf/phase-3-label-pooling` | Pending |
| 4 | Docs — update `doc/PERFORMANCE.md` + CHANGELOG + README | `perf/phase-4-142-docs` | Pending |