### PR TITLE
perf(tokens): eliminate second JWT parse in ValidateAccessTokenWithClaims (Phase 2, refs #142)

### DIFF
--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -72,6 +72,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -1585,27 +1586,36 @@ func (m *Manager) ValidateAccessTokenWithClaims(ctx context.Context, tokenString
 	span.SetAttribute("user_id", registered.Subject)
 	span.SetAttribute("token_id", registered.ID)
 
-	// ===== STEP 2: Re-Parse for Custom Claims =====
-	// Signature is already verified above; ParseUnverified is safe here and
-	// avoids a second key-manager round-trip.
-	rawToken, _, parseErr := jwt.NewParser().ParseUnverified(tokenString, jwt.MapClaims{})
-	if parseErr != nil {
-		// Token validated above — treat missing custom claims as empty rather than error.
+	// ===== STEP 2: Extract Payload Bytes =====
+	// Signature already verified above — only payload bytes are needed.
+	// Splitting directly avoids a second jwt.Parser + jwt.Token + MapClaims alloc.
+	parts := strings.SplitN(tokenString, ".", 3)
+	if len(parts) != 3 {
+		span.SetStatus(tracing.StatusOK, "")
+		return registered, map[string]interface{}{}, nil
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
 		span.SetStatus(tracing.StatusOK, "")
 		return registered, map[string]interface{}{}, nil
 	}
 
-	mapClaims, ok := rawToken.Claims.(jwt.MapClaims)
-	if !ok {
+	// ===== STEP 3: Decode Payload and Strip Reserved Claims =====
+	// Decode into map[string]json.RawMessage first — defers per-value
+	// deserialization so the 7 reserved keys are skipped without boxing.
+	var rawFields map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &rawFields); err != nil {
 		span.SetStatus(tracing.StatusOK, "")
 		return registered, map[string]interface{}{}, nil
 	}
 
-	// ===== STEP 3: Strip Reserved Claims =====
-	custom := make(map[string]interface{}, len(mapClaims))
-	for k, v := range mapClaims {
+	custom := make(map[string]interface{}, max(0, len(rawFields)-len(reservedJWTClaims)))
+	for k, rawVal := range rawFields {
 		if _, isReserved := reservedJWTClaims[k]; !isReserved {
-			custom[k] = v
+			var v interface{}
+			if err := json.Unmarshal(rawVal, &v); err == nil {
+				custom[k] = v
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

`ValidateAccessTokenWithClaims` previously ran two full JWT parses:
1. `jwt.ParseWithClaims(...)` — signature verify + registered claims extraction
2. `jwt.NewParser().ParseUnverified(tokenString, jwt.MapClaims{})` — second parse into `map[string]interface{}` for custom fields

Parse 2 allocated: a new `jwt.Parser`, `jwt.Token`, a second base64 decode of the JWT payload, and `jwt.MapClaims` with every value boxed into `interface{}`. This was the primary source of the 85-alloc gap between the two validate variants.

**This PR replaces Step 2 with direct payload extraction:**
1. `strings.SplitN` to split the already-verified token string — no JWT library involved
2. `base64.RawURLEncoding.DecodeString` on the middle segment — one allocation for the byte slice
3. `json.Unmarshal` into `map[string]json.RawMessage` — defers per-value deserialization so the 7 reserved claim keys are skipped without boxing into `interface{}`

The `encoding/json` import is stdlib — no new `go.mod` entry.

## Benchmark results (Apple M4 Max, Go 1.26.2, -count=3)

| Benchmark | Baseline | After Ph1 | After Ph2 | Total delta |
|---|---|---|---|---|
| `ValidateAccessToken` allocs/op | 109 | 106 | 106 | −3 |
| `ValidateAccessTokenWithClaims` allocs/op | 194 | 191 | 163 | **−31** |

## Verification

- 253 unit + 218 storage + 60 integration specs passing under `-race`
- `golangci-lint`, `go vet`, `govulncheck` all clean
- Custom claims round-trip integration spec confirms values survive the new extraction path

## Phase tracker

| Phase | Description | Branch | Status |
|---|---|---|---|
| 1 | Quick wins — reserved map, nil parseOpts, remove Debug calls | `perf/phase-1-validate-quick-wins` | Merged (#169) |
| **2** | Direct payload extraction — eliminate second JWT parse | `perf/phase-2-payload-extraction` | **This PR** |
| 3 | Pre-built metric label maps for validation success path | `perf/phase-3-label-pooling` | Pending |
| 4 | Docs — update `doc/PERFORMANCE.md` + CHANGELOG + README | `perf/phase-4-142-docs` | Pending |