### PR TITLE
perf(tokens): pre-build validate metric label maps to eliminate per-call allocs (refs #142)

### DIFF
--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -138,6 +138,10 @@ type Manager struct {
 	clockSkew            time.Duration // Leeway applied to exp and nbf validation
 	namespace            string        // Optional; opaque label for observability output
 
+	// ===== Hot-Path Label Cache =====
+	validateCounterSuccessLabels map[string]string // Pre-built success labels for validate counter; avoids per-call map alloc
+	validateDurationLabels       map[string]string // Pre-built labels for validate duration histogram; avoids per-call map alloc
+
 	// ===== State Management =====
 	isRunning    atomic.Bool    // Thread-safe running state
 	shutdownChan chan struct{}   // Signals background goroutines to stop
@@ -254,6 +258,15 @@ func NewManager(config TokenManagerConfig) (*Manager, error) {
 		audience:             config.Audience,
 		namespace:            config.Namespace,
 		shutdownChan:         make(chan struct{}),
+		validateCounterSuccessLabels: map[string]string{
+			"status":     "success",
+			"error_type": "",
+			"namespace":  config.Namespace,
+		},
+		validateDurationLabels: map[string]string{
+			"operation": "validate_access_token",
+			"namespace":  config.Namespace,
+		},
 	}
 
 	return m, nil
@@ -1379,15 +1392,18 @@ func (m *Manager) ValidateAccessToken(ctx context.Context, tokenString string) (
 	status := "error"
 	errorType := "error"
 	defer func() {
-		m.metrics.IncrementCounter(metricTokensValidatedTotal, map[string]string{
-			"status":     status,
-			"error_type": errorType,
-			"namespace":  m.namespace,
-		})
-		m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
-			"operation": "validate_access_token",
-			"namespace":  m.namespace,
-		})
+		var counterLabels map[string]string
+		if status == "success" {
+			counterLabels = m.validateCounterSuccessLabels
+		} else {
+			counterLabels = map[string]string{
+				"status":     status,
+				"error_type": errorType,
+				"namespace":  m.namespace,
+			}
+		}
+		m.metrics.IncrementCounter(metricTokensValidatedTotal, counterLabels)
+		m.metrics.RecordDuration(metricOperationDuration, time.Since(start), m.validateDurationLabels)
 	}()
 
 	// ===== STEP 1: Service State Check =====


### PR DESCRIPTION
## Summary

- Add `validateCounterSuccessLabels` and `validateDurationLabels` fields to `Manager` struct (hot-path label cache section)
- Initialize both maps in `NewManager` after namespace assignment — allocated once at construction, reused on every successful `ValidateAccessToken` call
- Update `ValidateAccessToken` defer to branch on `status`: reuse pre-built maps on the success path; allocate fresh maps only on error paths (which are off the hot path)

## Benchmark result (Apple M4 Max, Go 1.26.2, `-count=3`)

| Method | Before | After | Delta |
|---|---|---|---|
| `ValidateAccessToken` | 106 allocs/op | 102 allocs/op | −4 |

## Cumulative vs baseline (issue #142)

| Method | Baseline | After Phase 3 | Total saved |
|---|---|---|---|
| `ValidateAccessToken` | 109 allocs/op | 102 allocs/op | −7 |
| `ValidateAccessTokenWithClaims` | 194 allocs/op | 163 allocs/op | −31 |

## Notes

- No interface changes. Stdlib only. No new `go.mod` entries.
- The `validateDurationLabels` map is always reused (duration metric has no per-call variance). The counter map is only reused on `status == "success"` — error paths allocate a fresh map because `status` and `error_type` are call-specific.
- Phase 4 (docs update) will run final benchmarks with `-count=5` and update `doc/PERFORMANCE.md`.