### PR TITLE
docs(perf): update PERFORMANCE.md, README, and CHANGELOG for issue #142 (closes #142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ All notable changes to this project will be documented in this file.
 
 - **Microbenchmark suite** — `testing.B` benchmarks in `pkg/storage/bench_test.go`, `pkg/keys/bench_test.go`, and `pkg/tokens/bench_test.go` covering all storage operations (MemoryRefreshStore + RedisRefreshStore via miniredis), key manager cache and rotation paths, token issuance and validation (serial and parallel), rotation-under-load concurrency, observability tax (NoOp vs PrometheusMetrics vs OtelTracer), and a baseline comparison against raw `golang-jwt/jwt`. Results and reproduction instructions in `doc/PERFORMANCE.md`. See #141.
 
+### Performance
+
+- **`ValidateAccessToken` and `ValidateAccessTokenWithClaims` hot-path alloc reduction** — three-phase structural optimization reduces `ValidateAccessToken` from 109 → 102 allocs/op (−7, −6%) and `ValidateAccessTokenWithClaims` from 194 → 159 allocs/op (−35, −18%). Changes are internal to `pkg/tokens/manager.go`: package-level `reservedJWTClaims` map (Phase 1, PR #169); direct base64+JSON payload extraction replacing a second `jwt.ParseUnverified` call (Phase 2, PR #170); pre-built metric label maps reused on the success path (Phase 3, PR #171). No interface changes. Stdlib only. See `doc/PERFORMANCE.md` and #142.
+
 ---
 
 ## [v0.4.0] — 2026-04-30

--- a/README.md
+++ b/README.md
@@ -1055,7 +1055,7 @@ Measured on Apple M4 Max, Go 1.26.2, `GOMAXPROCS=16`. Redis numbers use in-proce
 | Operation | ns/op | B/op | allocs/op |
 |---|---|---|---|
 | `IssueAccessToken` | 78,775 | 6,893 | 75 |
-| `ValidateAccessToken` | 5,580 | 7,384 | 109 |
+| `ValidateAccessToken` | 5,067 | 6,633 | 102 |
 | `IssueTokenPair` | 69,436 | 8,612 | 90 |
 | `RefreshAccessToken` | 867,641 | 9,497 | 109 |
 | `Store` (Memory) | 797 | 2,034 | 23 |

--- a/doc/PERFORMANCE.md
+++ b/doc/PERFORMANCE.md
@@ -111,15 +111,41 @@ All token manager benchmarks use `MemoryRefreshStore` for deterministic crypto i
 | `IssueAccessTokenWithClaims` — Small (2 fields) | 68,787 | 8,660 | 94 |
 | `IssueAccessTokenWithClaims` — Medium (10 fields) | 79,835 | 11,751 | 113 |
 | `IssueAccessTokenWithClaims` — Large (50 fields) | 106,376 | 30,066 | 202 |
-| `ValidateAccessToken` | 5,580 | 7,384 | 109 |
-| `ValidateAccessTokenWithClaims` | 7,116 | 11,752 | 194 |
+| `ValidateAccessToken` | 5,067 | 6,633 | 102 |
+| `ValidateAccessTokenWithClaims` | 6,140 | 9,840 | 159 |
 | `IssueTokenPair` | 69,436 | 8,612 | 90 |
 
-Issuance (~70–80 µs) is dominated by RSA 2048-bit signing. Validation (~5.6 µs) is PKCS#1
-v1.5 verification — roughly 14× faster than signing.
+Issuance (~70–80 µs) is dominated by RSA 2048-bit signing. Validation (~5.1 µs) is PKCS#1
+v1.5 verification — roughly 15× faster than signing.
 
 `WithAudience` adds no measurable overhead — the functional-option closure dispatch is
 noise relative to RSA signing cost.
+
+#### v0.5.0 Alloc Reduction — Issue #142
+
+Three-phase structural fix targeting the `ValidateAccessToken` / `ValidateAccessTokenWithClaims`
+hot path. All changes are in `pkg/tokens/manager.go`. No interface changes. Stdlib only.
+
+| Method | Before (v0.4.0) | After (v0.5.0) | Alloc Δ |
+|---|---|---|---|
+| `ValidateAccessToken` | 5,580 ns / 7,384 B / 109 allocs | 5,067 ns / 6,633 B / 102 allocs | −7 allocs (−6%) |
+| `ValidateAccessTokenWithClaims` | 7,116 ns / 11,752 B / 194 allocs | 6,140 ns / 9,840 B / 159 allocs | −35 allocs (−18%) |
+
+**Phase 1 (PR #169):** Hoisted `reservedJWTClaims` from a per-call map literal to a package-level
+`var`; changed `parseOpts` from an empty-slice literal to nil (saves a slice-header alloc when
+`ClockSkew` is zero); removed two `Debug` log calls on the critical path.
+
+**Phase 2 (PR #170):** Replaced `jwt.NewParser().ParseUnverified(tokenString, jwt.MapClaims{})` in
+`ValidateAccessTokenWithClaims` with direct payload extraction — `strings.SplitN` +
+`base64.RawURLEncoding.DecodeString` + `json.Unmarshal` into `map[string]json.RawMessage`. The
+signature is already verified by the preceding `ParseWithClaims` call; the second parse existed
+solely to extract raw claim values. Decoding into `json.RawMessage` defers per-value
+deserialization so the seven reserved keys are skipped before any boxing occurs.
+
+**Phase 3 (PR #171):** Added `validateCounterSuccessLabels` and `validateDurationLabels` fields to
+`Manager`, initialized once in `NewManager`. The `ValidateAccessToken` defer reuses the pre-built
+maps on the success path — fresh maps are allocated only on error paths, which are off the hot
+path.
 
 ### Token Lifecycle
 


### PR DESCRIPTION
## Summary

Final docs phase for issue #142 — hot-path alloc reduction on `ValidateAccessToken` / `ValidateAccessTokenWithClaims`.

- **`doc/PERFORMANCE.md`** — update Pure Crypto table with post-optimization numbers; add "v0.5.0 Alloc Reduction — Issue #142" subsection with before/after table and per-phase explanation (Phases 1–3, PRs #169–#171)
- **`README.md`** — update `ValidateAccessToken` row in Performance summary table
- **`CHANGELOG.md`** — add `### Performance` section under `[Unreleased — v0.5.0]`

## Before / After (Apple M4 Max, Go 1.26.2, `-count=5`)

| Method | Before | After | Δ |
|---|---|---|---|
| `ValidateAccessToken` | 5,580 ns / 7,384 B / 109 allocs | 5,067 ns / 6,633 B / 102 allocs | −7 allocs (−6%) |
| `ValidateAccessTokenWithClaims` | 7,116 ns / 11,752 B / 194 allocs | 6,140 ns / 9,840 B / 159 allocs | −35 allocs (−18%) |

## Notes

- No code changes — docs only.
- `closes #142` is in this PR per the phased plan (Phases 1–3 used `refs #142`).