### PR TITLE
chore: add Apache 2.0 SPDX headers to all Go source files (closes #144)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,10 +3,16 @@ linters:
   default: none
   enable:
     - errcheck
+    - goheader
     - govet
     - ineffassign
     - staticcheck
   settings:
+    goheader:
+      template: |-
+        Copyright 2026 Angel Tomala-Reyes
+
+        SPDX-License-Identifier: Apache-2.0
     errcheck:
       check-type-assertions: false
       exclude-functions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ All notable changes to this project will be documented in this file.
 
 - **Microbenchmark suite** — `testing.B` benchmarks in `pkg/storage/bench_test.go`, `pkg/keys/bench_test.go`, and `pkg/tokens/bench_test.go` covering all storage operations (MemoryRefreshStore + RedisRefreshStore via miniredis), key manager cache and rotation paths, token issuance and validation (serial and parallel), rotation-under-load concurrency, observability tax (NoOp vs PrometheusMetrics vs OtelTracer), and a baseline comparison against raw `golang-jwt/jwt`. Results and reproduction instructions in `doc/PERFORMANCE.md`. See #141.
 
+### Chore
+
+- **Apache 2.0 SPDX license headers added to all Go source files** — every `.go` file under `pkg/`, `internal/`, and `examples/` now carries a 3-line header (`Copyright 2026 Angel Tomala-Reyes` + `SPDX-License-Identifier: Apache-2.0`). `goheader` added to `.golangci.yml` to enforce headers on new files going forward. See #144.
+
 ### Documentation
 
 - **`SECURITY.md` created** — vulnerability disclosure policy at the repo root: supported versions table, private advisory reporting flow via GitHub Security Advisories, coordinated disclosure policy, in-scope / out-of-scope matrix (rate limiting and middleware explicitly out of scope), and an ADR reference table for all security-relevant design decisions. See #133.

--- a/examples/chi-example/auth/middleware.go
+++ b/examples/chi-example/auth/middleware.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package auth
 
 import (

--- a/examples/chi-example/main.go
+++ b/examples/chi-example/main.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/examples/correlation-example/main.go
+++ b/examples/correlation-example/main.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // correlation-example demonstrates end-to-end correlation ID support using only
 // the standard library. Every log line produced during a request carries the
 // same correlation_id, making production log filtering trivial:

--- a/examples/echo-example/main.go
+++ b/examples/echo-example/main.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/examples/echo-example/middleware/auth.go
+++ b/examples/echo-example/middleware/auth.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package middleware
 
 import (

--- a/examples/gin-example/main.go
+++ b/examples/gin-example/main.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/examples/gin-example/middleware/auth.go
+++ b/examples/gin-example/middleware/auth.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package middleware
 
 import (

--- a/examples/health-check/main.go
+++ b/examples/health-check/main.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/examples/prometheus-metrics/main.go
+++ b/examples/prometheus-metrics/main.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/examples/token-audit/main.go
+++ b/examples/token-audit/main.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/examples/tracing-example/main.go
+++ b/examples/tracing-example/main.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // tracing-example demonstrates distributed tracing with jwtauth using the
 // OpenTelemetry SDK and the stdout exporter. Spans are printed to stdout — no
 // external backend (Jaeger, Zipkin, etc.) is required.

--- a/internal/testutil/errors.go
+++ b/internal/testutil/errors.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package testutil
 
 import "fmt"

--- a/internal/testutil/mock_logger.go
+++ b/internal/testutil/mock_logger.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package testutil
 
 import (

--- a/pkg/keys/bench_test.go
+++ b/pkg/keys/bench_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package keys_test
 
 import (

--- a/pkg/keys/disk.go
+++ b/pkg/keys/disk.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package keys
 
 import (

--- a/pkg/keys/disk_test.go
+++ b/pkg/keys/disk_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package keys_test
 
 import (

--- a/pkg/keys/export_test.go
+++ b/pkg/keys/export_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package keys
 
 // PemPrefix returns the effective PEM key prefix for testing purposes only.

--- a/pkg/keys/interface.go
+++ b/pkg/keys/interface.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package keys
 
 import (

--- a/pkg/keys/keystore.go
+++ b/pkg/keys/keystore.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package keys
 
 import (

--- a/pkg/keys/manager.go
+++ b/pkg/keys/manager.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Package keys provides zero-downtime RSA key rotation for JWT signing.
 //
 // KeyManager generates RSA key pairs, rotates them on a configurable schedule, and

--- a/pkg/keys/manager_test.go
+++ b/pkg/keys/manager_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package keys_test
 
 import (

--- a/pkg/keys/observability.go
+++ b/pkg/keys/observability.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package keys
 
 // Metric names for KeyStore operations. Both DiskKeyStore and any future

--- a/pkg/keys/redis.go
+++ b/pkg/keys/redis.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package keys
 
 import (

--- a/pkg/keys/redis_test.go
+++ b/pkg/keys/redis_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package keys_test
 
 import (

--- a/pkg/logging/correlation.go
+++ b/pkg/logging/correlation.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package logging
 
 import "context"

--- a/pkg/logging/correlation_handler.go
+++ b/pkg/logging/correlation_handler.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package logging
 
 import (

--- a/pkg/logging/correlation_handler_test.go
+++ b/pkg/logging/correlation_handler_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package logging_test
 
 import (

--- a/pkg/logging/correlation_test.go
+++ b/pkg/logging/correlation_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package logging_test
 
 import (

--- a/pkg/logging/interface.go
+++ b/pkg/logging/interface.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package logging
 
 // Logger is the standard logging interface for the JWT authorization token engine.

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package logging_test
 
 import (

--- a/pkg/logging/noop.go
+++ b/pkg/logging/noop.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package logging
 
 // NoOpLogger is a Logger implementation that discards all log messages.

--- a/pkg/logging/slog.go
+++ b/pkg/logging/slog.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package logging
 
 import (

--- a/pkg/metrics/interface.go
+++ b/pkg/metrics/interface.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Generate mock from this interface using mockgen
 //go:generate mockgen -source=interface.go -destination=../../internal/testutil/mock_metrics.go -package=testutil -mock_names=Metrics=MockMetrics
 

--- a/pkg/metrics/metrics_suite_test.go
+++ b/pkg/metrics/metrics_suite_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package metrics_test
 
 import (

--- a/pkg/metrics/noop.go
+++ b/pkg/metrics/noop.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package metrics
 
 import "time"

--- a/pkg/metrics/noop_test.go
+++ b/pkg/metrics/noop_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package metrics_test
 
 import (

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package metrics
 
 import (

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package metrics_test
 
 import (

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package storage_test
 
 import (

--- a/pkg/storage/errors.go
+++ b/pkg/storage/errors.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package storage
 
 import "errors"

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package storage
 
 import (

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package storage
 
 import (

--- a/pkg/storage/memory_test.go
+++ b/pkg/storage/memory_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package storage_test
 
 import (

--- a/pkg/storage/observability.go
+++ b/pkg/storage/observability.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package storage
 
 // Metric names for storage operations. Both MemoryRefreshStore and

--- a/pkg/storage/redis.go
+++ b/pkg/storage/redis.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package storage
 
 import (

--- a/pkg/storage/redis_test.go
+++ b/pkg/storage/redis_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package storage_test
 
 import (

--- a/pkg/storage/storage_suite_test.go
+++ b/pkg/storage/storage_suite_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package storage_test
 
 import (

--- a/pkg/storage/suite_test.go
+++ b/pkg/storage/suite_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package storage_test
 
 import (

--- a/pkg/tokens/bench_test.go
+++ b/pkg/tokens/bench_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package tokens_test
 
 import (

--- a/pkg/tokens/claims.go
+++ b/pkg/tokens/claims.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package tokens
 
 import (

--- a/pkg/tokens/helpers_test.go
+++ b/pkg/tokens/helpers_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package tokens_test
 
 import (

--- a/pkg/tokens/integration/disk_memory_test.go
+++ b/pkg/tokens/integration/disk_memory_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package integration

--- a/pkg/tokens/integration/integration_suite_test.go
+++ b/pkg/tokens/integration/integration_suite_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package integration

--- a/pkg/tokens/integration/redis_test.go
+++ b/pkg/tokens/integration/redis_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package integration

--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Package tokens provides stateful JWT authorization token management.
 //
 // Manager handles the complete token lifecycle: access token issuance with

--- a/pkg/tokens/manager_lifecycle_test.go
+++ b/pkg/tokens/manager_lifecycle_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package tokens_test
 
 import (

--- a/pkg/tokens/manager_list_tokens_test.go
+++ b/pkg/tokens/manager_list_tokens_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package tokens_test
 
 import (

--- a/pkg/tokens/manager_metrics_test.go
+++ b/pkg/tokens/manager_metrics_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package tokens_test
 
 import (

--- a/pkg/tokens/manager_test.go
+++ b/pkg/tokens/manager_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package tokens_test
 
 import (

--- a/pkg/tokens/observability.go
+++ b/pkg/tokens/observability.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package tokens
 
 // Metric names for TokenManager operations. All implementations record the

--- a/pkg/tokens/options.go
+++ b/pkg/tokens/options.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package tokens
 
 // IssueOption configures per-call behaviour of token issuing methods.

--- a/pkg/tracing/interface.go
+++ b/pkg/tracing/interface.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Package tracing provides distributed tracing abstractions for the JWT authentication system.
 //
 // All components (KeyManager, TokenService, RefreshStore, KeyStore) accept optional

--- a/pkg/tracing/noop.go
+++ b/pkg/tracing/noop.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package tracing
 
 import "context"

--- a/pkg/tracing/noop_test.go
+++ b/pkg/tracing/noop_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package tracing_test
 
 import (

--- a/pkg/tracing/otel.go
+++ b/pkg/tracing/otel.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package tracing
 
 import (

--- a/pkg/tracing/otel_test.go
+++ b/pkg/tracing/otel_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package tracing_test
 
 import (


### PR DESCRIPTION
## Summary

- Stamps every `.go` file under `pkg/`, `internal/`, and `examples/` with a 3-line SPDX header using `google/addlicense` with a custom template file:
  ```
  // Copyright 2026 Angel Tomala-Reyes
  //
  // SPDX-License-Identifier: Apache-2.0
  ```
- Adds `goheader` to `.golangci.yml` so CI catches any new `.go` file added without the header going forward.

## Stats

- 66 source files stamped, 1 CHANGELOG entry, 1 `.golangci.yml` change
- 0 logic changes — header prepend only

## Verification

- `golangci-lint run ./...` passes with `goheader` enabled — 0 issues
- All 253 unit + 60 integration specs pass under `-race`

## Test plan

- [x] Confirm `golangci-lint run ./...` passes in CI
- [x] Spot-check a few files in the GitHub diff to confirm header format is correct
- [x] Add a headerless `.go` file locally, run `golangci-lint`, confirm it fails — then delete it