### PR TITLE
docs(adr): apply correctness fixes from ADR audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,11 +668,11 @@ sequenceDiagram
     Client->>API: POST /login (credentials)
     API->>API: Verify credentials
     API->>Manager: IssueTokenPair(ctx, userID)
-    Manager->>KeyMgr: GetCurrentSigningKey()
-    KeyMgr-->>Manager: RSA private key
-    Manager->>Manager: Sign JWT access token
-    Manager->>Manager: Generate refresh token (UUID)
-    Manager->>Redis: Store(refreshToken, userID, expiry)
+    Manager->>KeyMgr: GetCurrentSigningKey(ctx)
+    KeyMgr-->>Manager: RSA private key + keyID
+    Manager->>Manager: Sign JWT access token (kid header = keyID)
+    Manager->>Manager: Generate refresh token (256-bit random)
+    Manager->>Redis: Store(refreshToken, userID, audience, expiry)
     Redis-->>Manager: OK
     Manager-->>API: accessToken, refreshToken
     API-->>Client: 200 OK {access, refresh}
@@ -681,10 +681,11 @@ sequenceDiagram
     
     Client->>API: GET /protected (Bearer accessToken)
     API->>Manager: ValidateAccessToken(ctx, accessToken)
-    Manager->>KeyMgr: GetPublicKeys()
-    KeyMgr-->>Manager: RSA public keys
+    Manager->>Manager: Extract kid from token header
+    Manager->>KeyMgr: GetPublicKey(ctx, kid)
+    KeyMgr-->>Manager: RSA public key
     Manager->>Manager: Verify signature + claims
-    Manager-->>API: claims (userID, exp, iss, aud)
+    Manager-->>API: *jwt.RegisteredClaims
     API->>API: Process request
     API-->>Client: 200 OK {data}
 
@@ -692,11 +693,11 @@ sequenceDiagram
     
     Client->>API: POST /refresh (refreshToken)
     API->>Manager: RefreshAccessToken(ctx, refreshToken)
-    Manager->>Redis: Get(refreshToken)
-    Redis-->>Manager: {userID, expiry}
-    Manager->>Manager: Check expiry
-    Manager->>KeyMgr: GetCurrentSigningKey()
-    KeyMgr-->>Manager: RSA private key
+    Manager->>Redis: Retrieve(refreshToken)
+    Redis-->>Manager: {userID, audience, expiry}
+    Manager->>Manager: Check expiry and revocation
+    Manager->>KeyMgr: GetCurrentSigningKey(ctx)
+    KeyMgr-->>Manager: RSA private key + keyID
     Manager->>Manager: Sign new JWT access token
     Manager-->>API: newAccessToken
     API-->>Client: 200 OK {access}
@@ -705,7 +706,7 @@ sequenceDiagram
     
     Client->>API: POST /logout (refreshToken)
     API->>Manager: RevokeRefreshToken(ctx, refreshToken)
-    Manager->>Redis: Delete(refreshToken)
+    Manager->>Redis: Revoke(refreshToken)
     Redis-->>Manager: OK
     Manager-->>API: OK
     API-->>Client: 200 OK
@@ -1084,47 +1085,49 @@ See [doc/ARCHITECTURE.md](doc/ARCHITECTURE.md#project-structure) for the package
 
 ### Test Coverage
 
-**Current**: 605 comprehensive tests across KeyManager, TokenManager, RefreshStore, Metrics, Logging, and Tracing, all passing with race detection (KeyManager ~90%, TokenManager ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%)
+**Current**: 947 comprehensive specs (887 unit + 60 integration) across all packages, all passing with race detection (KeyManager ~90%, TokenManager ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%)
 
-**KeyManager** (3 test suites — 125 total specs):
-- **9-phase Manager tests** (52 specs, MockKeyStore — no I/O):
+**KeyManager** (3 test suites — 168 total specs):
+- **9-phase Manager tests** (MockKeyStore — no I/O):
   - Constructor validation, config defaults, ErrInvalidKeyStore
   - Start: loads from store, generates key on empty store, error paths
   - GetCurrentSigningKey, GetPublicKey (cache hit/miss), GetJWKS
   - RotateKeys: Save + UpdateMetadata calls, currentKeyID update
   - Shutdown: scheduler stop, idempotency, context timeout
   - Metrics recording: rotation counter/duration, signing/validation counters, active-versions gauge
-- **10-phase DiskKeyStore tests** (42 specs, real tmp directory):
+- **10-phase DiskKeyStore tests** (real tmp directory):
   - Constructor, Save (0600 permissions, companion JSON), LoadAll
   - LoadKey (key size validation), UpdateMetadata, Delete (idempotent)
   - Error handling, concurrency, metrics recording (storage_backend: "disk"), tracing
-- **10-phase RedisKeyStore tests** (39 specs, miniredis):
+- **10-phase RedisKeyStore tests** (miniredis):
   - Constructor (nil client returns ErrNilRedisClient), Save round-trip, LoadAll (skip expired)
   - LoadKey, UpdateMetadata, Delete (idempotent)
   - Error handling: corrupt metadata, missing metadata entry, Redis unavailability via SetError
   - Concurrency, metrics recording (storage_backend: "redis")
 
-**TokenManager** (7 test suites, 153 total tests):
-- **Lifecycle Management Tests** (20 tests):
+**TokenManager** (7 test suites, 253 total specs):
+- **Lifecycle Management Tests**:
   - Start: idempotency, logging, background cleanup, failure handling, context cancellation
-  - Shutdown: logging, cleanup termination, goroutine coordination, timeout respect, idempotency
+  - Shutdown: logging, cleanup termination, goroutine coordination, timeout respect, idempotency, restart after clean shutdown
   - IsRunning: state tracking and thread-safety verification
-  - Complete Lifecycle: integration test of start → use → shutdown cycle
+  - Complete Lifecycle: integration test of start → use → shutdown → restart cycle
 - **Token Issuance Tests**:
-  - IssueAccessToken / IssueAccessTokenWithClaims: successful issuance, custom claims, reserved claim protection, guard conditions
-  - IssueRefreshToken: successful issuance, storage, metadata handling, guard conditions
-  - IssueTokenPair: coordinated access and refresh token issuance, guard conditions
+  - IssueAccessToken / IssueAccessTokenWithClaims: successful issuance, custom claims, reserved claim protection, per-call audience override via `WithAudience`, guard conditions
+  - IssueRefreshToken / IssueRefreshTokenWithClaims: issuance, storage, audience stored on token, metadata handling, guard conditions
+  - IssueTokenPair / IssueTokenPairWithClaims: coordinated access and refresh token issuance, guard conditions
 - **Validation & Refresh Tests**:
   - ValidateAccessToken / ValidateAccessTokenWithClaims: signature verification, claims extraction, custom claims round-trip, clock skew leeway, expiration, audience/issuer enforcement, wrong signing method, missing kid header, guard conditions
-  - RefreshAccessToken: token rotation, revocation checks, expiration handling, error propagation, guard conditions
+  - RefreshAccessToken / RefreshAccessTokenWithClaims: token rotation, audience propagation, revocation checks, expiration handling, error propagation, guard conditions
 - **Revocation & Introspection Tests**:
   - RevokeRefreshToken / RevokeAllUserTokens: single and bulk revocation flows
-  - IntrospectToken: active/inactive/revoked/expired status per RFC 7662
+  - RevokeAllForAudience / RevokeAllForUserAndAudience: audience-scoped token revocation
+  - IntrospectToken: active/inactive/revoked/expired status per RFC 7662; `TokenID` and `Audience` populated on all paths
   - CleanupExpiredTokens: manual sweep with error handling
+- **Enumeration Tests**: ListTokens, ListTokensForUser, ListTokensForAudience — cursor-based pagination, audience isolation
 - **Concurrent Operations**: parallel token issuance and service state safety
 
-**RefreshStore** (154 total tests: 77 per implementation × 2):
-- **Shared Test Suite** (77 tests, runs against both Memory and Redis):
+**RefreshStore** (218 total specs: 109 per implementation × 2):
+- **Shared Test Suite** (109 specs, runs against both Memory and Redis):
   - **Phase 1**: Constructor initialization
   - **Phase 2**: Happy paths (Store, Retrieve) with metadata preservation
   - **Phase 3**: Input validation (empty/whitespace tokenID/userID, expired tokens, metadata defensive copy)
@@ -1132,12 +1135,40 @@ See [doc/ARCHITECTURE.md](doc/ARCHITECTURE.md#project-structure) for the package
   - **Phase 5**: Retrieve validation and state checks (revocation, expiration)
   - **Phase 6**: Revoke idempotency and state-changing operations
   - **Phase 7**: RevokeAllForUser bulk operations with user isolation
+  - **Phase 7.5**: RevokeAllForAudience / RevokeAllForUserAndAudience — audience-scoped revocation with isolation guarantees
   - **Phase 8**: Cleanup (expired token removal, mixed expiration states)
   - **Phase 8.5**: Edge cases (unicode characters, large-scale operations, far-future timestamps)
   - **Phase 9**: Context cancellation handling across all operations
   - **Phase 12**: `ListTokens` — global cursor-based pagination (empty store, single page, multi-page, empty cursor, exhausted cursor, cancelled context)
   - **Phase 13**: `ListTokensForUser` — user-scoped cursor-based pagination (user isolation, empty userID validation, multi-page, cancelled context)
+  - **Phase 14**: `ListTokensForAudience` — audience-scoped cursor-based pagination (audience isolation, SSCAN passthrough on Redis, multi-page, cancelled context)
 - **Test Suite Architecture**: Single parameterized suite eliminates 800+ lines of duplication, ensures both implementations have identical semantics
+
+**Logging** (104 specs):
+- Correlation ID injection — `WithCorrelationID`, `GetCorrelationID` context helpers
+- `CorrelationIDHandler` — slog handler wrapping for correlation ID propagation across service boundaries
+- `SlogAdapter` — context-aware routing to `*Context()` slog methods
+- `NewCorrelationJSONLogger` / `NewCorrelationTextLogger` — pre-wired production constructors
+- `NoOpLogger` — no-op implementation
+
+**Metrics** (66 specs):
+- `PrometheusMetrics` — 27 pre-registered metrics covering all six components
+- `IncrementCounter`, `AddCounter`, `SetGauge`, `RecordHistogram`, `RecordDuration` implementations
+- Label correctness: `error_type` label on all counters, `namespace` label propagation
+- `NoOpMetrics` — no-op implementation
+
+**Tracing** (78 specs):
+- `NoOpTracer` / `NoOpSpan` — no-op implementation, race-detection clean
+- `OtelTracer` adapter — bridges `pkg/tracing.Tracer` to `go.opentelemetry.io/otel`
+- `SpanOption` functional options: `WithAttributes`, `WithSpanKind`
+- All `StatusCode` and `SpanKind` enum values exercised
+
+**Integration Tests** (60 specs, `pkg/tokens/integration/`):
+- Runs against both disk+memory and Redis backends (miniredis)
+- Full token lifecycle: issuance, validation, refresh, revocation, enumeration
+- Audience-scoped revocation (`RevokeAllForAudience`, `RevokeAllForUserAndAudience`) and enumeration (`ListTokensForAudience`)
+- Custom claims round-trip, cursor-based pagination (`ListTokens`, `ListTokensForUser`, `ListTokensForAudience`)
+- `--fail-on-pending` enforced in CI
 
 **Test Organization**:
 - Separate test files for logical concerns (`manager_test.go`, `manager_lifecycle_test.go`)
@@ -1211,7 +1242,7 @@ Tests follow **progressive phase-based development**:
 
 ### v0.4.0
 - ✅ `pkg/tracing` interfaces scaffolded — `Tracer`, `Span`, `SpanOption`, `StatusCode`, `SpanKind`
-- ✅ `NoOpTracer` / `NoOpSpan` implementations (36 tests, race-detection clean)
+- ✅ `NoOpTracer` / `NoOpSpan` implementations (race-detection clean)
 - ✅ `MockTracer` / `MockSpan` generated for dependency injection in component tests
 - ✅ Tracing wired into all six components — `DiskKeyStore`, `RedisKeyStore`, `MemoryRefreshStore`, `RedisRefreshStore`, `KeyManager`, `TokenManager`
 - ✅ `OtelTracer` adapter (`pkg/tracing/otel`) bridging `pkg/tracing.Tracer` to `go.opentelemetry.io/otel`
@@ -1219,12 +1250,50 @@ Tests follow **progressive phase-based development**:
 - ✅ `KeyPrefix` field on `RedisKeyStoreConfig` and `RedisRefreshStoreConfig` — isolates Redis keys per instance for multi-tenant deployments
 - ✅ Cursor-based token enumeration: `ListTokens` and `ListTokensForUser` on `RefreshStore` and `TokenManager`
 
+### v0.5.0 ✅ Complete
+- ✅ Relicensed MIT → Apache 2.0 (effective v0.5.0; v0.4.0 and earlier remain MIT)
+- ✅ Apache 2.0 SPDX headers on all 66 `.go` source files; `goheader` linter added to CI
+- ✅ `IssueOption` / `WithAudience` — per-call audience targeting on all 6 issuing methods
+- ✅ `RefreshToken.Audience []string` — audience stored with token and propagated through refresh
+- ✅ `RevokeAllForAudience` + `RevokeAllForUserAndAudience` — audience-scoped instant revocation
+- ✅ `ListTokensForAudience` — audience-scoped cursor-based token enumeration
+- ✅ `TokenMetadata.Audience` and `TokenMetadata.TokenID` populated by `IntrospectToken` on all paths
+- ✅ Microbenchmark suite — library-level performance baselines for storage, key management, and token lifecycle
+- ✅ Hot-path alloc reduction — `ValidateAccessToken`: 109→102 allocs/op; `ValidateAccessTokenWithClaims`: 194→159 allocs/op
+- ✅ `SECURITY.md` — vulnerability disclosure policy, coordinated disclosure, in/out-of-scope matrix
+- ✅ Redis Security Hardening guide — TLS, ACL minimum command sets, network isolation in `doc/DEPLOYMENT.md`
+- ✅ Custom Claims Validation guidance — type-assert and range-check responsibility in `doc/DEPLOYMENT.md`
+- ✅ Rate Limiting recommended starting values table + gateway configuration references
+
+### v0.6.0
+- Standardize expiration boundary semantics across `MemoryRefreshStore` and `RedisRefreshStore` — eliminate `Before` vs `Before || Equal` divergence
+- Fix nil pointer dereference in `GetKeyInfo` when a key was loaded via `GetPublicKey` (public-only cached `KeyPair`)
+- Add `ErrTokenMissingKid` package-level sentinel — replace inline `errors.New` so callers can use `errors.Is`
+- Guard `cleanupExpiredKeys` from removing the current signing key — prevent token signing failures during rotation
+- Pin `Cleanup()` return value to deleted-token count across both `RefreshStore` implementations
+- Add missing duration histograms for `RevokeAllForAudience` and `RevokeAllForUserAndAudience` in `PrometheusMetrics`
+- ADR-009 — document multi-audience token revocation atomicity (why revoking by audience A fully revokes multi-audience tokens)
+
+### v0.7.0
+- `GetAllKeyInfo() ([]KeyInfo, error)` on `KeyManager` — enumerate all active keys for admin surfaces and health checks
+- Namespace field — wire through logs, spans, and metric labels across all six components; or formally demote and document as a v1.1 commitment
+- ADR-010 — JTI uniqueness and replay prevention stance (JTI is for audit correlation, not replay prevention)
+- ADR-011 — cursor semantics and pagination consistency contract (opaque cursors, best-effort ordering guarantees)
+- Example: `examples/audience-revocation/` — multi-audience issuance, `ListTokensForAudience`, `RevokeAllForAudience` round-trip
+- Example: `examples/redis-production/` — `RedisKeyStore` + `RedisRefreshStore` with `KeyPrefix` and `Namespace`
+- Example: `examples/custom-store/` — minimal `RefreshStore` implementation stub with compile-time assertion
+
 ### v1.0.0 (Stable)
-- API stability guarantee
-- Production-ready for all components
-- Comprehensive documentation
-- OpenTelemetry integration complete
-- Performance benchmarks
+- API stability guarantee across `KeyManager`, `TokenManager`, `RefreshStore`, `KeyStore`, and all observability interfaces
+- Production-ready documentation for all components
+- Example: `IntrospectToken` in framework middleware
+- Example: `GetJWKS` endpoint pattern
+- Example: `CleanupExpiredTokens` manual trigger
+- Span attribute naming convention enforced and documented
+- `PrometheusMetrics.MetricNames()` — programmatic enumeration of registered metric names
+
+### v1.1.0
+- PostgreSQL `RefreshStore` implementation — durable, transactional token storage for deployments that already operate a PostgreSQL cluster and want to avoid a Redis dependency
 
 ## Architecture
 
@@ -1244,7 +1313,7 @@ This library follows SOLID principles and clean architecture patterns. For detai
 | ADR | Decision | Date |
 |-----|----------|------|
 | [ADR-001](doc/adr/001-no-rate-limiting.md) | No rate limiting — belongs at API Gateway / infrastructure layer | 2026-03-11 |
-| [ADR-002](doc/adr/002-stateful-refresh-tokens.md) | Stateful refresh tokens — opaque UUIDs for instant revocation | 2026-03-18 |
+| [ADR-002](doc/adr/002-stateful-refresh-tokens.md) | Stateful refresh tokens — opaque 256-bit random values for instant revocation | 2026-03-18 |
 | [ADR-003](doc/adr/003-rs256-only.md) | RS256 only — prevents algorithm confusion attacks | 2026-04-01 |
 | [ADR-004](doc/adr/004-kid-validation.md) | `kid` UUID validation at every `KeyStore` boundary — path traversal prevention | 2026-04-21 |
 | [ADR-005](doc/adr/005-security-boundaries.md) | Security boundaries — explicit validation gate for every attacker-controlled token field | 2026-04-21 |
@@ -1281,7 +1350,7 @@ Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for requirements, 
 
 ## Requirements
 
-- **Go 1.21+**
+- **Go 1.26+**
 - No external dependencies for core functionality
 - Optional: Ginkgo/Gomega for running tests
 
@@ -1306,8 +1375,8 @@ Built by a Senior Platform Engineer with deep experience in distributed systems 
 
 ---
 
-**Status**: v0.4.0 — production-quality, pre-v1.0 (see API Stability note at top)
-**Version**: v0.4.0
+**Status**: v0.5.0-dev — production-quality, pre-v1.0 (see API Stability note at top)
+**Version**: v0.5.0 (active development; latest release: v0.4.0)
 **Components**: KeyManager ✅ | TokenManager ✅ | RefreshStore (Memory + Redis) ✅ | Metrics (Prometheus) ✅ | Logging (Correlation ID) ✅ | Tracing ✅
-**Test Coverage**: 605 tests (KeyManager ~90%, TokenManager ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%), all passing, race-detection enabled
-**Last Updated**: April 29, 2026
+**Test Coverage**: 947 specs (887 unit + 60 integration) — KeyManager ~90%, TokenManager ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100% — all passing, race-detection enabled
+**Last Updated**: May 6, 2026

--- a/doc/adr/001-no-rate-limiting.md
+++ b/doc/adr/001-no-rate-limiting.md
@@ -33,7 +33,7 @@ Users should implement rate limiting at the infrastructure layer:
 - Cloudflare / CDN
 
 For application-level rate limiting, users can choose from existing Go libraries:
-- `golang.org/x/time/rate` (standard library)
+- `golang.org/x/time/rate` (golang.org/x extended package — separate module)
 - `github.com/ulule/limiter` (Redis-backed)
 - `github.com/throttled/throttled` (flexible)
 

--- a/doc/adr/002-stateful-refresh-tokens.md
+++ b/doc/adr/002-stateful-refresh-tokens.md
@@ -28,7 +28,7 @@ JWT tokens can be stateless (no server-side storage) or stateful (server tracks 
 
 **We will use stateful refresh tokens with server-side storage.**
 
-Refresh tokens are opaque identifiers (UUIDs) stored in a RefreshStore backend. Access tokens remain stateless JWTs (no storage required for validation).
+Refresh tokens are opaque, 256-bit cryptographically random identifiers stored in a RefreshStore backend — not JWTs, so clients cannot decode or inspect them. Access tokens remain stateless JWTs (no storage required for validation).
 
 **Storage backends:**
 - `MemoryRefreshStore`: In-memory (single-instance, testing)
@@ -38,7 +38,7 @@ Refresh tokens are opaque identifiers (UUIDs) stored in a RefreshStore backend. 
 ## Consequences
 
 **Positive:**
-- Instant revocation (RevokeRefreshToken, RevokeAllUserTokens)
+- Instant revocation (RevokeRefreshToken, RevokeAllUserTokens, RevokeAllForAudience, RevokeAllForUserAndAudience)
 - Session management (know which devices are logged in)
 - Security event response (compromise → revoke immediately)
 - Compliance (GDPR "right to be forgotten" — revoke all tokens)

--- a/doc/adr/005-security-boundaries.md
+++ b/doc/adr/005-security-boundaries.md
@@ -34,6 +34,7 @@ The gates implemented in jwtauth are:
 | `iss` | Compared against configured `Issuer` after parse | `ErrTokenInvalidClaims` |
 | `aud` | Compared against configured `Audience` after parse | `ErrTokenInvalidClaims` |
 | `exp` | Checked against `time.Now()` with leeway | `ErrTokenExpired` |
+| `nbf` | Checked against `time.Now()` with leeway | `ErrTokenNotValidYet` |
 | Custom claims | Caller-validated after extraction | n/a (caller responsibility) |
 
 The gates are applied in the order listed above. An invalid `alg` or `kid` is

--- a/doc/adr/007-namespace-consistency-contract.md
+++ b/doc/adr/007-namespace-consistency-contract.md
@@ -26,9 +26,9 @@ The zero value preserves existing behavior exactly — no label is injected into
 or metrics. When non-empty, the namespace is stored in the manager struct and is available for
 attachment to observability output.
 
-The field is inert in this phase. No existing log call, span attribute, or metric label is
-modified here. This ADR records the configuration surface; a subsequent phase wires the field
-into observability output (see issue #112).
+At the time of this decision the field was inert — no log call, span attribute, or metric label
+was modified. This ADR recorded the configuration surface only; wiring was deferred to a
+subsequent phase (see issue #112 and Addendum below).
 
 The field is not validated or interpreted. The library treats it as an opaque label — format,
 naming conventions, and semantics are entirely the consumer's decision.
@@ -43,3 +43,16 @@ naming conventions, and semantics are entirely the consumer's decision.
 - The contract between `Namespace` on a manager config and `KeyPrefix` on a store config is
   intentionally loose: both solve isolation in their respective layers (observability vs.
   data storage), and callers are free to use different values for each
+
+## Addendum — Namespace fully wired (issue #112, PRs #113–#118, 2026-04-27)
+
+The `Namespace` field is now fully wired across all observability output in both managers:
+
+- **Log lines** — every `Logger` call in `KeyManager` and `TokenManager` carries the namespace
+  as a structured key (`"namespace"`) when the field is non-empty.
+- **Trace spans** — span attributes include `namespace` on every span opened by either manager.
+- **Metric labels** — all counters, gauges, histograms, and duration recordings carry a
+  `namespace` label; an empty namespace emits an empty string (preserving prior cardinality).
+
+The deferred "subsequent phase" referenced in the original Decision is complete. No interface
+changes were required — the field was already present on both config types.


### PR DESCRIPTION
## Summary

Correctness fixes identified during a full ADR consistency audit conducted 2026-05-06. All changes are documentation-only — no code, no tests, no new dependencies.

- **ADR-001**: `golang.org/x/time/rate` was labeled "(standard library)" — corrected to "(golang.org/x extended package — separate module)"
- **ADR-002**: Decision sentence restructured for clarity (opaque 256-bit random identifiers, not UUIDs); `RevokeAllForAudience` and `RevokeAllForUserAndAudience` added to the Positive revocation method list (both shipped in v0.5.0)
- **ADR-005**: `nbf` row added to the validation gates table — `exp` and `nbf` are both time-checked by the JWT parser with leeway; the `jti` bullet is left unchanged pending the format decision in issue #196
- **ADR-007**: "The field is inert in this phase" qualified as historical context; Addendum added confirming `Namespace` is fully wired across logs, spans, and metric labels (issue #112, PRs #113–#118)
- **README**: Sequence diagram updated (`GetPublicKey(ctx, kid)`, `Store` audience argument, `Retrieve`/`Revoke` naming, phantom `Revoke(oldRefreshToken)` step removed); test counts updated to 947 specs; roadmap sections added for v0.5.0–v1.1.0; ADR-002 table entry corrected

## Related

- Issue #196 — `jti` format decision (ADR-005 `jti` bullet update deferred until that decision is made)

## Test plan

- [ ] CI green (doc-only change — lint + build sufficient)
- [ ] Verify all internal cross-links render correctly in GitHub preview