### PR TITLE
fix(keys): nil guard in GetKeyInfo for public-only cached KeyPair

### DIFF
--- a/README.md
+++ b/README.md
@@ -1085,9 +1085,9 @@ See [doc/ARCHITECTURE.md](doc/ARCHITECTURE.md#project-structure) for the package
 
 ### Test Coverage
 
-**Current**: 947 comprehensive specs (887 unit + 60 integration) across all packages, all passing with race detection (KeyManager ~90%, TokenManager ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%)
+**Current**: 948 comprehensive specs (888 unit + 60 integration) across all packages, all passing with race detection (KeyManager ~81%, TokenManager ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%)
 
-**KeyManager** (3 test suites — 168 total specs):
+**KeyManager** (3 test suites — 169 total specs):
 - **9-phase Manager tests** (MockKeyStore — no I/O):
   - Constructor validation, config defaults, ErrInvalidKeyStore
   - Start: loads from store, generates key on empty store, error paths
@@ -1378,5 +1378,5 @@ Built by a Senior Platform Engineer with deep experience in distributed systems 
 **Status**: v0.5.0-dev — production-quality, pre-v1.0 (see API Stability note at top)
 **Version**: v0.5.0 (active development; latest release: v0.4.0)
 **Components**: KeyManager ✅ | TokenManager ✅ | RefreshStore (Memory + Redis) ✅ | Metrics (Prometheus) ✅ | Logging (Correlation ID) ✅ | Tracing ✅
-**Test Coverage**: 947 specs (887 unit + 60 integration) — KeyManager ~90%, TokenManager ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100% — all passing, race-detection enabled
+**Test Coverage**: 948 specs (888 unit + 60 integration) — KeyManager ~81%, TokenManager ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100% — all passing, race-detection enabled
 **Last Updated**: May 6, 2026

--- a/pkg/keys/manager.go
+++ b/pkg/keys/manager.go
@@ -677,6 +677,15 @@ func (m *Manager) GetJWKS(ctx context.Context) (*JWKS, error) {
 	return &JWKS{Keys: keys}, nil
 }
 
+// keyPairKeySize returns the RSA key size in bits.
+// PublicKey.N and PrivateKey.N share the same modulus — use whichever is present.
+func keyPairKeySize(kp *KeyPair) int {
+	if kp.PrivateKey != nil {
+		return kp.PrivateKey.N.BitLen()
+	}
+	return kp.PublicKey.N.BitLen()
+}
+
 // GetKeyInfo returns public metadata for a specific key by ID.
 // If keyID is empty, returns metadata for the current signing key.
 // Returns ErrManagerNotRunning if the manager is not running.
@@ -742,7 +751,7 @@ func (m *Manager) GetKeyInfo(ctx context.Context, keyID string) (*KeyInfo, error
 		CreatedAt:   keyPair.CreatedAt,
 		RotateAt:    rotateAt,
 		ExpiresAt:   keyPair.ExpiresAt,
-		KeySizeBits: keyPair.PrivateKey.N.BitLen(),
+		KeySizeBits: keyPairKeySize(keyPair),
 		Algorithm:   "RS256",
 		IsCurrent:   isCurrent,
 		IsValid:     isValid,

--- a/pkg/keys/manager_test.go
+++ b/pkg/keys/manager_test.go
@@ -1292,6 +1292,39 @@ var _ = Describe("Manager", func() {
 			})
 		})
 
+		Context("when a key is cached as public-only via GetPublicKey", func() {
+			var externalKeyID string
+
+			BeforeEach(func() {
+				externalKeyID = "key-external"
+				extKey := newTestKey()
+				mockKS.EXPECT().LoadAll(gomock.Any()).Return([]*keys.StoredKey{
+					{
+						KeyID:      "key-main",
+						PrivateKey: newTestKey(),
+						Metadata:   keys.KeyMetadata{ID: "key-main", CreatedAt: time.Now()},
+					},
+				}, nil)
+				var err error
+				m, err = keys.NewManager(newTestConfig(mockKS))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(m.Start(ctx)).To(Succeed())
+
+				// Prime the public-only cache entry for key-external.
+				mockKS.EXPECT().LoadKey(gomock.Any(), externalKeyID).Return(extKey, &keys.KeyMetadata{ID: externalKeyID, CreatedAt: time.Now()}, nil)
+				_, err = m.GetPublicKey(ctx, externalKeyID)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			AfterEach(shutdownManager)
+
+			It("returns correct KeySizeBits when the key is cached as public-only via GetPublicKey", func() {
+				info, err := m.GetKeyInfo(ctx, externalKeyID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(info.KeySizeBits).To(Equal(2048))
+			})
+		})
+
 		Context("GetCurrentKeyInfo", func() {
 			var currentKeyID string
 


### PR DESCRIPTION
## Summary

- `GetPublicKey` caches a partial `KeyPair` (`PrivateKey: nil`) when loading a key from the `KeyStore` for validation. `GetKeyInfo` then unconditionally called `keyPair.PrivateKey.N.BitLen()`, panicking at runtime on any deployment using multi-instance key distribution.
- Adds a `keyPairKeySize` helper that falls back to `PublicKey.N.BitLen()` when `PrivateKey` is nil — safe because both halves share the same RSA modulus `N`.
- Adds a Phase 10 regression spec covering the `GetPublicKey` → `GetKeyInfo` path.

## Changes

- `pkg/keys/manager.go` — `keyPairKeySize` helper + `GetKeyInfo` call site fixed
- `pkg/keys/manager_test.go` — 1 new Phase 10 spec (168 → 169 total specs)
- `README.md` — spec count 947 → 948, KeyManager suite 168 → 169, coverage ~90% → ~81%

## Test plan

- [x] `./run-ci-locally.sh` green (169/169 Key Manager specs, 948 total, `-race`)
- [x] New spec exercises `GetPublicKey` (mock `LoadKey`) → `GetKeyInfo` — no panic, `KeySizeBits == 2048`
- [x] `keyPairKeySize` reaches 100% statement coverage

Closes #177