### PR TITLE
fix(tokens): rotate refresh token on successful refresh (closes #195)

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,10 +695,12 @@ sequenceDiagram
     API->>Manager: RefreshAccessToken(ctx, refreshToken)
     Manager->>Redis: Retrieve(refreshToken)
     Redis-->>Manager: {userID, audience, expiry}
-    Manager->>Manager: Check expiry and revocation
+    Manager->>Manager: Check expiry
     Manager->>KeyMgr: GetCurrentSigningKey(ctx)
     KeyMgr-->>Manager: RSA private key + keyID
     Manager->>Manager: Sign new JWT access token
+    Manager->>Redis: Revoke(refreshToken)
+    Redis-->>Manager: OK
     Manager-->>API: newAccessToken
     API-->>Client: 200 OK {access}
 
@@ -1085,7 +1087,7 @@ See [doc/ARCHITECTURE.md](doc/ARCHITECTURE.md#project-structure) for the package
 
 ### Test Coverage
 
-**Current**: 948 comprehensive specs (888 unit + 60 integration) across all packages, all passing with race detection (KeyManager ~81%, TokenManager ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%)
+**Current**: 952 comprehensive specs (892 unit + 60 integration) across all packages, all passing with race detection (KeyManager ~81%, TokenManager ~92%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%)
 
 **KeyManager** (3 test suites — 169 total specs):
 - **9-phase Manager tests** (MockKeyStore — no I/O):
@@ -1105,7 +1107,7 @@ See [doc/ARCHITECTURE.md](doc/ARCHITECTURE.md#project-structure) for the package
   - Error handling: corrupt metadata, missing metadata entry, Redis unavailability via SetError
   - Concurrency, metrics recording (storage_backend: "redis")
 
-**TokenManager** (7 test suites, 253 total specs):
+**TokenManager** (7 test suites, 257 total specs):
 - **Lifecycle Management Tests**:
   - Start: idempotency, logging, background cleanup, failure handling, context cancellation
   - Shutdown: logging, cleanup termination, goroutine coordination, timeout respect, idempotency, restart after clean shutdown
@@ -1378,5 +1380,5 @@ Built by a Senior Platform Engineer with deep experience in distributed systems 
 **Status**: v0.5.0-dev — production-quality, pre-v1.0 (see API Stability note at top)
 **Version**: v0.5.0 (active development; latest release: v0.4.0)
 **Components**: KeyManager ✅ | TokenManager ✅ | RefreshStore (Memory + Redis) ✅ | Metrics (Prometheus) ✅ | Logging (Correlation ID) ✅ | Tracing ✅
-**Test Coverage**: 948 specs (888 unit + 60 integration) — KeyManager ~81%, TokenManager ~87%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100% — all passing, race-detection enabled
+**Test Coverage**: 952 specs (892 unit + 60 integration) — KeyManager ~81%, TokenManager ~92%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100% — all passing, race-detection enabled
 **Last Updated**: May 6, 2026

--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -1645,8 +1645,11 @@ func (m *Manager) ValidateAccessTokenWithClaims(ctx context.Context, tokenString
 }
 
 // RefreshAccessToken exchanges a valid refresh token for a new access token.
-// It retrieves the refresh token from storage, checks expiration and revocation
-// status, then calls IssueAccessToken for the token's owner.
+// It retrieves the refresh token from storage, checks expiration, issues a new
+// access token, then revokes the old refresh token to prevent replay attacks.
+// If revocation of the old token fails, the error is logged and a metric is
+// recorded but the new access token is still returned — the old token will
+// expire naturally.
 //
 // Returns ErrManagerNotRunning, ErrInvalidRefreshToken, ErrRefreshTokenExpired,
 // ErrTokenRevoked, or the context error.
@@ -1745,17 +1748,6 @@ func (m *Manager) RefreshAccessToken(ctx context.Context, refreshToken string) (
 		return "", ErrRefreshTokenExpired
 	}
 
-	// ===== STEP 6: Check If Revoked =====
-	if token.Revoked {
-		status = "revoked"
-		errorType = "revoked"
-		m.logger.Warn("refresh token has been revoked", ctx,
-			"tokenID", refreshToken)
-		span.RecordError(ErrTokenRevoked)
-		span.SetStatus(tracing.StatusError, ErrTokenRevoked.Error())
-		return "", ErrTokenRevoked
-	}
-
 	// ===== STEP 7: Issue New Access Token =====
 	newAccessToken, err := m.IssueAccessToken(ctx, token.UserID, WithAudience(token.Audience...))
 	if err != nil {
@@ -1766,6 +1758,18 @@ func (m *Manager) RefreshAccessToken(ctx context.Context, refreshToken string) (
 		span.RecordError(wrapped)
 		span.SetStatus(tracing.StatusError, wrapped.Error())
 		return "", wrapped
+	}
+
+	// ===== STEP 8: Revoke Old Refresh Token =====
+	if rErr := m.refreshStore.Revoke(ctx, refreshToken); rErr != nil {
+		m.logger.Warn("failed to revoke old refresh token after successful refresh", ctx,
+			"tokenID", refreshToken,
+			"error", rErr)
+		m.metrics.IncrementCounter(metricTokensRevokedTotal, map[string]string{
+			"revocation_scope": "rotation",
+			"status":           "error",
+			"namespace":        m.namespace,
+		})
 	}
 
 	// ===== STEP 9: Record Success and Log =====
@@ -1780,13 +1784,16 @@ func (m *Manager) RefreshAccessToken(ctx context.Context, refreshToken string) (
 
 // RefreshAccessTokenWithClaims exchanges a valid refresh token for a new access
 // token, embedding caller-supplied custom claims into the issued token. It
-// retrieves the refresh token from storage, checks expiration and revocation
-// status, then calls IssueAccessTokenWithClaims for the token's owner. Reserved
-// JWT field names (sub, iss, aud, exp, nbf, iat, jti) in claims are silently
-// dropped to prevent caller-controlled claim injection.
+// retrieves the refresh token from storage, checks expiration, issues a new
+// access token, then revokes the old refresh token to prevent replay attacks.
+// If revocation of the old token fails, the error is logged and a metric is
+// recorded but the new access token is still returned — the old token will
+// expire naturally. Reserved JWT field names (sub, iss, aud, exp, nbf, iat,
+// jti) in claims are silently dropped to prevent caller-controlled claim
+// injection.
 //
 // Returns ErrManagerNotRunning, ErrInvalidRefreshToken, ErrRefreshTokenExpired,
-// ErrTokenRevoked, or the context error.
+// or the context error.
 func (m *Manager) RefreshAccessTokenWithClaims(ctx context.Context, refreshToken string, claims CustomClaims) (string, error) {
 	ctx, span := m.startSpan(ctx, "RefreshAccessTokenWithClaims")
 	defer span.End()
@@ -1882,17 +1889,6 @@ func (m *Manager) RefreshAccessTokenWithClaims(ctx context.Context, refreshToken
 		return "", ErrRefreshTokenExpired
 	}
 
-	// ===== STEP 6: Check If Revoked =====
-	if token.Revoked {
-		status = "revoked"
-		errorType = "revoked"
-		m.logger.Warn("refresh token has been revoked", ctx,
-			"tokenID", refreshToken)
-		span.RecordError(ErrTokenRevoked)
-		span.SetStatus(tracing.StatusError, ErrTokenRevoked.Error())
-		return "", ErrTokenRevoked
-	}
-
 	// ===== STEP 7: Issue New Access Token With Claims =====
 	newAccessToken, err := m.IssueAccessTokenWithClaims(ctx, token.UserID, claims, WithAudience(token.Audience...))
 	if err != nil {
@@ -1903,6 +1899,18 @@ func (m *Manager) RefreshAccessTokenWithClaims(ctx context.Context, refreshToken
 		span.RecordError(wrapped)
 		span.SetStatus(tracing.StatusError, wrapped.Error())
 		return "", wrapped
+	}
+
+	// ===== STEP 8: Revoke Old Refresh Token =====
+	if rErr := m.refreshStore.Revoke(ctx, refreshToken); rErr != nil {
+		m.logger.Warn("failed to revoke old refresh token after successful refresh", ctx,
+			"tokenID", refreshToken,
+			"error", rErr)
+		m.metrics.IncrementCounter(metricTokensRevokedTotal, map[string]string{
+			"revocation_scope": "rotation",
+			"status":           "error",
+			"namespace":        m.namespace,
+		})
 	}
 
 	// ===== STEP 9: Record Success and Log =====

--- a/pkg/tokens/manager_metrics_test.go
+++ b/pkg/tokens/manager_metrics_test.go
@@ -248,6 +248,7 @@ var _ = Describe("TokenManager Metrics", func() {
 			}
 			mockStore.EXPECT().Retrieve(gomock.Any(), "rt-1").Return(storedToken, nil)
 			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
+			mockStore.EXPECT().Revoke(gomock.Any(), "rt-1").Return(nil)
 			// IssueAccessToken metrics (called internally by RefreshAccessToken)
 			mockM.EXPECT().IncrementCounter("jwtauth_tokens_issued_total", gomock.Any())
 			mockM.EXPECT().RecordDuration("jwtauth_operation_duration_seconds", gomock.Any(), map[string]string{

--- a/pkg/tokens/manager_test.go
+++ b/pkg/tokens/manager_test.go
@@ -1162,6 +1162,7 @@ var _ = Describe("TokenManager", func() {
 
 				// Expect new access token signed
 				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
+				mockStore.EXPECT().Revoke(gomock.Any(), validRefreshToken).Return(nil)
 
 				accessToken, err := service.RefreshAccessToken(ctx, validRefreshToken)
 
@@ -1176,6 +1177,7 @@ var _ = Describe("TokenManager", func() {
 					Times(1)
 
 				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
+				mockStore.EXPECT().Revoke(gomock.Any(), validRefreshToken).Return(nil)
 
 				service.RefreshAccessToken(ctx, validRefreshToken)
 			})
@@ -1183,6 +1185,7 @@ var _ = Describe("TokenManager", func() {
 			It("should preserve user ID from refresh token", func() {
 				mockStore.EXPECT().Retrieve(gomock.Any(), gomock.Any()).Return(&storage.RefreshToken{UserID: testUserID, ExpiresAt: time.Now().Add(1 * time.Hour)}, nil)
 				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
+				mockStore.EXPECT().Revoke(gomock.Any(), validRefreshToken).Return(nil)
 
 				accessToken, _ := service.RefreshAccessToken(ctx, validRefreshToken)
 
@@ -1193,12 +1196,36 @@ var _ = Describe("TokenManager", func() {
 			It("should log refresh operation", func() {
 				mockStore.EXPECT().Retrieve(gomock.Any(), gomock.Any()).Return(&storage.RefreshToken{UserID: testUserID, ExpiresAt: time.Now().Add(1 * time.Hour)}, nil)
 				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
+				mockStore.EXPECT().Revoke(gomock.Any(), validRefreshToken).Return(nil)
 
 				service.RefreshAccessToken(ctx, validRefreshToken)
 
 				Eventually(func() bool {
 					return mockLogger.HasLog("info", "access token refreshed")
 				}).Should(BeTrue())
+			})
+
+			It("should revoke the old refresh token after issuing a new access token", func() {
+				mockStore.EXPECT().
+					Retrieve(gomock.Any(), validRefreshToken).
+					Return(&storage.RefreshToken{UserID: testUserID, ExpiresAt: time.Now().Add(time.Hour)}, nil)
+				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
+				mockStore.EXPECT().Revoke(gomock.Any(), validRefreshToken).Return(nil).Times(1)
+
+				_, err := service.RefreshAccessToken(ctx, validRefreshToken)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should still return the new access token when old token revocation fails", func() {
+				mockStore.EXPECT().
+					Retrieve(gomock.Any(), validRefreshToken).
+					Return(&storage.RefreshToken{UserID: testUserID, ExpiresAt: time.Now().Add(time.Hour)}, nil)
+				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
+				mockStore.EXPECT().Revoke(gomock.Any(), validRefreshToken).Return(errors.New("store unavailable"))
+
+				accessToken, err := service.RefreshAccessToken(ctx, validRefreshToken)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(accessToken).NotTo(BeEmpty())
 			})
 		})
 
@@ -1313,6 +1340,7 @@ var _ = Describe("TokenManager", func() {
 						ExpiresAt: time.Now().Add(time.Hour),
 					}, nil)
 				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
+				mockStore.EXPECT().Revoke(gomock.Any(), validRefreshToken).Return(nil)
 
 				accessToken, err := service.RefreshAccessTokenWithClaims(ctx, validRefreshToken, claims)
 				Expect(err).NotTo(HaveOccurred())
@@ -1333,6 +1361,7 @@ var _ = Describe("TokenManager", func() {
 						ExpiresAt: time.Now().Add(time.Hour),
 					}, nil)
 				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
+				mockStore.EXPECT().Revoke(gomock.Any(), validRefreshToken).Return(nil)
 
 				accessToken, err := service.RefreshAccessTokenWithClaims(ctx, validRefreshToken, nil)
 				Expect(err).NotTo(HaveOccurred())
@@ -1348,12 +1377,36 @@ var _ = Describe("TokenManager", func() {
 					ExpiresAt: time.Now().Add(time.Hour),
 				}, nil)
 				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
+				mockStore.EXPECT().Revoke(gomock.Any(), validRefreshToken).Return(nil)
 
 				service.RefreshAccessTokenWithClaims(ctx, validRefreshToken, nil)
 
 				Eventually(func() bool {
 					return mockLogger.HasLog("info", "access token refreshed with claims")
 				}).Should(BeTrue())
+			})
+
+			It("should revoke the old refresh token after issuing a new access token", func() {
+				mockStore.EXPECT().
+					Retrieve(gomock.Any(), validRefreshToken).
+					Return(&storage.RefreshToken{UserID: testUserID, ExpiresAt: time.Now().Add(time.Hour)}, nil)
+				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
+				mockStore.EXPECT().Revoke(gomock.Any(), validRefreshToken).Return(nil).Times(1)
+
+				_, err := service.RefreshAccessTokenWithClaims(ctx, validRefreshToken, nil)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should still return the new access token when old token revocation fails", func() {
+				mockStore.EXPECT().
+					Retrieve(gomock.Any(), validRefreshToken).
+					Return(&storage.RefreshToken{UserID: testUserID, ExpiresAt: time.Now().Add(time.Hour)}, nil)
+				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
+				mockStore.EXPECT().Revoke(gomock.Any(), validRefreshToken).Return(errors.New("store unavailable"))
+
+				accessToken, err := service.RefreshAccessTokenWithClaims(ctx, validRefreshToken, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(accessToken).NotTo(BeEmpty())
 			})
 		})
 
@@ -2302,6 +2355,7 @@ var _ = Describe("TokenManager", func() {
 					ExpiresAt: time.Now().Add(1 * time.Hour),
 				}, nil)
 				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
+				mockStore.EXPECT().Revoke(gomock.Any(), "tok").Return(nil)
 
 				accessToken, err := service.RefreshAccessToken(ctx, "tok")
 
@@ -2320,6 +2374,7 @@ var _ = Describe("TokenManager", func() {
 					ExpiresAt: time.Now().Add(1 * time.Hour),
 				}, nil)
 				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
+				mockStore.EXPECT().Revoke(gomock.Any(), "tok").Return(nil)
 
 				accessToken, err := service.RefreshAccessToken(ctx, "tok")
 
@@ -2351,6 +2406,7 @@ var _ = Describe("TokenManager", func() {
 					ExpiresAt: time.Now().Add(1 * time.Hour),
 				}, nil)
 				mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
+				mockStore.EXPECT().Revoke(gomock.Any(), "tok").Return(nil)
 
 				accessToken, err := service.RefreshAccessTokenWithClaims(ctx, "tok", nil)
 
@@ -2722,6 +2778,7 @@ var _ = Describe("TokenManager — Phase N: Tracing", func() {
 			}
 			mockStore.EXPECT().Retrieve(gomock.Any(), refreshTok).Return(record, nil)
 			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
+			mockStore.EXPECT().Revoke(gomock.Any(), refreshTok).Return(nil)
 
 			mockTracer.EXPECT().Start(gomock.Any(), gomock.Eq("TokenManager.RefreshAccessToken"), gomock.Any()).Return(ctx, testSpan)
 			// IssueAccessToken is called internally — route to setupSpan to avoid expectation conflicts.
@@ -2800,6 +2857,7 @@ var _ = Describe("TokenManager — Phase N: Tracing", func() {
 			}
 			mockStore.EXPECT().Retrieve(gomock.Any(), refreshTok).Return(record, nil)
 			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
+			mockStore.EXPECT().Revoke(gomock.Any(), refreshTok).Return(nil)
 
 			mockTracer.EXPECT().Start(gomock.Any(), gomock.Eq("TokenManager.RefreshAccessTokenWithClaims"), gomock.Any()).Return(ctx, testSpan)
 			// IssueAccessTokenWithClaims is called internally — route to setupSpan to avoid expectation conflicts.


### PR DESCRIPTION
## Summary

- **Root cause**: `RefreshAccessToken` and `RefreshAccessTokenWithClaims` never revoked the old refresh token after issuing a new access token — a stolen token was replayable for the full 30-day TTL with no library-level mitigation
- **Dead code removed**: STEP 6 (`if token.Revoked`) in both methods was unreachable — both stores return `ErrTokenRevoked` from `Retrieve`, never a non-nil revoked token; STEP 4 handles it first
- **Fix**: Added STEP 8 to both methods — `Revoke(refreshToken)` after the new access token is issued; revocation failure is `Warn`-logged and metered under `revocation_scope="rotation"` but the caller still receives the new token (graceful degradation)

## Changes

- `pkg/tokens/manager.go` — both refresh methods: remove dead STEP 6, add STEP 8, update `RefreshAccessTokenWithClaims` doc comment
- `pkg/tokens/manager_test.go` — 7 existing success-path tests updated with `Revoke` mock expectation; 4 new specs added (rotation assertion + graceful-failure per method)
- `pkg/tokens/manager_metrics_test.go` — metrics success-path test updated with `Revoke` expectation
- `README.md` — sequence diagram `Revoke(refreshToken)` step restored; spec counts updated (948 → 952, Tokens suite 253 → 257, TokenManager ~87% → ~92%)

## Test plan

- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `govulncheck ./...` — no vulnerabilities
- [x] Unit tests: 892/892 passing under `-race`
- [x] Integration tests: 60/60 passing under `-race`
- [x] TokenManager coverage: 91.9% (was ~87%)