### PR TITLE
fix(tokens,keys): add ErrTokenMissingKid sentinel and guard current key from cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1087,9 +1087,9 @@ See [doc/ARCHITECTURE.md](doc/ARCHITECTURE.md#project-structure) for the package
 
 ### Test Coverage
 
-**Current**: 952 comprehensive specs (892 unit + 60 integration) across all packages, all passing with race detection (KeyManager ~81%, TokenManager ~92%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%)
+**Current**: 955 comprehensive specs (895 unit + 60 integration) across all packages, all passing with race detection (KeyManager ~81%, TokenManager ~92%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%)
 
-**KeyManager** (3 test suites — 169 total specs):
+**KeyManager** (3 test suites — 170 total specs):
 - **9-phase Manager tests** (MockKeyStore — no I/O):
   - Constructor validation, config defaults, ErrInvalidKeyStore
   - Start: loads from store, generates key on empty store, error paths
@@ -1380,5 +1380,5 @@ Built by a Senior Platform Engineer with deep experience in distributed systems 
 **Status**: v0.5.0-dev — production-quality, pre-v1.0 (see API Stability note at top)
 **Version**: v0.5.0 (active development; latest release: v0.4.0)
 **Components**: KeyManager ✅ | TokenManager ✅ | RefreshStore (Memory + Redis) ✅ | Metrics (Prometheus) ✅ | Logging (Correlation ID) ✅ | Tracing ✅
-**Test Coverage**: 952 specs (892 unit + 60 integration) — KeyManager ~81%, TokenManager ~92%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100% — all passing, race-detection enabled
+**Test Coverage**: 955 specs (895 unit + 60 integration) — KeyManager ~81%, TokenManager ~92%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100% — all passing, race-detection enabled
 **Last Updated**: May 6, 2026

--- a/pkg/keys/manager.go
+++ b/pkg/keys/manager.go
@@ -256,6 +256,13 @@ func (m *Manager) Keys() map[string]*KeyPair {
 	return m.keys
 }
 
+// CleanupExpiredKeysForTest invokes cleanupExpiredKeys for testing purposes only.
+// This is exported solely to allow tests to trigger the cleanup sweep synchronously
+// without waiting for the rotation scheduler ticker.
+func (m *Manager) CleanupExpiredKeysForTest(ctx context.Context) {
+	m.cleanupExpiredKeys(ctx)
+}
+
 // NewManager creates and returns a new Manager with the given configuration.
 // Returns ErrInvalidKeyStore if KeyStore is nil, ErrInvalidKeySize if KeySize is
 // less than 2048 bits, ErrInvalidKeyRotationInterval if KeyRotationInterval is

--- a/pkg/keys/manager_test.go
+++ b/pkg/keys/manager_test.go
@@ -1361,4 +1361,48 @@ var _ = Describe("Manager", func() {
 			})
 		})
 	})
+
+	Describe("Phase 12: cleanupExpiredKeys — current key guard", func() {
+		var m *keys.Manager
+
+		BeforeEach(func() {
+			var err error
+			m, err = keys.NewManager(newTestConfig(mockKS))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			if m.IsRunning() {
+				shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				defer cancel()
+				m.Shutdown(shutdownCtx)
+			}
+		})
+
+		It("should not delete the current signing key even when its ExpiresAt has passed", func() {
+			key := newTestKey()
+			keyID := "current-key-past-expiry"
+			storedKeys := []*keys.StoredKey{
+				{
+					KeyID:      keyID,
+					PrivateKey: key,
+					Metadata: keys.KeyMetadata{
+						ID:        keyID,
+						CreatedAt: time.Now().Add(-48 * time.Hour),
+						// ExpiresAt deliberately in the past — mimics a rotation miss.
+						ExpiresAt: time.Now().Add(-1 * time.Hour),
+					},
+				},
+			}
+			mockKS.EXPECT().LoadAll(gomock.Any()).Return(storedKeys, nil)
+			Expect(m.Start(ctx)).To(Succeed())
+
+			// Force a cleanup sweep — the current key must survive.
+			m.CleanupExpiredKeysForTest(ctx)
+
+			_, gotKeyID, err := m.GetCurrentSigningKey(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(gotKeyID).To(Equal(keyID))
+		})
+	})
 })

--- a/pkg/tokens/claims.go
+++ b/pkg/tokens/claims.go
@@ -189,4 +189,8 @@ var (
 
 	// ErrInvalidIssuer indicates the token issuer doesn't match
 	ErrInvalidIssuer = errors.New("invalid token issuer")
+
+	// ErrTokenMissingKid indicates the JWT is missing the required kid header field.
+	// Callers may use errors.Is to distinguish this case from other validation failures.
+	ErrTokenMissingKid = errors.New("token missing kid header")
 )

--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -1384,10 +1384,10 @@ func (m *Manager) IssueTokenPairWithClaims(ctx context.Context, userID string, a
 // It verifies the RS256 signature using the public key identified by the token's
 // "kid" header, then checks expiration, issuer, and audience claims.
 //
-/// Returns the parsed RegisteredClaims on success, or one of: ErrManagerNotRunning,
-// ErrTokenExpired, ErrTokenNotYetValid, ErrInvalidIssuer, ErrInvalidAudience,
-// ErrInvalidToken (covers malformed tokens, wrong signing method, and unknown key IDs),
-// or the context error.
+// Returns the parsed RegisteredClaims on success, or one of: ErrManagerNotRunning,
+// ErrTokenExpired, ErrTokenNotYetValid, ErrTokenMissingKid if the JWT has no kid
+// header, ErrInvalidIssuer, ErrInvalidAudience, ErrInvalidToken (covers malformed
+// tokens, wrong signing method, and unknown key IDs), or the context error.
 func (m *Manager) ValidateAccessToken(ctx context.Context, tokenString string) (*jwt.RegisteredClaims, error) {
 	ctx, span := m.startSpan(ctx, "ValidateAccessToken")
 	defer span.End()
@@ -1452,7 +1452,7 @@ func (m *Manager) ValidateAccessToken(ctx context.Context, tokenString string) (
 			kid, ok := token.Header["kid"].(string)
 			if !ok {
 				m.logger.Warn("token missing kid in header", ctx)
-				return nil, errors.New("missing kid in token header")
+				return nil, ErrTokenMissingKid
 			}
 			m.logger.Debug("token kid extracted from header", ctx,
 				"kid", kid)
@@ -1498,6 +1498,13 @@ func (m *Manager) ValidateAccessToken(ctx context.Context, tokenString string) (
 			span.RecordError(ErrInvalidToken)
 			span.SetStatus(tracing.StatusError, ErrInvalidToken.Error())
 			return nil, ErrInvalidToken
+		}
+		if errors.Is(err, ErrTokenMissingKid) {
+			status = "error"
+			errorType = "missing_kid"
+			span.RecordError(ErrTokenMissingKid)
+			span.SetStatus(tracing.StatusError, ErrTokenMissingKid.Error())
+			return nil, ErrTokenMissingKid
 		}
 
 		span.RecordError(ErrInvalidToken)
@@ -1586,9 +1593,10 @@ func (m *Manager) ValidateAccessToken(ctx context.Context, tokenString string) (
 //
 // Returns ErrManagerNotRunning if the service has not been started, ErrTokenExpired
 // if the token has expired beyond the configured ClockSkew, ErrTokenNotYetValid if
-// the nbf claim has not been reached, ErrInvalidIssuer or ErrInvalidAudience if
-// configured values do not match, ErrInvalidToken for malformed tokens or unknown
-// key IDs, or the context error if the context is cancelled.
+// the nbf claim has not been reached, ErrTokenMissingKid if the JWT has no kid
+// header, ErrInvalidIssuer or ErrInvalidAudience if configured values do not match,
+// ErrInvalidToken for malformed tokens or unknown key IDs, or the context error if
+// the context is cancelled.
 func (m *Manager) ValidateAccessTokenWithClaims(ctx context.Context, tokenString string) (*jwt.RegisteredClaims, map[string]interface{}, error) {
 	ctx, span := m.startSpan(ctx, "ValidateAccessTokenWithClaims")
 	defer span.End()

--- a/pkg/tokens/manager_test.go
+++ b/pkg/tokens/manager_test.go
@@ -1102,13 +1102,13 @@ var _ = Describe("TokenManager", func() {
 		Context("with missing kid header", func() {
 			var noKidToken string
 			BeforeEach(func() {
-				tok := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.RegisteredClaims{
+				unsignedToken := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.RegisteredClaims{
 					Subject:   "user-123",
 					ExpiresAt: jwt.NewNumericDate(time.Now().Add(15 * time.Minute)),
 				})
 				// kid deliberately NOT set
 				var err error
-				noKidToken, err = tok.SignedString(testKey)
+				noKidToken, err = unsignedToken.SignedString(testKey)
 				Expect(err).NotTo(HaveOccurred())
 			})
 

--- a/pkg/tokens/manager_test.go
+++ b/pkg/tokens/manager_test.go
@@ -1100,15 +1100,26 @@ var _ = Describe("TokenManager", func() {
 		})
 
 		Context("with missing kid header", func() {
-			It("should return ErrInvalidToken", func() {
-				token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.RegisteredClaims{
+			var noKidToken string
+			BeforeEach(func() {
+				tok := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.RegisteredClaims{
 					Subject:   "user-123",
 					ExpiresAt: jwt.NewNumericDate(time.Now().Add(15 * time.Minute)),
 				})
 				// kid deliberately NOT set
-				signed, _ := token.SignedString(testKey)
-				_, err := service.ValidateAccessToken(ctx, signed)
-				Expect(err).To(Equal(tokens.ErrInvalidToken))
+				var err error
+				noKidToken, err = tok.SignedString(testKey)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should return ErrTokenMissingKid", func() {
+				_, err := service.ValidateAccessToken(ctx, noKidToken)
+				Expect(err).To(Equal(tokens.ErrTokenMissingKid))
+			})
+
+			It("should satisfy errors.Is(err, ErrTokenMissingKid)", func() {
+				_, err := service.ValidateAccessToken(ctx, noKidToken)
+				Expect(errors.Is(err, tokens.ErrTokenMissingKid)).To(BeTrue())
 			})
 		})
 


### PR DESCRIPTION
## Summary

- **#178** — `ValidateAccessToken` was returning an inline `errors.New` from the keyfunc when a JWT had no `kid` header. The JWT library wraps keyfunc errors, so the value fell through STEP 5's catch-all and callers received the opaque `ErrInvalidToken` with no way to distinguish this case. Fix: export `ErrTokenMissingKid` sentinel in `pkg/tokens/claims.go`, use it in the keyfunc, and add a STEP 5 branch that surfaces it directly.
- **#179** — `cleanupExpiredKeys` already had the `if keyID == m.currentKeyID { continue }` guard implemented (line 950 of `pkg/keys/manager.go`), but the invariant had no test coverage. Fix: add `CleanupExpiredKeysForTest` test export and a Phase 12 spec that verifies the current signing key survives a cleanup sweep even when its `ExpiresAt` is in the past.

## ADR compliance

- ADR-005: adding a sentinel does not weaken the kid trust boundary — it only makes the error observable. ✅
- ADR-003, ADR-004: the cleanup guard does not affect algorithm selection or kid validation. ✅

## Test plan

- [x] `errors.Is(err, tokens.ErrTokenMissingKid)` passes for a JWT with no kid header
- [x] `ValidateAccessToken` returns `ErrTokenMissingKid` (not `ErrInvalidToken`) for missing kid
- [x] Phase 12 spec: `GetCurrentSigningKey` succeeds after `CleanupExpiredKeysForTest` when the current key's `ExpiresAt` is in the past
- [x] `./run-ci-locally.sh` green — 955 specs (895 unit + 60 integration), all passing under `-race`

Closes #178, closes #179