### PR TITLE
fix(tokens): switch generateTokenID to uuid.New().String() (closes #196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@ All notable changes to this project will be documented in this file.
 
 - **Microbenchmark suite** — `testing.B` benchmarks in `pkg/storage/bench_test.go`, `pkg/keys/bench_test.go`, and `pkg/tokens/bench_test.go` covering all storage operations (MemoryRefreshStore + RedisRefreshStore via miniredis), key manager cache and rotation paths, token issuance and validation (serial and parallel), rotation-under-load concurrency, observability tax (NoOp vs PrometheusMetrics vs OtelTracer), and a baseline comparison against raw `golang-jwt/jwt`. Results and reproduction instructions in `doc/PERFORMANCE.md`. See #141.
 
+### Fixed
+
+- **`tokens.ErrTokenMissingKid` exported sentinel** — `ValidateAccessToken` previously returned an inline `errors.New(...)` when the JWT header lacked a `kid` field, making the missing-kid case indistinguishable from generic `ErrInvalidToken` via `errors.Is`. The sentinel is now exported and surfaced directly so middleware can return a precise 401 payload. `ValidateAccessTokenWithClaims` inherits the fix by delegation. See #178.
+
+- **`cleanupExpiredKeys` current-key guard covered by spec** — the guard that prevents the active signing key from being deleted during a cleanup sweep was already implemented (`if keyID == m.currentKeyID { continue }`) but had no test coverage. A new Phase 12 spec in the KeyManager suite verifies the guard using a `CleanupExpiredKeysForTest` test export that triggers the sweep synchronously. See #179.
+
+- **`jti` claim switched to UUID v4** — `generateTokenID()` previously used `crypto/rand` + `base64.RawURLEncoding` to produce a 22-character base64url string. It now returns `uuid.New().String()` (36-character UUID v4), aligning `jti` with the `kid` format and making the implementation match what ADR-005 already documents. No interface changes; no new module dependencies. See #196.
+
 ### Chore
 
 - **Apache 2.0 SPDX license headers added to all Go source files** — every `.go` file under `pkg/`, `internal/`, and `examples/` now carries a 3-line header (`Copyright 2026 Angel Tomala-Reyes` + `SPDX-License-Identifier: Apache-2.0`). `goheader` added to `.golangci.yml` to enforce headers on new files going forward. See #144.

--- a/README.md
+++ b/README.md
@@ -1087,7 +1087,7 @@ See [doc/ARCHITECTURE.md](doc/ARCHITECTURE.md#project-structure) for the package
 
 ### Test Coverage
 
-**Current**: 955 comprehensive specs (895 unit + 60 integration) across all packages, all passing with race detection (KeyManager ~81%, TokenManager ~92%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%)
+**Current**: 956 comprehensive specs (896 unit + 60 integration) across all packages, all passing with race detection (KeyManager ~81%, TokenManager ~92%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%)
 
 **KeyManager** (3 test suites — 170 total specs):
 - **9-phase Manager tests** (MockKeyStore — no I/O):
@@ -1107,7 +1107,7 @@ See [doc/ARCHITECTURE.md](doc/ARCHITECTURE.md#project-structure) for the package
   - Error handling: corrupt metadata, missing metadata entry, Redis unavailability via SetError
   - Concurrency, metrics recording (storage_backend: "redis")
 
-**TokenManager** (7 test suites, 257 total specs):
+**TokenManager** (7 test suites, 258 total specs):
 - **Lifecycle Management Tests**:
   - Start: idempotency, logging, background cleanup, failure handling, context cancellation
   - Shutdown: logging, cleanup termination, goroutine coordination, timeout respect, idempotency, restart after clean shutdown
@@ -1380,5 +1380,5 @@ Built by a Senior Platform Engineer with deep experience in distributed systems 
 **Status**: v0.5.0-dev — production-quality, pre-v1.0 (see API Stability note at top)
 **Version**: v0.5.0 (active development; latest release: v0.4.0)
 **Components**: KeyManager ✅ | TokenManager ✅ | RefreshStore (Memory + Redis) ✅ | Metrics (Prometheus) ✅ | Logging (Correlation ID) ✅ | Tracing ✅
-**Test Coverage**: 955 specs (895 unit + 60 integration) — KeyManager ~81%, TokenManager ~92%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100% — all passing, race-detection enabled
-**Last Updated**: May 6, 2026
+**Test Coverage**: 956 specs (896 unit + 60 integration) — KeyManager ~81%, TokenManager ~92%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100% — all passing, race-detection enabled
+**Last Updated**: May 7, 2026

--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -90,6 +90,7 @@ import (
 	"github.com/aetomala/jwtauth/pkg/storage"
 	"github.com/aetomala/jwtauth/pkg/tracing"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
 )
 
 // TokenManagerConfig holds the configuration for a Manager.
@@ -2631,24 +2632,16 @@ func (m *Manager) ListTokensForAudience(ctx context.Context, audience string, cu
 	return tokens, nextCursor, nil
 }
 
-// generateTokenID creates a cryptographically random token identifier.
+// generateTokenID returns a new UUID v4 string to use as the jti claim.
 //
 // The token ID (jti claim) is used for:
 //   - Token revocation (blacklisting)
 //   - Audit trails
 //   - Preventing replay attacks
 //
-// Returns a URL-safe base64 encoded string (22 characters).
+// Returns a 36-character UUID v4 string (e.g. "550e8400-e29b-41d4-a716-446655440000").
 func generateTokenID() (string, error) {
-	// Generate 16 random bytes
-	b := make([]byte, 16)
-	if _, err := rand.Read(b); err != nil {
-		return "", fmt.Errorf("failed to generate random bytes: %w", err)
-	}
-
-	// Encode as URL-safe base64 (no padding)
-	// Example: "xF7hN2kP9mQ8rT4vL6wY3g"
-	return base64.RawURLEncoding.EncodeToString(b), nil
+	return uuid.New().String(), nil
 }
 
 // generateRefreshToken creates a cryptographically random refresh token.

--- a/pkg/tokens/manager_test.go
+++ b/pkg/tokens/manager_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/google/uuid"
 	"go.uber.org/mock/gomock"
 
 	"github.com/aetomala/jwtauth/internal/testutil"
@@ -240,6 +241,18 @@ var _ = Describe("TokenManager", func() {
 			token, err := service.IssueAccessToken(ctx, testUserID)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(token).NotTo((BeEmpty()))
+		})
+
+		It("should embed a valid UUID v4 as the jti claim", func() {
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(testKey, testKeyID, nil)
+			tokenString, err := service.IssueAccessToken(ctx, testUserID)
+			Expect(err).NotTo(HaveOccurred())
+			parsedToken, _, parseErr := new(jwt.Parser).ParseUnverified(tokenString, &jwt.RegisteredClaims{})
+			Expect(parseErr).NotTo(HaveOccurred())
+			claims, ok := parsedToken.Claims.(*jwt.RegisteredClaims)
+			Expect(ok).To(BeTrue())
+			_, uuidErr := uuid.Parse(claims.ID)
+			Expect(uuidErr).NotTo(HaveOccurred())
 		})
 
 		It("should use KeyManager to sign token", func() {


### PR DESCRIPTION
## Summary

- Replaces `generateTokenID()` body: `crypto/rand` + `base64.RawURLEncoding` (22-char base64url) → `uuid.New().String()` (36-char UUID v4)
- Adds `github.com/google/uuid` import to `pkg/tokens/manager.go` — already in `go.mod`, no new module entry
- `crypto/rand` and `encoding/base64` imports retained — still used by `generateRefreshToken()` and `ValidateAccessTokenWithClaims`
- Adds spec: `uuid.Parse(claims.ID)` succeeds on a freshly issued access token
- Adds `### Fixed` section to CHANGELOG v0.5.0 Unreleased block — covers #178, #179, and #196
- Updates README spec counts: 955 → 956 total, 895 → 896 unit, TokenManager suite 257 → 258

## Why

ADR-005 already documents jti as "generated internally by `uuid.New()`". `kid` already uses UUID v4. This makes the code accurate and aligns both IDs on the same format — consistent log parsing and trace queries without any format translation.

## Test plan

- [x] `./run-ci-locally.sh` green — 956 specs (896 unit + 60 integration), race-detection clean
- [x] New spec: `uuid.Parse(claims.ID)` passes on freshly issued access token
- [x] `generateRefreshToken()` unchanged — refresh tokens remain 43-char base64url (opaque, not JWTs)
- [x] No new `go.mod` entries