### PR TITLE
fix(storage): standardize expiration boundary checks to !expiresAt.After(now)

### DIFF
--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -167,7 +167,7 @@ func (m *MemoryRefreshStore) Store(ctx context.Context, tokenID, userID string, 
 		return ErrInvalidUserID
 	}
 
-	if expiresAt.Before(time.Now()) {
+	if !expiresAt.After(time.Now()) {
 		status = "validation_error"
 		errorType = "validation_error"
 		m.logger.Warn("store rejected: token is already expired", ctx,
@@ -314,7 +314,7 @@ func (m *MemoryRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Ref
 	}
 
 	// ===== STEP 6: Check Expiration =====
-	if token.ExpiresAt.Before(time.Now()) {
+	if !token.ExpiresAt.After(time.Now()) {
 		status = "expired"
 		errorType = "expired"
 		m.logger.Warn("retrieve: token has expired", ctx,
@@ -561,7 +561,7 @@ func (m *MemoryRefreshStore) Cleanup(ctx context.Context) (int, error) {
 
 	// ===== STEP 3: Sweep and Remove Expired Tokens =====
 	for tokenID, token := range m.tokens {
-		if token.ExpiresAt.Before(now) || token.ExpiresAt.Equal(now) {
+		if !token.ExpiresAt.After(now) {
 			m.logger.Debug("removing expired token", ctx,
 				"tokenID", token.TokenID,
 				"expiredAt", token.ExpiresAt)

--- a/pkg/storage/redis.go
+++ b/pkg/storage/redis.go
@@ -178,7 +178,7 @@ func (r *RedisRefreshStore) Store(ctx context.Context, tokenID, userID string, a
 		return ErrInvalidUserID
 	}
 
-	if expiresAt.Before(time.Now()) || expiresAt.Equal(time.Now()) {
+	if !expiresAt.After(time.Now()) {
 		status = "validation_error"
 		errorType = "validation_error"
 		r.logger.Warn("store rejected: token is already expired", ctx,
@@ -383,7 +383,7 @@ func (r *RedisRefreshStore) Retrieve(ctx context.Context, tokenID string) (*Refr
 	}
 
 	expiresAt := time.UnixMilli(expiresAtMillis)
-	if expiresAt.Before(time.Now()) {
+	if !expiresAt.After(time.Now()) {
 		status = "expired"
 		errorType = "expired"
 		r.logger.Warn("retrieve: token has expired", ctx,
@@ -718,7 +718,7 @@ func (r *RedisRefreshStore) Cleanup(ctx context.Context) (int, error) {
 		}
 
 		expiresAt := time.UnixMilli(expiresAtMillis)
-		if expiresAt.Before(now) || expiresAt.Equal(now) {
+		if !expiresAt.After(now) {
 			expiredKeys = append(expiredKeys, key)
 
 			userID := hash["userID"]

--- a/pkg/storage/suite_test.go
+++ b/pkg/storage/suite_test.go
@@ -300,6 +300,17 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 					Skip("Store rejected expired token at write time")
 				}
 			})
+
+			It("should return ErrTokenExpired for token that expired after being stored", func() {
+				shortLived := time.Now().Add(50 * time.Millisecond)
+				err := store.Store(ctx, tokenID, userID, nil, shortLived, metadata)
+				Expect(err).NotTo(HaveOccurred())
+
+				time.Sleep(100 * time.Millisecond)
+
+				_, err = store.Retrieve(ctx, tokenID)
+				Expect(err).To(MatchError(storage.ErrTokenExpired))
+			})
 		})
 
 		// ============================================================
@@ -513,6 +524,20 @@ func RunRefreshStoreTests(description, backend string, factory StoreFactory, cle
 				token, err := store.Retrieve(ctx, "future-token")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(token.TokenID).To(Equal("future-token"))
+			})
+
+			It("should treat boundary-exact expiry as expired during cleanup", func() {
+				shortLived := time.Now().Add(50 * time.Millisecond)
+				err := store.Store(ctx, tokenID, userID, nil, shortLived, metadata)
+				if err != nil {
+					Skip("Store rejected short-lived token")
+				}
+
+				time.Sleep(100 * time.Millisecond)
+
+				count, err := store.Cleanup(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(count).To(BeNumerically(">=", 1))
 			})
 		})
 


### PR DESCRIPTION
## Summary

Fixes an inconsistency in how `MemoryRefreshStore` and `RedisRefreshStore` handle tokens that expire at exactly the current instant.

- `memory.go` — `Store` and `Retrieve` used `.Before(now)` (strictly `<`), silently accepting the boundary instant as valid
- `redis.go` — `Retrieve` had the same flaw; `Store` already used `.Before() || .Equal()` but inconsistently with `memory.go`
- Both `Cleanup` implementations used the verbose `.Before() || .Equal()` two-condition form

All six sites are now unified to `!expiresAt.After(now)` — equivalent to `expiresAt <= now` — which unambiguously treats the boundary instant as expired and matches the semantic "valid only strictly before T".

## Tests

Two new specs added to `RunRefreshStoreTests` (runs against both backends):
- Phase 5: store a short-lived token, wait for expiry, confirm `ErrTokenExpired` on `Retrieve`
- Phase 8: store a short-lived token, wait for expiry, confirm `Cleanup` sweeps it

All 222 storage specs and 60 integration specs pass under `-race`.

## ADR compliance

- **ADR-002 (Stateful refresh tokens):** Fix tightens the expiry gate, consistent with instant-revocation intent. No other ADRs touched.

Closes #176