### PR TITLE
fix(storage): use explicit nonExpired counter in RedisRefreshStore.Cleanup gauge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ All notable changes to this project will be documented in this file.
 
 - **`jti` claim switched to UUID v4** — `generateTokenID()` previously used `crypto/rand` + `base64.RawURLEncoding` to produce a 22-character base64url string. It now returns `uuid.New().String()` (36-character UUID v4), aligning `jti` with the `kid` format and making the implementation match what ADR-005 already documents. No interface changes; no new module dependencies. See #196.
 
+- **`RedisRefreshStore.Cleanup` gauge accuracy** — `metricStorageTokensCount` was computed as `totalScanned - removed`, inflating the gauge when token keys fail to deserialize during the SCAN sweep (HGetAll error or invalid `expiresAt` timestamp). The fix introduces an explicit `nonExpired` counter incremented only for keys that successfully parse and are not expired. The `(int, error)` return value was already correct in both implementations. See #180.
+
 ### Chore
 
 - **Go toolchain bumped to 1.26.3** — addresses `GO-2026-4971` (panic in `net.Dial`/`LookupPort` when a hostname contains a NUL byte; Windows only; reachable in this repo only through the example binary). Unblocks `govulncheck` in CI. See #208.

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -107,7 +107,9 @@ type RefreshStore interface {
 	// audience is empty. Returns the context error if the context is cancelled.
 	RevokeAllForUserAndAudience(ctx context.Context, userID, audience string) (int, error)
 
-	// Cleanup removes expired tokens.
+	// Cleanup removes expired tokens from the store and returns the count of
+	// tokens actually deleted. Implementations must return only the count of
+	// tokens removed — not keys scanned, keys skipped, or remaining tokens.
 	//
 	// This should be called periodically to:
 	//   - Free storage space

--- a/pkg/storage/redis.go
+++ b/pkg/storage/redis.go
@@ -693,6 +693,7 @@ func (r *RedisRefreshStore) Cleanup(ctx context.Context) (int, error) {
 	count := 0
 	now := time.Now()
 	totalScanned := 0
+	nonExpired := 0
 
 	iter := r.client.Scan(ctx, 0, r.tokenPrefix+"*", 0).Iterator()
 
@@ -735,6 +736,8 @@ func (r *RedisRefreshStore) Cleanup(ctx context.Context) (int, error) {
 				_ = r.client.SRem(ctx, r.audienceSetPrefix+aud, tokenID).Err()
 				_ = r.client.SRem(ctx, r.audienceUserSetPrefix+aud+":"+userID, tokenID).Err()
 			}
+		} else {
+			nonExpired++
 		}
 	}
 
@@ -764,7 +767,7 @@ func (r *RedisRefreshStore) Cleanup(ctx context.Context) (int, error) {
 		count = len(expiredKeys)
 	}
 	removed = count
-	remaining = totalScanned - removed
+	remaining = nonExpired
 
 	// ===== STEP 4: Log Success =====
 	status = "success"


### PR DESCRIPTION
## Summary

Fixes a gauge inaccuracy in `RedisRefreshStore.Cleanup()` where `metricStorageTokensCount` was inflated by unreadable token keys.

The previous computation `remaining = totalScanned - removed` used `totalScanned`, which counts every key the SCAN cursor visits — including keys that fail to deserialize (HGetAll error or invalid `expiresAt` timestamp). Those keys skip via `continue`, are never deleted, but were silently counted as remaining valid tokens.

The fix introduces a `nonExpired` counter incremented only when a key is successfully parsed **and** found to be non-expired. This aligns Redis with `MemoryRefreshStore`, which computes `remaining = len(m.tokens)` after deletion under a write lock.

The `(int, error)` return value was already correct in both implementations — both returned the count of tokens deleted. The `RefreshStore.Cleanup()` interface doc comment is tightened to make this contract explicit.

## Changes

- `pkg/storage/redis.go` — add `nonExpired` counter in SCAN loop; use it for gauge instead of `totalScanned - removed`
- `pkg/storage/interface.go` — strengthen `Cleanup()` doc comment
- `CHANGELOG.md` — bug fix entry

## ADR compliance

- **ADR-002 (Stateful refresh tokens):** No change to revocation or token lifecycle semantics. Gauge accuracy improvement only.

## Tests

222/222 storage specs and 60/60 integration specs pass under `-race`. Phase 8 `"should return count of removed tokens"` (`Expect(count).To(Equal(3))`) confirms return value correctness for both backends.

Closes #180