### PR TITLE
ci: narrow govulncheck scope to ./pkg/... (closes #210)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,7 +38,11 @@ jobs:
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
 
-      - name: govulncheck
+      - name: govulncheck (library)
+        run: govulncheck ./pkg/...
+
+      - name: govulncheck (examples — non-blocking)
+        continue-on-error: true
         run: govulncheck ./...
 
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ All notable changes to this project will be documented in this file.
 
 ### Chore
 
+- **`govulncheck` CI scope narrowed to `./pkg/...`** — example binaries in the root module
+  no longer gate library work. A non-blocking second step runs `govulncheck ./...` for
+  full-module visibility. Mirrored in `run-ci-locally.sh`. See #210.
+
 - **Go toolchain bumped to 1.26.3** — addresses `GO-2026-4971` (panic in `net.Dial`/`LookupPort` when a hostname contains a NUL byte; Windows only; reachable in this repo only through the example binary). Unblocks `govulncheck` in CI. See #208.
 
 - **Apache 2.0 SPDX license headers added to all Go source files** — every `.go` file under `pkg/`, `internal/`, and `examples/` now carries a 3-line header (`Copyright 2026 Angel Tomala-Reyes` + `SPDX-License-Identifier: Apache-2.0`). `goheader` added to `.golangci.yml` to enforce headers on new files going forward. See #144.

--- a/run-ci-locally.sh
+++ b/run-ci-locally.sh
@@ -37,7 +37,10 @@ run_test() {
 echo -e "\n${YELLOW}====== LINT JOB ======${NC}"
 run_test "go vet" "go vet ./..."
 run_test "golangci-lint" "golangci-lint run ./..."
-run_test "govulncheck" "govulncheck ./..."
+run_test "govulncheck (library)" "govulncheck ./pkg/..."
+
+echo -e "\n${YELLOW}[INFO]${NC} govulncheck (examples — non-blocking)"
+govulncheck ./... || true
 
 # Test Job
 echo -e "\n${YELLOW}====== TEST JOB ======${NC}"


### PR DESCRIPTION
## Summary

- Splits `govulncheck` in CI into two steps: a hard gate on `./pkg/...` and a non-blocking `continue-on-error` step on `./...` for full-module visibility
- Mirrors the same split in `run-ci-locally.sh` to prevent local/CI drift
- Root cause: `examples/correlation-example/` has no `go.mod` and is part of the root module; the other seven example directories are already excluded as separate modules

## Go version note (deferred)

Investigation found no transitive dependency or language feature in `./pkg/...` that requires Go above 1.25.0 (OTel v1.43.0). The current `go 1.26.3` declaration is attributable to `correlation-example` being in the root module. Moving it to its own `go.mod` and lowering the root `go` directive to 1.25.0 is filed as follow-up work — not in scope here.

## Test plan

- [ ] CI Lint job: `govulncheck (library)` step passes; `govulncheck (examples — non-blocking)` step runs but never fails the job
- [ ] `./run-ci-locally.sh` runs clean locally

closes #210