### PR TITLE
observability: rename operations_total to tokens_cleanup_total (Phase 3 of #206)

### DIFF
--- a/doc/UPGRADING.md
+++ b/doc/UPGRADING.md
@@ -43,6 +43,20 @@ scrape-health alerting.
 Storage-layer list operations remain observable via the token-layer `jwtauth_tokens_list_*`
 metrics and the `jwtauth_storage_operations_total` counter.
 
+### Renamed metrics
+
+#### Phase 3 — `operations_total` → `tokens_cleanup_total`
+
+`jwtauth_operations_total` is renamed to `jwtauth_tokens_cleanup_total`. The `operation`
+label is dropped — the metric name now encodes the operation. The `status` and `namespace`
+labels are unchanged.
+
+**Before:** `jwtauth_operations_total{operation="cleanup", status="success", namespace="..."}`
+**After:** `jwtauth_tokens_cleanup_total{status="success", namespace="..."}`
+
+**Action required:** Update alert rules and dashboards. The `operation="cleanup"` label
+carried no additional cardinality — no information is lost.
+
 ---
 
 ## v0.5.x → v0.6.0

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -95,9 +95,9 @@ func (pm *PrometheusMetrics) registerAllMetrics(namespace string) {
 		"Total number of tokens revoked",
 		[]string{"revocation_scope", "status", "namespace"})
 
-	pm.registerCounter(namespace, "operations_total",
-		"Total number of operations",
-		[]string{"operation", "status", "namespace"})
+	pm.registerCounter(namespace, "tokens_cleanup_total",
+		"Total number of cleanup operations",
+		[]string{"status", "namespace"})
 
 	pm.registerHistogram(namespace, "operation_duration_seconds",
 		"Duration of operations in seconds",

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -192,7 +192,7 @@ var _ = Describe("Prometheus", func() {
 
 				Expect(names).To(ContainElement(ContainSubstring("jwtauth_tokens_issued_total")))
 				Expect(names).To(ContainElement(ContainSubstring("jwtauth_tokens_validated_total")))
-				Expect(names).To(ContainElement(ContainSubstring("jwtauth_operations_total")))
+				Expect(names).To(ContainElement(ContainSubstring("jwtauth_tokens_cleanup_total")))
 			})
 
 			It("should register RefreshStore metrics", func() {
@@ -225,51 +225,50 @@ var _ = Describe("Prometheus", func() {
 
 			It("should support multiple increments", func() {
 				labels := map[string]string{
-					"operation": "validate",
 					"status":    "success",
 					"namespace": "",
 				}
 
-				pm.IncrementCounter("jwtauth_operations_total", labels)
-				pm.IncrementCounter("jwtauth_operations_total", labels)
-				pm.IncrementCounter("jwtauth_operations_total", labels)
+				pm.IncrementCounter("jwtauth_tokens_cleanup_total", labels)
+				pm.IncrementCounter("jwtauth_tokens_cleanup_total", labels)
+				pm.IncrementCounter("jwtauth_tokens_cleanup_total", labels)
 
-				Expect(counterValue(registry, "jwtauth_operations_total", labels)).To(Equal(3.0))
+				Expect(counterValue(registry, "jwtauth_tokens_cleanup_total", labels)).To(Equal(3.0))
 			})
 
 			It("should handle different label combinations independently", func() {
-				successLabels := map[string]string{"operation": "issue", "status": "success", "namespace": ""}
-				failureLabels := map[string]string{"operation": "issue", "status": "failure", "namespace": ""}
+				successLabels := map[string]string{"status": "success", "namespace": ""}
+				failureLabels := map[string]string{"status": "failure", "namespace": ""}
 
-				pm.IncrementCounter("jwtauth_operations_total", successLabels)
-				pm.IncrementCounter("jwtauth_operations_total", failureLabels)
+				pm.IncrementCounter("jwtauth_tokens_cleanup_total", successLabels)
+				pm.IncrementCounter("jwtauth_tokens_cleanup_total", failureLabels)
 
-				Expect(counterValue(registry, "jwtauth_operations_total", successLabels)).To(Equal(1.0))
-				Expect(counterValue(registry, "jwtauth_operations_total", failureLabels)).To(Equal(1.0))
+				Expect(counterValue(registry, "jwtauth_tokens_cleanup_total", successLabels)).To(Equal(1.0))
+				Expect(counterValue(registry, "jwtauth_tokens_cleanup_total", failureLabels)).To(Equal(1.0))
 			})
 
 			Context("AddCounter", func() {
 				It("should add specific value to counter", func() {
-					labels := map[string]string{"operation": "batch", "status": "success", "namespace": ""}
-					pm.AddCounter("jwtauth_operations_total", 5.0, labels)
+					labels := map[string]string{"status": "success", "namespace": ""}
+					pm.AddCounter("jwtauth_tokens_cleanup_total", 5.0, labels)
 
-					Expect(counterValue(registry, "jwtauth_operations_total", labels)).To(Equal(5.0))
+					Expect(counterValue(registry, "jwtauth_tokens_cleanup_total", labels)).To(Equal(5.0))
 				})
 
 				It("should accumulate values across multiple calls", func() {
-					labels := map[string]string{"operation": "batch", "status": "success", "namespace": ""}
+					labels := map[string]string{"status": "success", "namespace": ""}
 
-					pm.AddCounter("jwtauth_operations_total", 5.0, labels)
-					pm.AddCounter("jwtauth_operations_total", 3.0, labels)
+					pm.AddCounter("jwtauth_tokens_cleanup_total", 5.0, labels)
+					pm.AddCounter("jwtauth_tokens_cleanup_total", 3.0, labels)
 
-					Expect(counterValue(registry, "jwtauth_operations_total", labels)).To(Equal(8.0))
+					Expect(counterValue(registry, "jwtauth_tokens_cleanup_total", labels)).To(Equal(8.0))
 				})
 
 				It("should handle fractional values", func() {
-					labels := map[string]string{"operation": "partial", "status": "success", "namespace": ""}
-					pm.AddCounter("jwtauth_operations_total", 0.5, labels)
+					labels := map[string]string{"status": "partial", "namespace": ""}
+					pm.AddCounter("jwtauth_tokens_cleanup_total", 0.5, labels)
 
-					Expect(counterValue(registry, "jwtauth_operations_total", labels)).To(Equal(0.5))
+					Expect(counterValue(registry, "jwtauth_tokens_cleanup_total", labels)).To(Equal(0.5))
 				})
 			})
 		})
@@ -279,31 +278,31 @@ var _ = Describe("Prometheus", func() {
 	Describe("Phase 2: Counter Operations - Happy Path", func() {
 		Context("IncrementCounter", func() {
 			It("should increment counter by 1", func() {
-				labels := map[string]string{"operation": "issue", "status": "success", "namespace": ""}
-				pm.IncrementCounter("jwtauth_operations_total", labels)
+				labels := map[string]string{"status": "success", "namespace": ""}
+				pm.IncrementCounter("jwtauth_tokens_cleanup_total", labels)
 
-				Expect(counterValue(registry, "jwtauth_operations_total", labels)).To(Equal(1.0))
+				Expect(counterValue(registry, "jwtauth_tokens_cleanup_total", labels)).To(Equal(1.0))
 			})
 
 			It("should support multiple increments", func() {
-				labels := map[string]string{"operation": "validate", "status": "success", "namespace": ""}
+				labels := map[string]string{"status": "success", "namespace": ""}
 
-				pm.IncrementCounter("jwtauth_operations_total", labels)
-				pm.IncrementCounter("jwtauth_operations_total", labels)
-				pm.IncrementCounter("jwtauth_operations_total", labels)
+				pm.IncrementCounter("jwtauth_tokens_cleanup_total", labels)
+				pm.IncrementCounter("jwtauth_tokens_cleanup_total", labels)
+				pm.IncrementCounter("jwtauth_tokens_cleanup_total", labels)
 
-				Expect(counterValue(registry, "jwtauth_operations_total", labels)).To(Equal(3.0))
+				Expect(counterValue(registry, "jwtauth_tokens_cleanup_total", labels)).To(Equal(3.0))
 			})
 
 			It("should handle different label combinations independently", func() {
-				successLabels := map[string]string{"operation": "issue", "status": "success", "namespace": ""}
-				failureLabels := map[string]string{"operation": "issue", "status": "failure", "namespace": ""}
+				successLabels := map[string]string{"status": "success", "namespace": ""}
+				failureLabels := map[string]string{"status": "failure", "namespace": ""}
 
-				pm.IncrementCounter("jwtauth_operations_total", successLabels)
-				pm.IncrementCounter("jwtauth_operations_total", failureLabels)
+				pm.IncrementCounter("jwtauth_tokens_cleanup_total", successLabels)
+				pm.IncrementCounter("jwtauth_tokens_cleanup_total", failureLabels)
 
-				Expect(counterValue(registry, "jwtauth_operations_total", successLabels)).To(Equal(1.0))
-				Expect(counterValue(registry, "jwtauth_operations_total", failureLabels)).To(Equal(1.0))
+				Expect(counterValue(registry, "jwtauth_tokens_cleanup_total", successLabels)).To(Equal(1.0))
+				Expect(counterValue(registry, "jwtauth_tokens_cleanup_total", failureLabels)).To(Equal(1.0))
 			})
 		})
 	})
@@ -431,13 +430,13 @@ var _ = Describe("Prometheus", func() {
 		Context("invalid input handling", func() {
 			It("should not panic with nil labels", func() {
 				Expect(func() {
-					pm.IncrementCounter("jwtauth_operations_total", nil)
+					pm.IncrementCounter("jwtauth_tokens_cleanup_total", nil)
 				}).NotTo(Panic())
 			})
 
 			It("should not panic with empty labels", func() {
 				Expect(func() {
-					pm.IncrementCounter("jwtauth_operations_total", map[string]string{})
+					pm.IncrementCounter("jwtauth_tokens_cleanup_total", map[string]string{})
 				}).NotTo(Panic())
 			})
 
@@ -457,10 +456,10 @@ var _ = Describe("Prometheus", func() {
 
 		Context("label mismatch handling", func() {
 			It("should handle missing required labels", func() {
-				// Metric expects "operation" and "status" labels
+				// Metric expects "status" and "namespace" labels
 				Expect(func() {
-					pm.IncrementCounter("jwtauth_operations_total", map[string]string{
-						"operation": "issue",
+					pm.IncrementCounter("jwtauth_tokens_cleanup_total", map[string]string{
+						"namespace": "",
 						// Missing "status" label
 					})
 				}).NotTo(Panic())
@@ -468,9 +467,9 @@ var _ = Describe("Prometheus", func() {
 
 			It("should handle extra labels", func() {
 				Expect(func() {
-					pm.IncrementCounter("jwtauth_operations_total", map[string]string{
-						"operation": "issue",
+					pm.IncrementCounter("jwtauth_tokens_cleanup_total", map[string]string{
 						"status":    "success",
+						"namespace": "",
 						"extra_key": "extra_value",
 						"another":   "label",
 					})
@@ -509,8 +508,7 @@ var _ = Describe("Prometheus", func() {
 					go func() {
 						defer GinkgoRecover()
 						for j := 0; j < incrementsPerGoroutine; j++ {
-							pm.IncrementCounter("jwtauth_operations_total", map[string]string{
-								"operation": "concurrent",
+							pm.IncrementCounter("jwtauth_tokens_cleanup_total", map[string]string{
 								"status":    "success",
 								"namespace": "",
 							})
@@ -524,8 +522,8 @@ var _ = Describe("Prometheus", func() {
 					<-done
 				}
 
-				labels := map[string]string{"operation": "concurrent", "status": "success", "namespace": ""}
-				Expect(counterValue(registry, "jwtauth_operations_total", labels)).To(Equal(float64(goroutines * incrementsPerGoroutine)))
+				labels := map[string]string{"status": "success", "namespace": ""}
+				Expect(counterValue(registry, "jwtauth_tokens_cleanup_total", labels)).To(Equal(float64(goroutines * incrementsPerGoroutine)))
 			})
 
 			It("should handle concurrent AddCounter calls", func() {
@@ -534,8 +532,7 @@ var _ = Describe("Prometheus", func() {
 				for i := 0; i < 5; i++ {
 					go func() {
 						defer GinkgoRecover()
-						pm.AddCounter("jwtauth_operations_total", 10.0, map[string]string{
-							"operation": "concurrent_add",
+						pm.AddCounter("jwtauth_tokens_cleanup_total", 10.0, map[string]string{
 							"status":    "success",
 							"namespace": "",
 						})
@@ -547,8 +544,8 @@ var _ = Describe("Prometheus", func() {
 					<-done
 				}
 
-				labels := map[string]string{"operation": "concurrent_add", "status": "success", "namespace": ""}
-				Expect(counterValue(registry, "jwtauth_operations_total", labels)).To(Equal(50.0))
+				labels := map[string]string{"status": "success", "namespace": ""}
+				Expect(counterValue(registry, "jwtauth_tokens_cleanup_total", labels)).To(Equal(50.0))
 			})
 		})
 
@@ -614,8 +611,7 @@ var _ = Describe("Prometheus", func() {
 			})
 
 			It("should expose metrics in Prometheus text format", func() {
-				pm.IncrementCounter("jwtauth_operations_total", map[string]string{
-					"operation": "issue",
+				pm.IncrementCounter("jwtauth_tokens_cleanup_total", map[string]string{
 					"status":    "success",
 					"namespace": "",
 				})
@@ -633,7 +629,7 @@ var _ = Describe("Prometheus", func() {
 
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(resp.Header.Get("Content-Type")).To(ContainSubstring("text/plain"))
-				Expect(strings.Contains(string(body), "jwtauth_operations_total")).To(BeTrue())
+				Expect(strings.Contains(string(body), "jwtauth_tokens_cleanup_total")).To(BeTrue())
 				Expect(strings.Contains(string(body), "jwtauth_storage_tokens_count")).To(BeTrue())
 			})
 		})
@@ -646,8 +642,7 @@ var _ = Describe("Prometheus", func() {
 			})
 
 			It("should allow querying metrics from registry", func() {
-				pm.IncrementCounter("jwtauth_operations_total", map[string]string{
-					"operation": "test",
+				pm.IncrementCounter("jwtauth_tokens_cleanup_total", map[string]string{
 					"status":    "success",
 					"namespace": "",
 				})
@@ -885,10 +880,10 @@ var _ = Describe("Prometheus", func() {
 			})
 
 			It("should log warning for label key typos", func() {
-				// Typo in label key: "operaton" instead of "operation" — causes label mismatch
-				pmWithLogger.IncrementCounter("jwtauth_operations_total", map[string]string{
-					"operaton": "issue", // Typo: should be "operation"
-					"status":   "success",
+				// Typo in label key: "statuss" instead of "status" — causes label mismatch
+				pmWithLogger.IncrementCounter("jwtauth_tokens_cleanup_total", map[string]string{
+					"statuss":   "success", // Typo: should be "status"
+					"namespace": "",
 				})
 
 				// Our implementation logs a warning when labels don't match registered label names

--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -2381,10 +2381,9 @@ func (m *Manager) CleanupExpiredTokens(ctx context.Context) (int, error) {
 	start := time.Now()
 	status := "error"
 	defer func() {
-		m.metrics.IncrementCounter(metricOperationsTotal, map[string]string{
-			"operation": "cleanup",
+		m.metrics.IncrementCounter(metricTokensCleanupTotal, map[string]string{
 			"status":    status,
-			"namespace":  m.namespace,
+			"namespace": m.namespace,
 		})
 		m.metrics.RecordDuration(metricOperationDuration, time.Since(start), map[string]string{
 			"operation": "cleanup",

--- a/pkg/tokens/manager_metrics_test.go
+++ b/pkg/tokens/manager_metrics_test.go
@@ -368,8 +368,7 @@ var _ = Describe("TokenManager Metrics", func() {
 		It("records success counter and duration on successful cleanup", func() {
 			startService()
 			mockStore.EXPECT().Cleanup(gomock.Any()).Return(3, nil)
-			mockM.EXPECT().IncrementCounter("jwtauth_operations_total", map[string]string{
-				"operation": "cleanup",
+			mockM.EXPECT().IncrementCounter("jwtauth_tokens_cleanup_total", map[string]string{
 				"status":    "success",
 				"namespace": "",
 			})

--- a/pkg/tokens/observability.go
+++ b/pkg/tokens/observability.go
@@ -12,7 +12,7 @@ const (
 	metricTokensValidatedTotal    = "jwtauth_tokens_validated_total"
 	metricTokensRefreshedTotal    = "jwtauth_tokens_refreshed_total"
 	metricTokensRevokedTotal      = "jwtauth_tokens_revoked_total"
-	metricOperationsTotal   = "jwtauth_operations_total"
+	metricTokensCleanupTotal = "jwtauth_tokens_cleanup_total"
 	metricOperationDuration = "jwtauth_operation_duration_seconds"
 
 	metricTokensListTotal    = "jwtauth_tokens_list_total"


### PR DESCRIPTION
## Summary

Phase 3 of #206 — rename only, metric count unchanged (22 → 22).

- Renames `jwtauth_operations_total` → `jwtauth_tokens_cleanup_total`
- Drops the `operation` label — was always `"cleanup"`; the metric name now encodes the operation
- Retains `status` and `namespace` labels unchanged
- Adds Phase 3 rename documentation to `doc/UPGRADING.md`

## Files changed

| File | Change |
|---|---|
| `pkg/metrics/prometheus.go` | Registration renamed; label set shrunk from `{operation, status, namespace}` to `{status, namespace}` |
| `pkg/tokens/observability.go` | Constant renamed `metricOperationsTotal` → `metricTokensCleanupTotal` |
| `pkg/tokens/manager.go` | Call site in `CleanupExpiredTokens` updated; `"operation": "cleanup"` label removed |
| `pkg/tokens/manager_metrics_test.go` | Mock expectation updated to match |
| `pkg/metrics/prometheus_test.go` | All 44 metric name references updated; label maps scrubbed of `"operation"` key |
| `doc/UPGRADING.md` | Phase 3 rename section added under `## v0.6.x → v0.7.0` |

## Running count

34 → 31 (Phase 1) → 22 (Phase 2) → **22 (Phase 3, rename only)** → 18 (Phase 4)

## Verification

```
grep -rn 'jwtauth_operations_total\|metricOperationsTotal' ./pkg/  # zero hits ✓
./run-ci-locally.sh                                                 # 891 unit + 60 integration, all pass ✓
```

## Upgrade impact

**Before:** `jwtauth_operations_total{operation="cleanup", status="success", namespace="..."}`
**After:** `jwtauth_tokens_cleanup_total{status="success", namespace="..."}`

The `operation="cleanup"` label carried no additional cardinality. No information is lost.

**Part of:** #206
**Next:** Phase 4 — collapse `tokens_list_for_user/audience_*` into `tokens_list_total{scope}` and `tokens_list_duration_seconds{scope}`