### PR TITLE
observability: collapse list metrics under scope label (Phase 4 of #206)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,6 +13,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -48,6 +49,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Breaking
+
+- **`PrometheusMetrics` metric set reduced from 34 to 18** — sixteen metrics are removed or collapsed. The `Metrics` interface is unchanged — all five methods (`IncrementCounter`, `AddCounter`, `SetGauge`, `RecordHistogram`, `RecordDuration`) are unaffected. Update Prometheus dashboards and alert rules that reference removed or renamed metrics. See #206 and `UPGRADING.md` for the full migration table.
+
+  **Removed metrics (14):** `jwtauth_service_running`, `jwtauth_tokens_introspected_total`, `jwtauth_active_tokens`, `jwtauth_key_signing_operations_total`, `jwtauth_key_validation_operations_total`, `jwtauth_key_current_version`, `jwtauth_storage_list_tokens_total`, `jwtauth_storage_list_tokens_duration_seconds`, `jwtauth_storage_list_tokens_for_user_total`, `jwtauth_storage_list_tokens_for_user_duration_seconds`, `jwtauth_storage_list_tokens_for_audience_total`, `jwtauth_storage_list_tokens_for_audience_duration_seconds`, `jwtauth_tokens_list_for_user_total`, `jwtauth_tokens_list_for_user_duration_seconds`, `jwtauth_tokens_list_for_audience_total`, `jwtauth_tokens_list_for_audience_duration_seconds`.
+
+  **Renamed:** `jwtauth_operations_total{operation="cleanup"}` → `jwtauth_tokens_cleanup_total`. The `operation` label is dropped — the metric name now encodes the operation.
+
+  **Label added:** `jwtauth_tokens_list_total` and `jwtauth_tokens_list_duration_seconds` gain a `scope` label (`"all"`, `"user"`, `"audience"`). Existing queries targeting the all-tokens case must add `{scope="all"}` or use `sum(...)` to aggregate across scopes.
+
 ### Fixed
 
 - **`RefreshAccessToken` and `RefreshAccessTokenWithClaims` revoke old refresh token on rotation** — the old refresh token was not revoked after a successful refresh, leaving it valid until its natural TTL expiry and creating a replay window where the same refresh token could be used more than once. The old token is now revoked after the new access token is issued. See #195.

--- a/doc/UPGRADING.md
+++ b/doc/UPGRADING.md
@@ -57,6 +57,35 @@ labels are unchanged.
 **Action required:** Update alert rules and dashboards. The `operation="cleanup"` label
 carried no additional cardinality — no information is lost.
 
+### Changed metrics
+
+#### Phase 4 — list metrics unified under `scope` label
+
+`jwtauth_tokens_list_for_user_total`, `jwtauth_tokens_list_for_user_duration_seconds`,
+`jwtauth_tokens_list_for_audience_total`, and `jwtauth_tokens_list_for_audience_duration_seconds`
+are removed. `jwtauth_tokens_list_total` and `jwtauth_tokens_list_duration_seconds` gain a
+`scope` label: `"all"`, `"user"`, or `"audience"`.
+
+**Before:**
+```
+jwtauth_tokens_list_total                            # scope="all" only
+jwtauth_tokens_list_for_user_total
+jwtauth_tokens_list_for_audience_total
+```
+
+**After:**
+```
+jwtauth_tokens_list_total{scope="all"}
+jwtauth_tokens_list_total{scope="user"}
+jwtauth_tokens_list_total{scope="audience"}
+```
+
+To aggregate across all scopes: `sum(jwtauth_tokens_list_total)`
+
+**Action required:** Add `{scope="all"}` to existing `jwtauth_tokens_list_total` queries
+to preserve prior semantics, or use `sum(...)` to aggregate all scopes. Remove dashboards
+referencing the four removed per-scope metrics.
+
 ---
 
 ## v0.5.x → v0.6.0

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -106,29 +106,11 @@ func (pm *PrometheusMetrics) registerAllMetrics(namespace string) {
 
 	pm.registerCounter(namespace, "tokens_list_total",
 		"Total number of list-tokens operations on the token manager",
-		[]string{"namespace", "error_type"})
+		[]string{"scope", "namespace", "error_type"})
 
 	pm.registerHistogram(namespace, "tokens_list_duration_seconds",
 		"Duration of list-tokens operations on the token manager in seconds",
-		[]string{"namespace"},
-		[]float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10})
-
-	pm.registerCounter(namespace, "tokens_list_for_user_total",
-		"Total number of list-tokens-for-user operations on the token manager",
-		[]string{"namespace", "error_type"})
-
-	pm.registerHistogram(namespace, "tokens_list_for_user_duration_seconds",
-		"Duration of list-tokens-for-user operations on the token manager in seconds",
-		[]string{"namespace"},
-		[]float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10})
-
-	pm.registerCounter(namespace, "tokens_list_for_audience_total",
-		"Total number of list-tokens-for-audience operations on the token manager",
-		[]string{"namespace", "error_type"})
-
-	pm.registerHistogram(namespace, "tokens_list_for_audience_duration_seconds",
-		"Duration of list-tokens-for-audience operations on the token manager in seconds",
-		[]string{"namespace"},
+		[]string{"scope", "namespace"},
 		[]float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10})
 
 	// ===== RefreshStore Metrics =====

--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -2444,10 +2444,12 @@ func (m *Manager) ListTokens(ctx context.Context, cursor string, count int) ([]*
 	errorType := "error"
 	defer func() {
 		m.metrics.IncrementCounter(metricTokensListTotal, map[string]string{
+			"scope":      "all",
 			"namespace":  m.namespace,
 			"error_type": errorType,
 		})
 		m.metrics.RecordDuration(metricTokensListDuration, time.Since(start), map[string]string{
+			"scope":     "all",
 			"namespace": m.namespace,
 		})
 	}()
@@ -2505,11 +2507,13 @@ func (m *Manager) ListTokensForUser(ctx context.Context, userID string, cursor s
 	start := time.Now()
 	errorType := "error"
 	defer func() {
-		m.metrics.IncrementCounter(metricTokensListForUserTotal, map[string]string{
+		m.metrics.IncrementCounter(metricTokensListTotal, map[string]string{
+			"scope":      "user",
 			"namespace":  m.namespace,
 			"error_type": errorType,
 		})
-		m.metrics.RecordDuration(metricTokensListForUserDuration, time.Since(start), map[string]string{
+		m.metrics.RecordDuration(metricTokensListDuration, time.Since(start), map[string]string{
+			"scope":     "user",
 			"namespace": m.namespace,
 		})
 	}()
@@ -2569,11 +2573,13 @@ func (m *Manager) ListTokensForAudience(ctx context.Context, audience string, cu
 	start := time.Now()
 	errorType := "error"
 	defer func() {
-		m.metrics.IncrementCounter(metricTokensListForAudienceTotal, map[string]string{
+		m.metrics.IncrementCounter(metricTokensListTotal, map[string]string{
+			"scope":      "audience",
 			"namespace":  m.namespace,
 			"error_type": errorType,
 		})
-		m.metrics.RecordDuration(metricTokensListForAudienceDuration, time.Since(start), map[string]string{
+		m.metrics.RecordDuration(metricTokensListDuration, time.Since(start), map[string]string{
+			"scope":     "audience",
 			"namespace": m.namespace,
 		})
 	}()

--- a/pkg/tokens/observability.go
+++ b/pkg/tokens/observability.go
@@ -17,10 +17,4 @@ const (
 
 	metricTokensListTotal    = "jwtauth_tokens_list_total"
 	metricTokensListDuration = "jwtauth_tokens_list_duration_seconds"
-
-	metricTokensListForUserTotal    = "jwtauth_tokens_list_for_user_total"
-	metricTokensListForUserDuration = "jwtauth_tokens_list_for_user_duration_seconds"
-
-	metricTokensListForAudienceTotal    = "jwtauth_tokens_list_for_audience_total"
-	metricTokensListForAudienceDuration = "jwtauth_tokens_list_for_audience_duration_seconds"
 )


### PR DESCRIPTION
## Summary

Phase 4 of [#206](https://github.com/aetomala/jwtauth/issues/206) — collapse four per-scope list metrics into the existing `tokens_list_total` and `tokens_list_duration_seconds` via a new `scope` label.

**Metric count: 22 → 18** (final target)

### What changed

- `jwtauth_tokens_list_total` and `jwtauth_tokens_list_duration_seconds` gain a `scope` label with values `"all"`, `"user"`, and `"audience"`
- Four metrics removed: `jwtauth_tokens_list_for_user_total`, `jwtauth_tokens_list_for_user_duration_seconds`, `jwtauth_tokens_list_for_audience_total`, `jwtauth_tokens_list_for_audience_duration_seconds`
- `ListTokens`, `ListTokensForUser`, and `ListTokensForAudience` call sites updated in `manager.go`
- `UPGRADING.md` documents the migration path

### Migration

| Before | After |
|---|---|
| `jwtauth_tokens_list_total` | `jwtauth_tokens_list_total{scope="all"}` |
| `jwtauth_tokens_list_for_user_total` | `jwtauth_tokens_list_total{scope="user"}` |
| `jwtauth_tokens_list_for_audience_total` | `jwtauth_tokens_list_total{scope="audience"}` |

To aggregate across all scopes: `sum(jwtauth_tokens_list_total)`

### Verification

- 891 unit + 60 integration specs passing under `-race`
- `golangci-lint`: 0 issues
- `grep -c 'pm\.register' pkg/metrics/prometheus.go` → 19 (18 metrics + `registerAllMetrics`)
- `grep -rn 'tokens_list_for_user\|tokens_list_for_audience' ./pkg/` → 0 hits