### PR TITLE
docs(changelog): add missing v0.6.0 release entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ All notable changes to this project will be documented in this file.
 
   **Label added:** `jwtauth_tokens_list_total` and `jwtauth_tokens_list_duration_seconds` gain a `scope` label (`"all"`, `"user"`, `"audience"`). Existing queries targeting the all-tokens case must add `{scope="all"}` or use `sum(...)` to aggregate across scopes.
 
+---
+
+## [v0.6.0] — 2026-05-13
+
 ### Fixed
 
 - **`RefreshAccessToken` and `RefreshAccessTokenWithClaims` revoke old refresh token on rotation** — the old refresh token was not revoked after a successful refresh, leaving it valid until its natural TTL expiry and creating a replay window where the same refresh token could be used more than once. The old token is now revoked after the new access token is issued. See #195.


### PR DESCRIPTION
## Summary

- The `[Unreleased]` section was never converted to `[v0.6.0]` when the release was cut on 2026-05-13
- Inserts the `## [v0.6.0] — 2026-05-13` heading and separator, promoting the Fixed, Chore, and Documentation entries from that release under the correct versioned heading
- The v0.7.0 metrics reduction Breaking changes remain in `[Unreleased]`

## Test plan

- [ ] Verify `[v0.6.0] — 2026-05-13` section appears between `[Unreleased]` and `[v0.5.0]` in the rendered CHANGELOG
- [ ] Verify `[Unreleased]` contains only the metrics reduction Breaking entry