### PR TITLE
feat(keys): add GetAllKeyInfo to KeyManager interface and Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking
 
+- **`keys.KeyManager` gains `GetAllKeyInfo(ctx context.Context) ([]KeyInfo, error)`** — all custom `KeyManager` implementations must add this method or they will not compile. The built-in `keys.Manager` and `MockKeyManager` are already updated. Add a compile-time assertion to catch the gap early: `var _ keys.KeyManager = (*MyKeyManager)(nil)`. See #183.
+
 - **`PrometheusMetrics` metric set reduced from 34 to 18** — sixteen metrics are removed or collapsed. The `Metrics` interface is unchanged — all five methods (`IncrementCounter`, `AddCounter`, `SetGauge`, `RecordHistogram`, `RecordDuration`) are unaffected. Update Prometheus dashboards and alert rules that reference removed or renamed metrics. See #206 and `UPGRADING.md` for the full migration table.
 
   **Removed metrics (14):** `jwtauth_service_running`, `jwtauth_tokens_introspected_total`, `jwtauth_active_tokens`, `jwtauth_key_signing_operations_total`, `jwtauth_key_validation_operations_total`, `jwtauth_key_current_version`, `jwtauth_storage_list_tokens_total`, `jwtauth_storage_list_tokens_duration_seconds`, `jwtauth_storage_list_tokens_for_user_total`, `jwtauth_storage_list_tokens_for_user_duration_seconds`, `jwtauth_storage_list_tokens_for_audience_total`, `jwtauth_storage_list_tokens_for_audience_duration_seconds`, `jwtauth_tokens_list_for_user_total`, `jwtauth_tokens_list_for_user_duration_seconds`, `jwtauth_tokens_list_for_audience_total`, `jwtauth_tokens_list_for_audience_duration_seconds`.
@@ -21,6 +23,10 @@ All notable changes to this project will be documented in this file.
   **Renamed:** `jwtauth_operations_total{operation="cleanup"}` → `jwtauth_tokens_cleanup_total`. The `operation` label is dropped — the metric name now encodes the operation.
 
   **Label added:** `jwtauth_tokens_list_total` and `jwtauth_tokens_list_duration_seconds` gain a `scope` label (`"all"`, `"user"`, `"audience"`). Existing queries targeting the all-tokens case must add `{scope="all"}` or use `sum(...)` to aggregate across scopes.
+
+### Added
+
+- **`keys.Manager.GetAllKeyInfo(ctx context.Context) ([]KeyInfo, error)`** — returns one `KeyInfo` per key currently in the manager's in-memory cache — the active signing key plus any keys still in their overlap window. Order is unspecified. Returns an empty slice (not an error) when no keys are loaded. Suitable for admin surfaces, JWKS-parity health checks, and rotation monitoring dashboards — no private key material is included. See #183.
 
 ---
 

--- a/doc/UPGRADING.md
+++ b/doc/UPGRADING.md
@@ -6,6 +6,27 @@ This document describes breaking changes and the mechanical steps required to up
 
 ## v0.6.x → v0.7.0
 
+### `keys.KeyManager` gains `GetAllKeyInfo`
+
+`GetAllKeyInfo(ctx context.Context) ([]KeyInfo, error)` is a new required method on the
+`KeyManager` interface. Custom implementations that do not add it will fail to compile.
+
+**Action required:** Add the method to any custom `KeyManager` implementation:
+
+```go
+func (k *MyKeyManager) GetAllKeyInfo(ctx context.Context) ([]keys.KeyInfo, error) {
+    // return metadata for all currently held keys
+}
+```
+
+Use a compile-time assertion to catch the gap immediately:
+
+```go
+var _ keys.KeyManager = (*MyKeyManager)(nil)
+```
+
+---
+
 v0.7.0 reduces the PrometheusMetrics registered metric set from 34 to 18 high-signal
 metrics. The `Metrics` interface is unchanged — all five methods (`IncrementCounter`,
 `AddCounter`, `SetGauge`, `RecordHistogram`, `RecordDuration`) are unaffected. Prometheus

--- a/internal/testutil/mock_keys.go
+++ b/internal/testutil/mock_keys.go
@@ -42,6 +42,21 @@ func (m *MockKeyManager) EXPECT() *MockKeyManagerMockRecorder {
 	return m.recorder
 }
 
+// GetAllKeyInfo mocks base method.
+func (m *MockKeyManager) GetAllKeyInfo(ctx context.Context) ([]keys.KeyInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllKeyInfo", ctx)
+	ret0, _ := ret[0].([]keys.KeyInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAllKeyInfo indicates an expected call of GetAllKeyInfo.
+func (mr *MockKeyManagerMockRecorder) GetAllKeyInfo(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllKeyInfo", reflect.TypeOf((*MockKeyManager)(nil).GetAllKeyInfo), ctx)
+}
+
 // GetCurrentKeyInfo mocks base method.
 func (m *MockKeyManager) GetCurrentKeyInfo(ctx context.Context) (*keys.KeyInfo, error) {
 	m.ctrl.T.Helper()

--- a/pkg/keys/interface.go
+++ b/pkg/keys/interface.go
@@ -42,6 +42,14 @@ type KeyManager interface {
 	// Returns the context error if the context is cancelled.
 	GetCurrentKeyInfo(ctx context.Context) (*KeyInfo, error)
 
+	// GetAllKeyInfo returns metadata for all keys currently held in the manager's
+	// in-memory cache — the active signing key plus any keys still in their overlap
+	// window. Order is unspecified. Returns an empty slice (not an error) when no
+	// keys are loaded. Returns ErrManagerNotRunning if the manager is not running.
+	// Returns the context error if the context is cancelled. No private key material
+	// is included in the result.
+	GetAllKeyInfo(ctx context.Context) ([]KeyInfo, error)
+
 	// GetJWKS returns the JSON Web Key Set.
 	// Contains all currently valid public keys for token verification.
 	//

--- a/pkg/keys/manager.go
+++ b/pkg/keys/manager.go
@@ -752,6 +752,69 @@ func (m *Manager) GetCurrentKeyInfo(ctx context.Context) (*KeyInfo, error) {
 	return m.GetKeyInfo(ctx, "")
 }
 
+// GetAllKeyInfo returns metadata for all keys currently held in the manager's
+// in-memory cache — the active signing key plus any keys still in their overlap
+// window. Order is unspecified. Returns an empty slice (not an error) when no keys
+// are loaded. Returns ErrManagerNotRunning if the manager is not running. Returns
+// the context error if the context is cancelled. No private key material is included.
+func (m *Manager) GetAllKeyInfo(ctx context.Context) ([]KeyInfo, error) {
+	start := time.Now()
+	ctx, span := m.startSpan(ctx, "GetAllKeyInfo")
+	defer span.End()
+
+	// ===== STEP 1: Check Context =====
+	if err := ctx.Err(); err != nil {
+		span.RecordError(err)
+		span.SetStatus(tracing.StatusError, err.Error())
+		m.config.Logger.Error("GetAllKeyInfo aborted: context error", ctx, "error", err)
+		return nil, err
+	}
+
+	// ===== STEP 2: Check Manager is Running =====
+	if !m.IsRunning() {
+		span.RecordError(ErrManagerNotRunning)
+		span.SetStatus(tracing.StatusError, ErrManagerNotRunning.Error())
+		m.config.Logger.Error("GetAllKeyInfo called on stopped manager", ctx, "error", ErrManagerNotRunning)
+		return nil, ErrManagerNotRunning
+	}
+
+	// ===== STEP 3: Acquire Read Lock =====
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	// ===== STEP 4: Build KeyInfo Slice =====
+	now := time.Now()
+	result := make([]KeyInfo, 0, len(m.keys))
+	for _, keyPair := range m.keys {
+		isCurrent := keyPair.ID == m.currentKeyID
+		isValid := keyPair.ExpiresAt.IsZero() || now.Before(keyPair.ExpiresAt)
+
+		var rotateAt time.Time
+		if isCurrent {
+			rotateAt = keyPair.CreatedAt.Add(m.config.KeyRotationInterval)
+		}
+
+		result = append(result, KeyInfo{
+			KeyID:       keyPair.ID,
+			CreatedAt:   keyPair.CreatedAt,
+			RotateAt:    rotateAt,
+			ExpiresAt:   keyPair.ExpiresAt,
+			KeySizeBits: keyPairKeySize(keyPair),
+			Algorithm:   "RS256",
+			IsCurrent:   isCurrent,
+			IsValid:     isValid,
+		})
+	}
+
+	span.SetAttribute("key.count", len(result))
+	span.SetStatus(tracing.StatusOK, "")
+	m.config.Logger.Info("retrieved all key info", ctx, "count", len(result), "namespace", m.namespace)
+	m.metrics.RecordDuration(metricKeyOpDuration, time.Since(start),
+		map[string]string{"operation": "get_all_key_info", "namespace": m.namespace})
+
+	return result, nil
+}
+
 // RotateKeys rotates the current signing key to a newly generated one, and marks
 // the old key to expire after KeyOverlapDuration. This allows old tokens to be
 // validated during the transition period. Returns ErrManagerNotRunning if the

--- a/pkg/keys/manager_test.go
+++ b/pkg/keys/manager_test.go
@@ -1308,4 +1308,124 @@ var _ = Describe("Manager", func() {
 			Expect(gotKeyID).To(Equal(keyID))
 		})
 	})
+
+	// ===== PHASE 13: GetAllKeyInfo =====
+	Describe("Phase 13: GetAllKeyInfo", func() {
+		var m *keys.Manager
+
+		startWithKeys := func(storedKeys []*keys.StoredKey) {
+			mockKS.EXPECT().LoadAll(gomock.Any()).Return(storedKeys, nil)
+			var err error
+			m, err = keys.NewManager(newTestConfig(mockKS))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(m.Start(ctx)).To(Succeed())
+		}
+
+		shutdownManager := func() {
+			if m != nil && m.IsRunning() {
+				shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				defer cancel()
+				m.Shutdown(shutdownCtx)
+			}
+		}
+
+		Context("when the manager is not running", func() {
+			BeforeEach(func() {
+				var err error
+				m, err = keys.NewManager(newTestConfig(mockKS))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should return ErrManagerNotRunning", func() {
+				result, err := m.GetAllKeyInfo(ctx)
+				Expect(err).To(MatchError(keys.ErrManagerNotRunning))
+				Expect(result).To(BeNil())
+			})
+		})
+
+		Context("when context is already cancelled", func() {
+			BeforeEach(func() {
+				startWithKeys([]*keys.StoredKey{
+					{
+						KeyID:      "key-ctx-cancel",
+						PrivateKey: newTestKey(),
+						Metadata:   keys.KeyMetadata{ID: "key-ctx-cancel", CreatedAt: time.Now().Add(-1 * time.Hour)},
+					},
+				})
+			})
+
+			AfterEach(shutdownManager)
+
+			It("should return context.Canceled", func() {
+				cancelCtx, cancel := context.WithCancel(ctx)
+				cancel()
+				result, err := m.GetAllKeyInfo(cancelCtx)
+				Expect(err).To(MatchError(context.Canceled))
+				Expect(result).To(BeNil())
+			})
+		})
+
+		Context("with a single key loaded", func() {
+			var keyID string
+
+			BeforeEach(func() {
+				keyID = "key-single"
+				startWithKeys([]*keys.StoredKey{
+					{
+						KeyID:      keyID,
+						PrivateKey: newTestKey(),
+						Metadata:   keys.KeyMetadata{ID: keyID, CreatedAt: time.Now().Add(-1 * time.Hour)},
+					},
+				})
+			})
+
+			AfterEach(shutdownManager)
+
+			It("should return a slice of length 1 with correct fields", func() {
+				result, err := m.GetAllKeyInfo(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(HaveLen(1))
+				Expect(result[0].KeyID).To(Equal(keyID))
+				Expect(result[0].IsCurrent).To(BeTrue())
+				Expect(result[0].IsValid).To(BeTrue())
+				Expect(result[0].Algorithm).To(Equal("RS256"))
+				Expect(result[0].KeySizeBits).To(Equal(2048))
+				Expect(result[0].RotateAt.IsZero()).To(BeFalse())
+			})
+		})
+
+		Context("with current and overlap key after rotation", func() {
+			BeforeEach(func() {
+				startWithKeys([]*keys.StoredKey{
+					{
+						KeyID:      "original-key",
+						PrivateKey: newTestKey(),
+						Metadata:   keys.KeyMetadata{ID: "original-key", CreatedAt: time.Now().Add(-24 * time.Hour)},
+					},
+				})
+				mockKS.EXPECT().Save(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				mockKS.EXPECT().UpdateMetadata(gomock.Any(), "original-key", gomock.Any()).Return(nil)
+				Expect(m.RotateKeys(ctx)).To(Succeed())
+			})
+
+			AfterEach(shutdownManager)
+
+			It("should return a slice of length 2 with correct IsCurrent flags", func() {
+				result, err := m.GetAllKeyInfo(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(HaveLen(2))
+
+				var currentCount int
+				for _, info := range result {
+					if info.IsCurrent {
+						currentCount++
+						Expect(info.RotateAt.IsZero()).To(BeFalse())
+					} else {
+						Expect(info.ExpiresAt.IsZero()).To(BeFalse())
+					}
+				}
+				Expect(currentCount).To(Equal(1))
+			})
+		})
+	})
 })


### PR DESCRIPTION
## Summary

- Adds `GetAllKeyInfo(ctx context.Context) ([]KeyInfo, error)` to the `KeyManager` interface and implements it on `keys.Manager`
- Returns one `KeyInfo` per key in the manager's in-memory cache — active signing key plus any keys in their overlap window
- Returns an empty slice (not an error) when no keys are loaded
- Suitable for admin surfaces, JWKS-parity health checks, and rotation monitoring dashboards — no private key material included
- Breaking change for custom `KeyManager` implementations — `UPGRADING.md` updated with migration steps

**Observability:** span with `key.count` attribute, Info/Error logging, duration recorded on `jwtauth_key_operation_duration_seconds{operation="get_all_key_info"}`.

Closes #183

## Test plan

- [ ] Phase 13 specs pass: manager not running → `ErrManagerNotRunning`; context cancelled → `context.Canceled`; single key → slice of 1 with correct fields; current + overlap key post-`RotateKeys` → slice of 2, exactly one `IsCurrent=true`
- [ ] `MockKeyManager` has `GetAllKeyInfo` method (regenerated via `go generate`)
- [ ] `var _ keys.KeyManager = (*Manager)(nil)` compile-time assertion passes
- [ ] `bash run-ci-locally.sh` — all checks pass (168 unit + 60 integration specs, `-race` clean)