### PR TITLE
feat(keys): add Namespace field to DiskKeyStoreConfig (#184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ All notable changes to this project will be documented in this file.
 
 - **`keys.Manager.GetAllKeyInfo(ctx context.Context) ([]KeyInfo, error)`** — returns one `KeyInfo` per key currently in the manager's in-memory cache — the active signing key plus any keys still in their overlap window. Order is unspecified. Returns an empty slice (not an error) when no keys are loaded. Suitable for admin surfaces, JWKS-parity health checks, and rotation monitoring dashboards — no private key material is included. See #183.
 
+- **`DiskKeyStoreConfig.Namespace string`** — optional observability namespace label. When set, the value is carried on log fields (via logger enrichment at construction), span attributes (`"storage.namespace"`), and all keystore metric labels. Consistent with the existing `RedisKeyStore` namespace pattern and ADR-007. See #184.
+
+### Fixed
+
+- **DiskKeyStore metrics silently dropped when using `PrometheusMetrics`** — the three keystore metrics (`jwtauth_keystore_operations_total`, `jwtauth_keystore_operation_duration_seconds`, `jwtauth_keystore_keys_count`) are registered with a required `namespace` label, but `DiskKeyStore` omitted that label from every call. This caused `GetMetricWith` to return an error and silently discard every observation — all DiskKeyStore metrics were effectively dead. Adding `Namespace string` to `DiskKeyStoreConfig` resolves this. See #184.
+
 ---
 
 ## [v0.6.0] — 2026-05-13

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -257,9 +257,9 @@ type Metrics interface {
 | `jwtauth_storage_list_tokens_for_user_duration_seconds` | Histogram | storage_backend, namespace |
 | `jwtauth_storage_list_tokens_for_audience_total` | Counter | storage_backend, namespace, error_type |
 | `jwtauth_storage_list_tokens_for_audience_duration_seconds` | Histogram | storage_backend, namespace |
-| `jwtauth_keystore_operations_total` | Counter | operation, status, error_type, storage_backend |
-| `jwtauth_keystore_operation_duration_seconds` | Histogram | operation, storage_backend |
-| `jwtauth_keystore_keys_count` | Gauge | storage_backend |
+| `jwtauth_keystore_operations_total` | Counter | operation, status, error_type, storage_backend, namespace |
+| `jwtauth_keystore_operation_duration_seconds` | Histogram | operation, storage_backend, namespace |
+| `jwtauth_keystore_keys_count` | Gauge | storage_backend, namespace |
 | `jwtauth_key_rotations_total` | Counter | status, error_type |
 | `jwtauth_key_signing_operations_total` | Counter | status, error_type |
 | `jwtauth_key_validation_operations_total` | Counter | status, error_type |
@@ -516,9 +516,9 @@ Keys are optionally prefixed by `RedisKeyStoreConfig.KeyPrefix` (defaults to emp
 
 | Metric | Type | Labels |
 |--------|------|--------|
-| `jwtauth_keystore_operations_total` | Counter | `operation`, `status`, `storage_backend` |
-| `jwtauth_keystore_operation_duration_seconds` | Histogram | `operation`, `storage_backend` |
-| `jwtauth_keystore_keys_count` | Gauge | `storage_backend` |
+| `jwtauth_keystore_operations_total` | Counter | `operation`, `status`, `error_type`, `storage_backend`, `namespace` |
+| `jwtauth_keystore_operation_duration_seconds` | Histogram | `operation`, `storage_backend`, `namespace` |
+| `jwtauth_keystore_keys_count` | Gauge | `storage_backend`, `namespace` |
 
 `operation` values: `"load_all"`, `"save"`, `"update_metadata"`, `"load_key"`, `"delete"`
 
@@ -1125,4 +1125,4 @@ Key design decisions are captured in `doc/adr/`. Each ADR documents the context,
 
 **Last Updated**: May 13, 2026
 **Version**: v0.6.0
-**Status**: Stable — all components fully instrumented (KeyManager, DiskKeyStore, RedisKeyStore, MemoryRefreshStore, RedisRefreshStore, Metrics [Prometheus, 34 metrics], Logging [Correlation ID], Distributed Tracing, TokenManager)
+**Status**: Stable — all components fully instrumented (KeyManager, DiskKeyStore, RedisKeyStore, MemoryRefreshStore, RedisRefreshStore, Metrics [Prometheus, 18 metrics], Logging [Correlation ID], Distributed Tracing, TokenManager)

--- a/doc/adr/007-namespace-consistency-contract.md
+++ b/doc/adr/007-namespace-consistency-contract.md
@@ -56,3 +56,18 @@ The `Namespace` field is now fully wired across all observability output in both
 
 The deferred "subsequent phase" referenced in the original Decision is complete. No interface
 changes were required — the field was already present on both config types.
+
+## Addendum — DiskKeyStore namespace wired (issue #184, 2026-05-19)
+
+`DiskKeyStore` now accepts an optional `Namespace string` field on `DiskKeyStoreConfig`.
+When non-empty:
+
+- **Log lines** — the logger is enriched with `With("namespace", namespace)` at construction;
+  all log lines carry the namespace automatically without per-call overhead.
+- **Trace spans** — the `startSpan` helper pre-seeds every span with `"storage.namespace"`.
+- **Metric labels** — all five KeyStore operation metrics (`LoadAll`, `Save`, `UpdateMetadata`,
+  `LoadKey`, `Delete`) include `"namespace"` in their label maps.
+
+An empty string preserves prior behavior exactly. With this change, all six components tracked
+in ADR-007 are fully wired: KeyManager, TokenManager, DiskKeyStore, RedisKeyStore,
+RedisRefreshStore, and MemoryRefreshStore (single-tenant; namespace="" by design).

--- a/pkg/keys/disk.go
+++ b/pkg/keys/disk.go
@@ -24,11 +24,12 @@ import (
 
 // DiskKeyStoreConfig holds configuration for a DiskKeyStore instance.
 type DiskKeyStoreConfig struct {
-	Dir     string          // Absolute or relative path to the key storage directory.
-	KeySize int             // Minimum accepted RSA key bit-size for load-time validation. Defaults to 2048.
-	Logger  logging.Logger  // Optional; nil defaults to NoOpLogger.
-	Metrics metrics.Metrics // Optional; nil defaults to NoOpMetrics.
-	Tracer  tracing.Tracer  // Optional; nil defaults to NoOpTracer.
+	Dir       string          // Absolute or relative path to the key storage directory.
+	KeySize   int             // Minimum accepted RSA key bit-size for load-time validation. Defaults to 2048.
+	Logger    logging.Logger  // Optional; nil defaults to NoOpLogger.
+	Metrics   metrics.Metrics // Optional; nil defaults to NoOpMetrics.
+	Tracer    tracing.Tracer  // Optional; nil defaults to NoOpTracer.
+	Namespace string          // Optional; scopes log fields, span attributes, and metric labels. Empty string preserves prior behavior.
 }
 
 // DiskKeyStoreConfigDefault returns a DiskKeyStoreConfig with sensible defaults.
@@ -53,10 +54,11 @@ type DiskKeyStore struct {
 	keySize int    // minimum accepted RSA key bit-size for load-time validation
 
 	// ===== Observability =====
-	logger  logging.Logger  // never nil; defaults to NoOpLogger
-	metrics metrics.Metrics // never nil; defaults to NoOpMetrics
-	tracer  tracing.Tracer  // never nil; defaults to NoOpTracer
-	backend string          // always "disk"
+	logger    logging.Logger  // never nil; defaults to NoOpLogger
+	metrics   metrics.Metrics // never nil; defaults to NoOpMetrics
+	tracer    tracing.Tracer  // never nil; defaults to NoOpTracer
+	backend   string          // always "disk"
+	namespace string          // = cfg.Namespace; emitted in log fields, span attributes, and metric labels
 }
 
 // NewDiskKeyStore returns a new DiskKeyStore using cfg. Zero-value and nil
@@ -83,6 +85,9 @@ func NewDiskKeyStore(cfg DiskKeyStoreConfig) (*DiskKeyStore, error) {
 	if cfg.Tracer == nil {
 		cfg.Tracer = defaults.Tracer
 	}
+	if cfg.Namespace != "" {
+		cfg.Logger = cfg.Logger.With("namespace", cfg.Namespace)
+	}
 
 	// ===== STEP 3: Create Directory =====
 	if err := os.MkdirAll(cfg.Dir, 0755); err != nil {
@@ -91,24 +96,26 @@ func NewDiskKeyStore(cfg DiskKeyStoreConfig) (*DiskKeyStore, error) {
 
 	// ===== STEP 4: Return Initialized Store =====
 	return &DiskKeyStore{
-		dir:     cfg.Dir,
-		keySize: cfg.KeySize,
-		backend: "disk",
-		logger:  cfg.Logger,
-		metrics: cfg.Metrics,
-		tracer:  cfg.Tracer,
+		dir:       cfg.Dir,
+		keySize:   cfg.KeySize,
+		backend:   "disk",
+		logger:    cfg.Logger,
+		metrics:   cfg.Metrics,
+		tracer:    cfg.Tracer,
+		namespace: cfg.Namespace,
 	}, nil
 }
 
-// Namespace returns empty string — DiskKeyStore uses directory-level isolation
-// and does not support the namespace concept.
-func (d *DiskKeyStore) Namespace() string { return "" }
+// Namespace returns the observability namespace configured for this store.
+// Returns an empty string when none was configured.
+func (d *DiskKeyStore) Namespace() string { return d.namespace }
 
-// startSpan begins a new tracing span with storage.backend pre-set to "disk".
+// startSpan begins a new tracing span with storage.backend and storage.namespace pre-set.
 func (d *DiskKeyStore) startSpan(ctx context.Context, operation string) (context.Context, tracing.Span) {
 	return d.tracer.Start(ctx, "DiskKeyStore."+operation,
 		tracing.WithAttributes(map[string]any{
-			"storage.backend": d.backend,
+			"storage.backend":   d.backend,
+			"storage.namespace": d.namespace,
 		}),
 	)
 }
@@ -131,14 +138,17 @@ func (d *DiskKeyStore) LoadAll(ctx context.Context) ([]*StoredKey, error) {
 			"status":          status,
 			"error_type":      errorType,
 			"storage_backend": d.backend,
+			"namespace":       d.namespace,
 		})
 		d.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
 			"operation":       "load_all",
 			"storage_backend": d.backend,
+			"namespace":       d.namespace,
 		})
 		if status == "success" {
 			d.metrics.SetGauge(metricKeyStoreKeysCount, float64(keyCount), map[string]string{
 				"storage_backend": d.backend,
+				"namespace":       d.namespace,
 			})
 		}
 	}()
@@ -224,10 +234,12 @@ func (d *DiskKeyStore) Save(ctx context.Context, keyID string, privateKey *rsa.P
 			"status":          status,
 			"error_type":      errorType,
 			"storage_backend": d.backend,
+			"namespace":       d.namespace,
 		})
 		d.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
 			"operation":       "save",
 			"storage_backend": d.backend,
+			"namespace":       d.namespace,
 		})
 	}()
 
@@ -316,10 +328,12 @@ func (d *DiskKeyStore) UpdateMetadata(ctx context.Context, keyID string, meta Ke
 			"status":          status,
 			"error_type":      errorType,
 			"storage_backend": d.backend,
+			"namespace":       d.namespace,
 		})
 		d.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
 			"operation":       "update_metadata",
 			"storage_backend": d.backend,
+			"namespace":       d.namespace,
 		})
 	}()
 
@@ -385,10 +399,12 @@ func (d *DiskKeyStore) LoadKey(ctx context.Context, keyID string) (*rsa.PrivateK
 			"status":          status,
 			"error_type":      errorType,
 			"storage_backend": d.backend,
+			"namespace":       d.namespace,
 		})
 		d.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
 			"operation":       "load_key",
 			"storage_backend": d.backend,
+			"namespace":       d.namespace,
 		})
 	}()
 
@@ -464,10 +480,12 @@ func (d *DiskKeyStore) Delete(ctx context.Context, keyID string) error {
 			"status":          status,
 			"error_type":      errorType,
 			"storage_backend": d.backend,
+			"namespace":       d.namespace,
 		})
 		d.metrics.RecordDuration(metricKeyStoreOpDuration, time.Since(start), map[string]string{
 			"operation":       "delete",
 			"storage_backend": d.backend,
+			"namespace":       d.namespace,
 		})
 	}()
 

--- a/pkg/keys/disk_test.go
+++ b/pkg/keys/disk_test.go
@@ -605,10 +605,12 @@ var _ = Describe("DiskKeyStore", func() {
 				"status":          status,
 				"error_type":      errorType,
 				"storage_backend": "disk",
+				"namespace":       "",
 			})
 			mockM.EXPECT().RecordDuration("jwtauth_keystore_operation_duration_seconds", gomock.Any(), map[string]string{
 				"operation":       operation,
 				"storage_backend": "disk",
+				"namespace":       "",
 			})
 		}
 
@@ -628,6 +630,7 @@ var _ = Describe("DiskKeyStore", func() {
 				expectOpsMetrics("load_all", "success")
 				mockM.EXPECT().SetGauge("jwtauth_keystore_keys_count", gomock.Any(), map[string]string{
 					"storage_backend": "disk",
+					"namespace":       "",
 				})
 				ds := newMetricStore()
 				_, err := ds.LoadAll(ctx)


### PR DESCRIPTION
## Summary

- **Root cause fixed:** `DiskKeyStore` omitted the required `namespace` label from all 11 `PrometheusMetrics` calls. `GetMetricWith` returned a label-mismatch error on every call, silently discarding every keystore metric observation. All DiskKeyStore metrics were effectively dead when using `PrometheusMetrics`.
- **Fix:** Added `Namespace string` to `DiskKeyStoreConfig` and wired it through logger enrichment (at construction), `startSpan` span attributes, and all 11 metrics label maps across the five KeyStore methods.
- **ADR-007 complete:** With this change, all six components are fully wired — KeyManager, TokenManager, DiskKeyStore, RedisKeyStore, RedisRefreshStore, and MemoryRefreshStore.

## Files changed

| File | Change |
|------|--------|
| `pkg/keys/disk.go` | `Namespace string` on config + struct; logger enrichment; `startSpan` attribute; 11 label maps |
| `pkg/keys/disk_test.go` | Phase 9 metrics assertions updated to include `"namespace": ""` |
| `doc/ARCHITECTURE.md` | Keystore metrics label columns corrected (two locations); 34 → 18 metric count |
| `doc/adr/007-namespace-consistency-contract.md` | DiskKeyStore addendum appended |
| `CHANGELOG.md` | `### Fixed` (silent drop) + `### Added` (`DiskKeyStoreConfig.Namespace`) under `[Unreleased]` |

## Test plan

- [x] 168/168 unit specs in `pkg/keys` pass under `-race`
- [x] 60/60 integration specs pass under `-race`
- [x] `go vet`, `golangci-lint`, `govulncheck` all pass
- [x] Confirm `DiskKeyStore` constructed with a non-empty `Namespace` emits that value on metric labels, log fields, and span attributes
- [x] Confirm empty `Namespace` (default) emits `""` — preserving prior behavior

Closes #184