### PR TITLE
docs(examples): add POST /introspect to gin-example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ All notable changes to this project will be documented in this file.
   (Correlation, Health Check, Prometheus Metrics, Redis Production), and Token Operations
   (Token Audit, Audience Revocation). See #188.
 
+- **`examples/gin-example`** — added `POST /introspect` handler demonstrating `IntrospectToken`:
+  RFC 7662-style token metadata, `Active` / `TokenID` / `Audience` fields, and the pattern
+  for using `TokenID` to feed into `RevokeRefreshToken` for admin revocation flows. See #190.
+
 - **`examples/custom-store`** — new runnable example with a full in-memory `RefreshStore`
   implementation: compile-time assertion, all 11 interface methods, non-obvious invariants
   documented (defensive copy, cursor semantics, Cleanup return value), wired into

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,6 +21,7 @@ A simple and fast HTTP framework. Best for:
 - Framework-agnostic token validation
 - Simple middleware using `gin.HandlerFunc`
 - Built-in request binding and validation
+- `POST /introspect` — RFC 7662-style introspection showing `Active`, `TokenID`, `Audience`
 
 **Run**:
 ```bash

--- a/examples/gin-example/main.go
+++ b/examples/gin-example/main.go
@@ -91,6 +91,7 @@ func main() {
 	// Public endpoints
 	r.POST("/login", issueTokensHandler(mgr))
 	r.POST("/refresh", refreshHandler(mgr))
+	r.POST("/introspect", introspectHandler(mgr))
 
 	// Protected endpoints
 	protected := r.Group("/api")
@@ -179,6 +180,36 @@ func refreshHandler(mgr *tokens.Manager) gin.HandlerFunc {
 			AccessToken: accessToken,
 			ExpiresIn:   900, // 15 minutes
 		})
+	}
+}
+
+// IntrospectRequest is the request body for token introspection.
+type IntrospectRequest struct {
+	Token string `json:"token" binding:"required"`
+}
+
+// introspectHandler returns RFC 7662-style token metadata for a refresh token.
+// Active is false for revoked or expired tokens — the spec treats inactive tokens
+// as a valid response, not a failure. TokenID bridges the raw token to
+// RevokeRefreshToken for admin revocation flows.
+func introspectHandler(mgr *tokens.Manager) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req IntrospectRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+		defer cancel()
+
+		meta, err := mgr.IntrospectToken(ctx, req.Token)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "introspection failed"})
+			return
+		}
+
+		c.JSON(http.StatusOK, meta)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `introspectHandler` to `examples/gin-example/main.go` — a public `POST /introspect` endpoint demonstrating `IntrospectToken`
- Returns RFC 7662-style `TokenMetadata`: `Active`, `TokenID`, `Audience` fields
- Handler comment explains the admin-revocation bridge pattern: `TokenID` → `RevokeRefreshToken`
- Updates `examples/README.md` gin-example Features list
- Adds `CHANGELOG.md` entry under `### Documentation`

Closes #190.

## Test plan

- [x] `go build -o /dev/null .` in `examples/gin-example` — passes
- [x] `bash run-ci-locally.sh` — all checks green (899 unit + 60 integration specs)