### PR TITLE
docs(examples): add GET /.well-known/jwks.json to gin-example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ All notable changes to this project will be documented in this file.
   (Correlation, Health Check, Prometheus Metrics, Redis Production), and Token Operations
   (Token Audit, Audience Revocation). See #188.
 
+- **`examples/gin-example`** — added `GET /.well-known/jwks.json` handler demonstrating
+  `GetJWKS`: JSON Web Key Set serialisation, `Cache-Control: public, max-age=300` header,
+  and the "rotate on unknown kid" consumption pattern in a comment. See #191.
+
 - **`examples/gin-example`** — added `POST /introspect` handler demonstrating `IntrospectToken`:
   RFC 7662-style token metadata, `Active` / `TokenID` / `Audience` fields, and the pattern
   for using `TokenID` to feed into `RevokeRefreshToken` for admin revocation flows. See #190.

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,6 +22,7 @@ A simple and fast HTTP framework. Best for:
 - Simple middleware using `gin.HandlerFunc`
 - Built-in request binding and validation
 - `POST /introspect` — RFC 7662-style introspection showing `Active`, `TokenID`, `Audience`
+- `GET /.well-known/jwks.json` — JWKS endpoint with `Cache-Control` headers for external token validators
 
 **Run**:
 ```bash

--- a/examples/gin-example/main.go
+++ b/examples/gin-example/main.go
@@ -92,6 +92,7 @@ func main() {
 	r.POST("/login", issueTokensHandler(mgr))
 	r.POST("/refresh", refreshHandler(mgr))
 	r.POST("/introspect", introspectHandler(mgr))
+	r.GET("/.well-known/jwks.json", jwksHandler(km))
 
 	// Protected endpoints
 	protected := r.Group("/api")
@@ -210,6 +211,27 @@ func introspectHandler(mgr *tokens.Manager) gin.HandlerFunc {
 		}
 
 		c.JSON(http.StatusOK, meta)
+	}
+}
+
+// jwksHandler serves the JSON Web Key Set at the standard well-known endpoint.
+// Keys change only on rotation (default every 30 days). Cache-Control max-age=300
+// lets consumers cache aggressively without holding stale keys after rotation.
+// Consumers should also implement the "rotate on unknown kid" pattern — retry the
+// JWKS fetch on a 401 with an unrecognized kid before rejecting the token.
+func jwksHandler(km *keys.Manager) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+		defer cancel()
+
+		jwks, err := km.GetJWKS(ctx)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to retrieve JWKS"})
+			return
+		}
+
+		c.Header("Cache-Control", "public, max-age=300")
+		c.JSON(http.StatusOK, jwks)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `jwksHandler` to `examples/gin-example/main.go` — a public `GET /.well-known/jwks.json` endpoint demonstrating `GetJWKS`
- Sets `Cache-Control: public, max-age=300` — keys change only on rotation (default 30 days); 5-minute TTL balances caching and post-rotation freshness
- Handler comment explains the "rotate on unknown kid" consumption pattern for external validators
- Updates `examples/README.md` gin-example Features list
- Adds `CHANGELOG.md` entry under `### Documentation`

Closes #191.

## Test plan

- [x] `go build -o /dev/null .` in `examples/gin-example` — passes
- [x] `bash run-ci-locally.sh` — all checks green (899 unit + 60 integration specs)