### PR TITLE
fix(examples): add missing golang-jwt indirect dep to prometheus-metrics go.mod

### DIFF
--- a/examples/prometheus-metrics/go.mod
+++ b/examples/prometheus-metrics/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect


### PR DESCRIPTION
## Summary

- `go mod tidy` updated both `go.mod` and `go.sum` when `tokens.Manager` was added in PR #235
- `go.sum` was staged and committed; `go.mod` was not — this PR adds the missing `github.com/golang-jwt/jwt/v5 v5.3.1 // indirect` line

## Test plan

- [ ] `cd examples/prometheus-metrics && go build -o /dev/null .` — clean build