### PR TITLE
chore(tokens): normalize expiry idiom to !ExpiresAt.After(now)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,13 @@ All notable changes to this project will be documented in this file.
   `TokenManager` for an issuance + revocation + introspection + cleanup smoke test.
   Reference guide for PostgreSQL and other third-party backends. See #189.
 
+### Chore
+
+- **`tokens.Manager` expiry checks normalized to `!ExpiresAt.After(now)`** — three secondary
+  expiry checks in `RefreshAccessToken`, `RefreshAccessTokenWithClaims`, and `IntrospectToken`
+  now use the canonical boundary idiom established in #176. No behavior change under normal
+  operation; closes the at-boundary inconsistency. Closes #217.
+
 ### Fixed
 
 - **DiskKeyStore metrics silently dropped when using `PrometheusMetrics`** — the three keystore metrics (`jwtauth_keystore_operations_total`, `jwtauth_keystore_operation_duration_seconds`, `jwtauth_keystore_keys_count`) are registered with a required `namespace` label, but `DiskKeyStore` omitted that label from every call. This caused `GetMetricWith` to return an error and silently discard every observation — all DiskKeyStore metrics were effectively dead. Adding `Namespace string` to `DiskKeyStoreConfig` resolves this. See #184.

--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -1737,7 +1737,7 @@ func (m *Manager) RefreshAccessToken(ctx context.Context, refreshToken string) (
 		"tokenID", token.TokenID)
 
 	// ===== STEP 5: Check Expiration =====
-	if token.ExpiresAt.Before(time.Now()) {
+	if !token.ExpiresAt.After(time.Now()) {
 		status = "expired"
 		errorType = "expired"
 		m.logger.Warn("refresh token has expired", ctx,
@@ -1878,7 +1878,7 @@ func (m *Manager) RefreshAccessTokenWithClaims(ctx context.Context, refreshToken
 		"tokenID", token.TokenID)
 
 	// ===== STEP 5: Check Expiration =====
-	if token.ExpiresAt.Before(time.Now()) {
+	if !token.ExpiresAt.After(time.Now()) {
 		status = "expired"
 		errorType = "expired"
 		m.logger.Warn("refresh token has expired", ctx,
@@ -2314,7 +2314,7 @@ func (m *Manager) IntrospectToken(ctx context.Context, token string) (*TokenMeta
 	now := time.Now()
 
 	// Check if expired
-	if refreshToken.ExpiresAt.Before(now) {
+	if !refreshToken.ExpiresAt.After(now) {
 		m.logger.Info("introspect token is expired", ctx,
 			"token", token,
 			"expiredAt", refreshToken.ExpiresAt)


### PR DESCRIPTION
## Summary

- Replaces three `ExpiresAt.Before(now)` checks with `!ExpiresAt.After(now)` in `pkg/tokens/manager.go`
- Affected methods: `RefreshAccessToken` (STEP 5), `RefreshAccessTokenWithClaims` (STEP 5), `IntrospectToken` (STEP 5)
- Adds `### Chore` CHANGELOG entry under `[Unreleased]`

## Why

PR #211 (issue #176) standardized the expiry boundary idiom in `pkg/storage/` to `!expiresAt.After(now)`. The manager layer retained the old `Before(now)` form. These checks are currently dead (the storage layer's stricter `!After()` check fires first), but the inconsistency is a maintenance hazard — a future refactor could make them live and silently introduce an at-boundary bug.

## Test plan

- [ ] `bash run-ci-locally.sh` — all checks passed (774 unit + 60 integration specs)
- [ ] `grep -n "ExpiresAt.Before" pkg/tokens/manager.go` returns nothing

Closes #217