### PR TITLE
docs: rewrite metrics documentation for v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **You verify identity. jwtauth manages everything after:** zero-downtime key rotation, access token issuance, refresh token lifecycle, and instant revocation across horizontal scale.
 
-> **API Stability (pre-v1.0)**: All components are production-quality with comprehensive test coverage. The API surface is still evolving before v1.0.0. **v0.5.0 shipped:** `IssueOption` / `WithAudience` for per-call audience targeting (#124) — all six issuing methods accept `...tokens.IssueOption`; existing call sites compile unchanged. **v0.5.0 planned:** Audience-based token revocation `RevokeAllForAudience` (#135) — adds `Audience []string` to `RefreshToken` and two new methods to `RefreshStore`; custom implementations must be updated (see `UPGRADING.md`).
+> **API Stability (pre-v1.0)**: All components are production-quality with comprehensive test coverage. The API surface is still evolving before v1.0.0. **v0.5.0 shipped:** `IssueOption` / `WithAudience` for per-call audience targeting (#124) — all six issuing methods accept `...tokens.IssueOption`; existing call sites compile unchanged. **v0.7.0 shipped:** Metrics set reduced from 34 → 18, `Tracer` interface simplified (SpanOption/SpanKind removed), `GetAllKeyInfo` added to `KeyManager`. See `doc/UPGRADING.md` for migration details.
 
 ## Overview
 
@@ -54,7 +54,7 @@ If you've already decided you need stateful token management, here's how jwtauth
 | **Refresh tokens** | ❌ | ❌ | ❌ | ✅ Stateful storage |
 | **Instant revocation** | ❌ | ❌ | ❌ | ✅ RevokeAllUserTokens |
 | **Distributed state** | N/A | ❌ | N/A | ✅ Redis backend |
-| **Metrics** | ❌ | ❌ | ❌ | ✅ 22 Prometheus metrics |
+| **Metrics** | ❌ | ❌ | ❌ | ✅ 18 Prometheus metrics |
 | **Correlation logging** | ❌ | ❌ | ❌ | ✅ Built-in |
 | **Framework lock-in** | ❌ | ✅ Gin only | ❌ | ❌ |
 | **Complexity** | Low | Medium | High (JOSE) | Medium |
@@ -112,7 +112,7 @@ km, _ := keys.NewManager(keys.KeyManagerConfig{
 | Revocation (single token, all user sessions) | `RevokeRefreshToken`, `RevokeAllUserTokens` |
 | Custom claims round-trip without re-parsing | `IssueAccessTokenWithClaims` + `ValidateAccessTokenWithClaims` |
 | Clock skew tolerance for distributed deployments | `TokenManagerConfig.ClockSkew` |
-| 22 Prometheus metrics across all operations | Pre-registered, zero config |
+| 18 Prometheus metrics across all operations | Pre-registered, zero config |
 | 10 typed sentinel errors for middleware logic | `ErrTokenExpired`, `ErrTokenRevoked`, `ErrInvalidAudience`, … |
 
 **jwtauth is what you'd build on top of golang-jwt after a few months in production.**
@@ -283,7 +283,7 @@ You've already verified identity and need **production-grade token machinery** f
 - **Service state management** ensuring tokens only issue when service is running
 - **OpenTelemetry distributed tracing** — `Tracer` field wires spans into all token operations; defaults to `NoOpTracer` for zero-config use
 - **Namespace labeling** — `Namespace` field propagates an opaque label through all logs, spans, and metric labels for multi-tenant and multi-instance deployments
-- **Comprehensive BDD test coverage** (153 tests covering lifecycle, issuance, validation, clock skew, custom claims, refresh, revocation, and introspection; ~87% statement coverage)
+- **Comprehensive BDD test coverage** (258 tests covering lifecycle, issuance, validation, clock skew, custom claims, refresh, revocation, and introspection; ~87% statement coverage)
 
 **RefreshTokenStore** ✅
 - **Two implementations**: Memory (in-process) and Redis (distributed)
@@ -291,14 +291,14 @@ You've already verified identity and need **production-grade token machinery** f
   - Perfect for single-instance deployments and testing
   - Dual-index lookups (tokenID → token, userID → []tokenID) for O(1) retrieval
   - Defensive copying for isolation from caller mutations
-  - 77 comprehensive tests with 100% statement coverage
+  - 111 comprehensive tests with 100% statement coverage
 - **RedisRefreshStore**: Distributed storage for multi-instance deployments
   - Uses go-redis/v9 with pipeline support for atomic operations
   - Millisecond-precision timestamp storage
   - Efficient SCAN-based cleanup for expired tokens
   - Production-ready error handling and logging
-  - 77 comprehensive tests (identical test suite as Memory implementation)
-- **Shared test suite** pattern: Single suite (77 tests) runs against both implementations
+  - 111 comprehensive tests (identical test suite as Memory implementation)
+- **Shared test suite** pattern: Single suite (111 tests) runs against both implementations
 - **Common features** (both implementations):
   - Token lifecycle management (Store, Retrieve, Revoke, RevokeAllForUser, Cleanup)
   - **Cursor-based enumeration**: `ListTokens` iterates all tokens globally; `ListTokensForUser` iterates a single user's tokens — pass `""` as cursor to start from the beginning
@@ -306,7 +306,7 @@ You've already verified identity and need **production-grade token machinery** f
   - Idempotent revocation (safe to call multiple times)
   - Comprehensive context handling with cancellation propagation
   - Structured logging for audit trail
-  - **154 total storage tests** (77 × 2 implementations)
+  - **222 total storage tests** (111 × 2 implementations)
 
 ## Architecture Highlights
 
@@ -950,37 +950,34 @@ mgr, _ := tokens.NewManager(tokens.TokenManagerConfig{
 })
 ```
 
-**Metric reference** (22 metrics, namespace `jwtauth_` by default):
+**Metric reference** (18 metrics, namespace `jwtauth_` by default):
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `tokens_issued_total` | Counter | `status`, `error_type` | Tokens issued (access + refresh) |
-| `tokens_validated_total` | Counter | `status`, `error_type` | Access token validations |
-| `tokens_refreshed_total` | Counter | `status`, `error_type` | Refresh operations |
-| `tokens_revoked_total` | Counter | `operation`, `status` | Revocation calls |
-| `tokens_introspected_total` | Counter | `status` | RFC 7662 introspection calls |
-| `operations_total` | Counter | `operation`, `status` | General service operations |
-| `operation_duration_seconds` | Histogram | `operation` | Service operation latency |
-| `active_tokens` | Gauge | `storage_backend` | Active token count |
-| `service_running` | Gauge | — | `1` when running, `0` when stopped |
-| `storage_operations_total` | Counter | `operation`, `status`, `error_type`, `storage_backend` | RefreshStore operations |
-| `storage_cleanup_tokens_removed_total` | Counter | `storage_backend` | Tokens removed during cleanup |
-| `storage_operation_duration_seconds` | Histogram | `operation`, `storage_backend` | Storage operation latency |
-| `storage_tokens_count` | Gauge | `storage_backend` | Tokens currently in storage |
-| `keystore_operations_total` | Counter | `operation`, `status`, `error_type`, `storage_backend` | KeyStore operations |
-| `keystore_operation_duration_seconds` | Histogram | `operation`, `storage_backend` | KeyStore operation latency |
-| `keystore_keys_count` | Gauge | `storage_backend` | Keys in key store |
-| `key_rotations_total` | Counter | `status`, `error_type` | Key rotation attempts |
-| `key_signing_operations_total` | Counter | `status`, `error_type` | Signing key retrievals |
-| `key_validation_operations_total` | Counter | `status`, `error_type` | Validation key retrievals |
-| `key_operation_duration_seconds` | Histogram | `operation` | Key operation latency |
-| `key_current_version` | Gauge | — | Active key version number |
-| `key_active_versions_count` | Gauge | — | Active key version count |
+| `tokens_issued_total` | Counter | `status`, `error_type`, `namespace` | Tokens issued |
+| `tokens_validated_total` | Counter | `status`, `error_type`, `namespace` | Access token validations |
+| `tokens_refreshed_total` | Counter | `status`, `error_type`, `namespace` | Refresh operations |
+| `tokens_revoked_total` | Counter | `revocation_scope`, `status`, `namespace` | Revocation calls |
+| `tokens_cleanup_total` | Counter | `status`, `namespace` | Cleanup operations |
+| `tokens_list_total` | Counter | `scope`, `namespace`, `error_type` | List-tokens calls (scope: all/user/audience) |
+| `operation_duration_seconds` | Histogram | `operation`, `namespace` | TokenManager operation latency |
+| `tokens_list_duration_seconds` | Histogram | `scope`, `namespace` | List-tokens latency |
+| `storage_operations_total` | Counter | `operation`, `status`, `error_type`, `storage_backend`, `namespace` | RefreshStore operations |
+| `storage_cleanup_tokens_removed_total` | Counter | `storage_backend`, `namespace` | Tokens removed during cleanup |
+| `storage_operation_duration_seconds` | Histogram | `operation`, `storage_backend`, `namespace` | Storage operation latency |
+| `storage_tokens_count` | Gauge | `storage_backend`, `namespace` | Tokens currently in storage |
+| `keystore_operations_total` | Counter | `operation`, `status`, `error_type`, `storage_backend`, `namespace` | KeyStore operations |
+| `keystore_operation_duration_seconds` | Histogram | `operation`, `storage_backend`, `namespace` | KeyStore operation latency |
+| `keystore_keys_count` | Gauge | `storage_backend`, `namespace` | Keys in key store |
+| `key_rotations_total` | Counter | `status`, `error_type`, `namespace` | Key rotation attempts |
+| `key_operation_duration_seconds` | Histogram | `operation`, `namespace` | Key operation latency |
+| `key_active_versions_count` | Gauge | `namespace` | Active key versions (alert on == 0) |
 
 **Label conventions**:
 - `status` — `"success"` on the happy path, a short error code on failure (e.g. `"token_expired"`, `"key_not_found"`)
 - `error_type` — `""` on success, mirrors the `status` value on failure — follows the OpenTelemetry `error.type` semantic convention
 - `storage_backend` — `"memory"`, `"redis"`, or `"disk"`
+- `namespace` — operator-defined label set at construction time via `TokenManagerConfig.Namespace`, `KeyManagerConfig.Namespace`, or `DiskKeyStoreConfig.Namespace` / `RedisKeyStoreConfig.Namespace`; defaults to `""` when not configured
 
 **Example PromQL queries**:
 ```promql
@@ -1000,7 +997,7 @@ jwtauth_key_active_versions_count
 **Alerting guidance**:
 - `jwtauth_key_active_versions_count == 0` → critical — no signing key available, all token issuance will fail
 - `rate(jwtauth_key_rotations_total{status!="success"}[1h]) > 0` → warning — key rotation is failing
-- `jwtauth_service_running == 0` → critical — TokenManager has stopped
+- `up{job="jwtauth"} == 0` → critical — jwtauth process is not responding
 
 For the full operator reference including Grafana dashboard guidance and label cardinality analysis, see [doc/METRICS.md](doc/METRICS.md).
 
@@ -1087,9 +1084,9 @@ See [doc/ARCHITECTURE.md](doc/ARCHITECTURE.md#project-structure) for the package
 
 ### Test Coverage
 
-**Current**: 959 comprehensive specs (899 unit + 60 integration) across all packages, all passing with race detection (KeyManager ~81%, TokenManager ~92%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%)
+**Current**: 945 comprehensive specs (885 unit + 60 integration) across all packages, all passing with race detection (KeyManager ~81%, TokenManager ~92%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100%)
 
-**KeyManager** (3 test suites — 170 total specs):
+**KeyManager** (3 test suites — 168 total specs):
 - **9-phase Manager tests** (MockKeyStore — no I/O):
   - Constructor validation, config defaults, ErrInvalidKeyStore
   - Start: loads from store, generates key on empty store, error paths
@@ -1107,7 +1104,7 @@ See [doc/ARCHITECTURE.md](doc/ARCHITECTURE.md#project-structure) for the package
   - Error handling: corrupt metadata, missing metadata entry, Redis unavailability via SetError
   - Concurrency, metrics recording (storage_backend: "redis")
 
-**TokenManager** (7 test suites, 259 total specs):
+**TokenManager** (7 test suites, 258 total specs):
 - **Lifecycle Management Tests**:
   - Start: idempotency, logging, background cleanup, failure handling, context cancellation
   - Shutdown: logging, cleanup termination, goroutine coordination, timeout respect, idempotency, restart after clean shutdown
@@ -1154,16 +1151,15 @@ See [doc/ARCHITECTURE.md](doc/ARCHITECTURE.md#project-structure) for the package
 - `NoOpLogger` — no-op implementation
 
 **Metrics** (66 specs):
-- `PrometheusMetrics` — 34 pre-registered metrics covering all six components
+- `PrometheusMetrics` — 18 pre-registered metrics covering all six components
 - `IncrementCounter`, `AddCounter`, `SetGauge`, `RecordHistogram`, `RecordDuration` implementations
 - Label correctness: `error_type` label on all counters, `namespace` label propagation
 - `NoOpMetrics` — no-op implementation
 
-**Tracing** (78 specs):
+**Tracing** (67 specs):
 - `NoOpTracer` / `NoOpSpan` — no-op implementation, race-detection clean
 - `OtelTracer` adapter — bridges `pkg/tracing.Tracer` to `go.opentelemetry.io/otel`
-- `SpanOption` functional options: `WithAttributes`, `WithSpanKind`
-- All `StatusCode` and `SpanKind` enum values exercised
+- All `StatusCode` enum values exercised
 
 **Integration Tests** (60 specs, `pkg/tokens/integration/`):
 - Runs against both disk+memory and Redis backends (miniredis)
@@ -1228,7 +1224,7 @@ Tests follow **progressive phase-based development**:
 - ✅ RefreshStore: Shared test suite pattern (eliminates duplication, runs against all implementations)
 - ✅ RefreshStore: MemoryRefreshStore with defensive copying and concurrent safety
 - ✅ RefreshStore: RedisRefreshStore for distributed deployments with go-redis/v9
-- ✅ Prometheus metrics adapter (`metrics.NewPrometheusMetrics`) with 22 pre-registered jwtauth metrics
+- ✅ Prometheus metrics adapter (`metrics.NewPrometheusMetrics`) with 18 pre-registered jwtauth metrics
 - ✅ KeyStore interface extracted from KeyManager — `DiskKeyStore` for single-instance, `RedisKeyStore` for distributed deployments
 
 ### v0.3.0
@@ -1380,5 +1376,5 @@ Built by a Senior Platform Engineer with deep experience in distributed systems 
 **Status**: v0.5.0-dev — production-quality, pre-v1.0 (see API Stability note at top)
 **Version**: v0.5.0 (active development; latest release: v0.4.0)
 **Components**: KeyManager ✅ | TokenManager ✅ | RefreshStore (Memory + Redis) ✅ | Metrics (Prometheus) ✅ | Logging (Correlation ID) ✅ | Tracing ✅
-**Test Coverage**: 956 specs (896 unit + 60 integration) — KeyManager ~81%, TokenManager ~92%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100% — all passing, race-detection enabled
+**Test Coverage**: 945 specs (885 unit + 60 integration) — KeyManager ~81%, TokenManager ~92%, RefreshStore 100%, Metrics 100%, Logging 100%, Tracing 100% — all passing, race-detection enabled
 **Last Updated**: May 7, 2026

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -232,40 +232,24 @@ type Metrics interface {
 
 | Metric | Type | Labels |
 |--------|------|--------|
-| `jwtauth_tokens_issued_total` | Counter | status, error_type |
-| `jwtauth_tokens_validated_total` | Counter | status, error_type |
-| `jwtauth_tokens_refreshed_total` | Counter | status, error_type |
-| `jwtauth_tokens_revoked_total` | Counter | revocation_scope, status |
-| `jwtauth_tokens_introspected_total` | Counter | status |
-| `jwtauth_tokens_list_total` | Counter | namespace, error_type |
-| `jwtauth_tokens_list_duration_seconds` | Histogram | namespace |
-| `jwtauth_tokens_list_for_user_total` | Counter | namespace, error_type |
-| `jwtauth_tokens_list_for_user_duration_seconds` | Histogram | namespace |
-| `jwtauth_tokens_list_for_audience_total` | Counter | namespace, error_type |
-| `jwtauth_tokens_list_for_audience_duration_seconds` | Histogram | namespace |
-| `jwtauth_operations_total` | Counter | operation, status |
-| `jwtauth_operation_duration_seconds` | Histogram | operation |
-| `jwtauth_active_tokens` | Gauge | storage_backend |
-| `jwtauth_service_running` | Gauge | — |
-| `jwtauth_storage_operations_total` | Counter | operation, status, error_type, storage_backend |
-| `jwtauth_storage_cleanup_tokens_removed_total` | Counter | storage_backend |
-| `jwtauth_storage_operation_duration_seconds` | Histogram | operation, storage_backend |
-| `jwtauth_storage_tokens_count` | Gauge | storage_backend |
-| `jwtauth_storage_list_tokens_total` | Counter | storage_backend, namespace, error_type |
-| `jwtauth_storage_list_tokens_duration_seconds` | Histogram | storage_backend, namespace |
-| `jwtauth_storage_list_tokens_for_user_total` | Counter | storage_backend, namespace, error_type |
-| `jwtauth_storage_list_tokens_for_user_duration_seconds` | Histogram | storage_backend, namespace |
-| `jwtauth_storage_list_tokens_for_audience_total` | Counter | storage_backend, namespace, error_type |
-| `jwtauth_storage_list_tokens_for_audience_duration_seconds` | Histogram | storage_backend, namespace |
+| `jwtauth_tokens_issued_total` | Counter | status, error_type, namespace |
+| `jwtauth_tokens_validated_total` | Counter | status, error_type, namespace |
+| `jwtauth_tokens_refreshed_total` | Counter | status, error_type, namespace |
+| `jwtauth_tokens_revoked_total` | Counter | revocation_scope, status, namespace |
+| `jwtauth_tokens_cleanup_total` | Counter | status, namespace |
+| `jwtauth_tokens_list_total` | Counter | scope, namespace, error_type |
+| `jwtauth_operation_duration_seconds` | Histogram | operation, namespace |
+| `jwtauth_tokens_list_duration_seconds` | Histogram | scope, namespace |
+| `jwtauth_storage_operations_total` | Counter | operation, status, error_type, storage_backend, namespace |
+| `jwtauth_storage_cleanup_tokens_removed_total` | Counter | storage_backend, namespace |
+| `jwtauth_storage_operation_duration_seconds` | Histogram | operation, storage_backend, namespace |
+| `jwtauth_storage_tokens_count` | Gauge | storage_backend, namespace |
 | `jwtauth_keystore_operations_total` | Counter | operation, status, error_type, storage_backend, namespace |
 | `jwtauth_keystore_operation_duration_seconds` | Histogram | operation, storage_backend, namespace |
 | `jwtauth_keystore_keys_count` | Gauge | storage_backend, namespace |
-| `jwtauth_key_rotations_total` | Counter | status, error_type |
-| `jwtauth_key_signing_operations_total` | Counter | status, error_type |
-| `jwtauth_key_validation_operations_total` | Counter | status, error_type |
-| `jwtauth_key_operation_duration_seconds` | Histogram | operation |
-| `jwtauth_key_current_version` | Gauge | — |
-| `jwtauth_key_active_versions_count` | Gauge | — |
+| `jwtauth_key_rotations_total` | Counter | status, error_type, namespace |
+| `jwtauth_key_operation_duration_seconds` | Histogram | operation, namespace |
+| `jwtauth_key_active_versions_count` | Gauge | namespace |
 
 > **`error_type` label convention**: `""` (empty string) on success; mirrors the `status` value on failure (e.g., `"cancelled"`, `"not_found"`, `"validation_error"`). Enables two-level dashboarding — success/failure rate at the `status` level, failure breakdown at the `error_type` level. Aligned with the OpenTelemetry `error.type` semantic convention.
 
@@ -940,7 +924,7 @@ Catches:
 
 ### Phase 2: Metrics ✅
 - ✅ Metrics interface defined
-- ✅ Prometheus implementation (`PrometheusMetrics`) with 34 pre-registered metrics, 100% test coverage
+- ✅ Prometheus implementation (`PrometheusMetrics`) with 18 pre-registered metrics, 100% test coverage
 - ✅ NoOp implementation
 - ✅ gomock `MockMetrics` for dependency injection in tests
 - ✅ Wired into KeyManager, TokenManager, and RefreshStore — all components fully instrumented
@@ -1110,6 +1094,8 @@ Key design decisions are captured in `doc/adr/`. Each ADR documents the context,
 | [007](adr/007-namespace-consistency-contract.md) | Namespace Field on Manager Configs for Observability Consistency | 2026-04-27 |
 | [008](adr/008-reserved-claims-at-issuance.md) | Reserved Claims Protection at Token Issuance | 2026-04-29 |
 | [009](adr/009-multi-audience-token-revocation.md) | Multi-Audience Token Revocation Semantics | 2026-05-09 |
+| [010](adr/010-jti-and-replay-prevention.md) | JTI Uniqueness — No Replay Prevention | 2026-05-20 |
+| [011](adr/011-cursor-semantics.md) | Cursor Semantics — Opaque, Best-Effort, Unordered | 2026-05-20 |
 
 ---
 
@@ -1123,6 +1109,6 @@ Key design decisions are captured in `doc/adr/`. Each ADR documents the context,
 
 ---
 
-**Last Updated**: May 13, 2026
-**Version**: v0.6.0
+**Last Updated**: May 21, 2026
+**Version**: v0.7.0
 **Status**: Stable — all components fully instrumented (KeyManager, DiskKeyStore, RedisKeyStore, MemoryRefreshStore, RedisRefreshStore, Metrics [Prometheus, 18 metrics], Logging [Correlation ID], Distributed Tracing, TokenManager)

--- a/doc/METRICS.md
+++ b/doc/METRICS.md
@@ -1,6 +1,6 @@
 # Metrics Reference
 
-Complete operator reference for all 22 metrics exposed by `jwtauth`. All metrics are pre-registered at construction time via `metrics.NewPrometheusMetrics()` — naming conflicts are caught early rather than at observation time.
+Complete operator reference for all 18 metrics exposed by `jwtauth`. All metrics are pre-registered at construction time via `metrics.NewPrometheusMetrics()` — naming conflicts are caught early rather than at observation time.
 
 ---
 
@@ -41,55 +41,57 @@ Identifies which RefreshStore or KeyStore implementation is recording the metric
 | `"redis"` | `RedisRefreshStore` / `RedisKeyStore` |
 | `"disk"` | `DiskKeyStore` |
 
+### `namespace`
+Carries the `Namespace` field set on `TokenManagerConfig`, `KeyManagerConfig`, or
+`DiskKeyStoreConfig` / `RedisKeyStoreConfig` at construction time. Present on every metric.
+Defaults to `""` (empty string) when no namespace is configured. Use it to scope dashboards
+and alerts per deployment or tenant.
+
 ---
 
 ## TokenManager Metrics
 
 ### `jwtauth_tokens_issued_total`
 - **Type**: Counter
-- **Labels**: `status`, `error_type`
+- **Labels**: `status`, `error_type`, `namespace`
 - **Description**: Total tokens issued — incremented once per access token and once per refresh token during `IssueTokenPair`. Also incremented for `IssueAccessToken` and `IssueRefreshToken` individually.
 
 ### `jwtauth_tokens_validated_total`
 - **Type**: Counter
-- **Labels**: `status`, `error_type`
+- **Labels**: `status`, `error_type`, `namespace`
 - **Description**: Total access token validations. Incremented by `ValidateAccessToken` and `ValidateAccessTokenWithClaims`.
 
 ### `jwtauth_tokens_refreshed_total`
 - **Type**: Counter
-- **Labels**: `status`, `error_type`
+- **Labels**: `status`, `error_type`, `namespace`
 - **Description**: Total refresh operations. Incremented by `RefreshAccessToken`.
 
 ### `jwtauth_tokens_revoked_total`
 - **Type**: Counter
-- **Labels**: `operation`, `status`
-- **Description**: Total revocation calls. `operation` is `"revoke_token"` for single-token revocation or `"revoke_all_user_tokens"` for bulk revocation.
+- **Labels**: `revocation_scope`, `status`, `namespace`
+- **Description**: Total revocation calls. `revocation_scope` is `"token"` for single-token revocation, `"user"` for bulk user revocation, `"audience"` for audience-scoped revocation.
 
-### `jwtauth_tokens_introspected_total`
+### `jwtauth_tokens_cleanup_total`
 - **Type**: Counter
-- **Labels**: `status`
-- **Description**: Total RFC 7662 introspection calls via `IntrospectToken`.
+- **Labels**: `status`, `namespace`
+- **Description**: Total cleanup operations. Incremented by each background cleanup run and by `CleanupExpiredTokens`. Replaced the former `jwtauth_operations_total{operation="cleanup"}` — the operation is now encoded in the metric name.
 
-### `jwtauth_operations_total`
+### `jwtauth_tokens_list_total`
 - **Type**: Counter
-- **Labels**: `operation`, `status`
-- **Description**: General service operations not covered by the specific counters above.
+- **Labels**: `scope`, `namespace`, `error_type`
+- **Description**: Total list-tokens operations on the TokenManager. `scope` is `"all"` for `ListTokens`, `"user"` for `ListTokensForUser`, `"audience"` for `ListTokensForAudience`.
+
+### `jwtauth_tokens_list_duration_seconds`
+- **Type**: Histogram
+- **Labels**: `scope`, `namespace`
+- **Buckets**: 1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2.5s, 5s, 10s
+- **Description**: Latency for list-tokens operations on the TokenManager, broken out by scope.
 
 ### `jwtauth_operation_duration_seconds`
 - **Type**: Histogram
-- **Labels**: `operation`
+- **Labels**: `operation`, `namespace`
 - **Buckets**: 1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2.5s, 5s, 10s
 - **Description**: End-to-end latency for TokenManager operations. `operation` matches the method name (e.g. `"issue_token_pair"`, `"validate_access_token"`).
-
-### `jwtauth_active_tokens`
-- **Type**: Gauge
-- **Labels**: `storage_backend`
-- **Description**: Number of non-expired refresh tokens currently in the store. Updated after issue, revoke, and cleanup operations.
-
-### `jwtauth_service_running`
-- **Type**: Gauge
-- **Labels**: none
-- **Description**: `1` when the TokenManager is running (after `Start()`), `0` when stopped. Alert on `== 0`.
 
 ---
 
@@ -97,23 +99,23 @@ Identifies which RefreshStore or KeyStore implementation is recording the metric
 
 ### `jwtauth_storage_operations_total`
 - **Type**: Counter
-- **Labels**: `operation`, `status`, `error_type`, `storage_backend`
+- **Labels**: `operation`, `status`, `error_type`, `storage_backend`, `namespace`
 - **Description**: Total RefreshStore operations. `operation` values: `"store"`, `"get"`, `"delete"`, `"list_by_user"`, `"cleanup"`, `"revoke_all_user"`.
 
 ### `jwtauth_storage_cleanup_tokens_removed_total`
 - **Type**: Counter
-- **Labels**: `storage_backend`
+- **Labels**: `storage_backend`, `namespace`
 - **Description**: Cumulative number of expired tokens removed during background cleanup runs.
 
 ### `jwtauth_storage_operation_duration_seconds`
 - **Type**: Histogram
-- **Labels**: `operation`, `storage_backend`
+- **Labels**: `operation`, `storage_backend`, `namespace`
 - **Buckets**: 0.1ms, 0.5ms, 1ms, 2.5ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms
 - **Description**: Latency for individual storage operations. Use p99 to detect Redis latency spikes.
 
 ### `jwtauth_storage_tokens_count`
 - **Type**: Gauge
-- **Labels**: `storage_backend`
+- **Labels**: `storage_backend`, `namespace`
 - **Description**: Current number of tokens in storage. Updated on store, delete, and cleanup.
 
 ---
@@ -122,18 +124,18 @@ Identifies which RefreshStore or KeyStore implementation is recording the metric
 
 ### `jwtauth_keystore_operations_total`
 - **Type**: Counter
-- **Labels**: `operation`, `status`, `error_type`, `storage_backend`
+- **Labels**: `operation`, `status`, `error_type`, `storage_backend`, `namespace`
 - **Description**: Total KeyStore operations. `operation` values: `"list_keys"`, `"load_key"`, `"save_key"`, `"delete_key"`.
 
 ### `jwtauth_keystore_operation_duration_seconds`
 - **Type**: Histogram
-- **Labels**: `operation`, `storage_backend`
+- **Labels**: `operation`, `storage_backend`, `namespace`
 - **Buckets**: 0.1ms, 0.5ms, 1ms, 2.5ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms
 - **Description**: Latency for individual KeyStore operations (disk reads, Redis round-trips).
 
 ### `jwtauth_keystore_keys_count`
 - **Type**: Gauge
-- **Labels**: `storage_backend`
+- **Labels**: `storage_backend`, `namespace`
 - **Description**: Number of key entries in the KeyStore. Updated on save and delete.
 
 ---
@@ -142,33 +144,18 @@ Identifies which RefreshStore or KeyStore implementation is recording the metric
 
 ### `jwtauth_key_rotations_total`
 - **Type**: Counter
-- **Labels**: `status`, `error_type`
+- **Labels**: `status`, `error_type`, `namespace`
 - **Description**: Total key rotation attempts. A rotation failure means new tokens will continue to be signed with the current key until the next rotation succeeds. Alert on sustained failures.
-
-### `jwtauth_key_signing_operations_total`
-- **Type**: Counter
-- **Labels**: `status`, `error_type`
-- **Description**: Total calls to `GetCurrentSigningKey`. Incremented once per token issuance. Failure means no signing key was available.
-
-### `jwtauth_key_validation_operations_total`
-- **Type**: Counter
-- **Labels**: `status`, `error_type`
-- **Description**: Total calls to `GetPublicKey`. Incremented once per token validation. Failure means the token's `kid` did not match any known key — typically an old token after a key rotation outside the overlap window.
 
 ### `jwtauth_key_operation_duration_seconds`
 - **Type**: Histogram
-- **Labels**: `operation`
+- **Labels**: `operation`, `namespace`
 - **Buckets**: 0.1ms, 0.5ms, 1ms, 2.5ms, 5ms, 10ms, 25ms, 50ms
 - **Description**: Latency for KeyManager operations. `operation` values: `"get_signing_key"`, `"get_public_key"`, `"rotate"`.
 
-### `jwtauth_key_current_version`
-- **Type**: Gauge
-- **Labels**: none
-- **Description**: The version number of the currently active signing key. Monotonically increases with each rotation — useful for confirming that rotation has occurred.
-
 ### `jwtauth_key_active_versions_count`
 - **Type**: Gauge
-- **Labels**: none
+- **Labels**: `namespace`
 - **Description**: Number of key versions currently loaded in the KeyManager (signing key + overlap keys). Should always be ≥ 1. Alert immediately on `== 0`.
 
 ### Custom Gauges via `GetCurrentKeyInfo`
@@ -241,13 +228,6 @@ jwtauth_key_active_versions_count
 # Key rotation failures in the past hour
 rate(jwtauth_key_rotations_total{status!="success"}[1h])
 
-# Signing operation failures (no signing key available)
-rate(jwtauth_key_signing_operations_total{status!="success"}[5m])
-
-# Validation failures due to unknown key (token from outside overlap window)
-rate(jwtauth_key_validation_operations_total{status="key_not_found"}[5m])
-
-
 # ── Storage ──────────────────────────────────────────────────────────────────
 
 # Storage operation latency p99
@@ -260,10 +240,19 @@ rate(jwtauth_storage_operations_total{status!="success"}[5m]) by (operation, err
 jwtauth_storage_tokens_count
 
 
+# ── List Operations ──────────────────────────────────────────────────────────
+
+# List-tokens error rate by scope
+rate(jwtauth_tokens_list_total{error_type!=""}[5m]) by (scope, error_type)
+
+# List-tokens p99 latency by scope
+histogram_quantile(0.99, rate(jwtauth_tokens_list_duration_seconds_bucket[5m])) by (scope)
+
+
 # ── Service Health ───────────────────────────────────────────────────────────
 
-# Service running status (1 = running, 0 = stopped)
-jwtauth_service_running
+# Service liveness (1 = up, 0 = down)
+up{job="jwtauth"}
 
 # End-to-end operation latency p95
 histogram_quantile(0.95, rate(jwtauth_operation_duration_seconds_bucket[5m])) by (operation)
@@ -285,11 +274,11 @@ groups:
           summary: "No active signing key — all token issuance will fail until rotation succeeds"
 
       - alert: TokenManagerStopped
-        expr: jwtauth_service_running == 0
+        expr: up{job="jwtauth"} == 0
         for: 1m
         annotations:
           severity: critical
-          summary: "TokenManager is not running"
+          summary: "jwtauth process is not responding"
 
   - name: jwtauth.warning
     rules:
@@ -326,10 +315,8 @@ Recommended panels for a jwtauth dashboard:
 | Token issuance rate | `rate(jwtauth_tokens_issued_total{status="success"}[5m])` | Time series |
 | Validation error breakdown | `rate(jwtauth_tokens_validated_total{status!="success"}[5m]) by (error_type)` | Stacked bar |
 | Active key count | `jwtauth_key_active_versions_count` | Stat (alert threshold: 0) |
-| Service running | `jwtauth_service_running` | Stat (green/red) |
 | Storage latency p99 | `histogram_quantile(0.99, rate(jwtauth_storage_operation_duration_seconds_bucket[5m]))` | Time series |
 | Active token count | `jwtauth_storage_tokens_count` | Time series |
-| Key rotation history | `jwtauth_key_current_version` | Time series |
 
 ---
 
@@ -343,6 +330,7 @@ All labels use bounded enumerations — safe for high-cardinality environments:
 | `error_type` | ~13 | Mirrors `status` values |
 | `storage_backend` | 3 | `"memory"`, `"redis"`, `"disk"` |
 | `operation` | ~10 | Fixed method names per component |
+| `namespace` | Operator-defined | Bounded — set at construction time; typically ≤ handful of values per deployment |
 
 No user-supplied data (user IDs, token values, IP addresses) appears in any label — there is no unbounded cardinality risk.
 


### PR DESCRIPTION
## Summary

Fixes the stale metrics documentation that was never updated after the v0.7.0 metrics reduction (PRs #221–#224, 34 → 18 metrics). This was a blocker before v0.7.0 can be tagged.

- **`doc/METRICS.md`**: Remove 7 stale metric entries, add 3 new ones (`tokens_cleanup_total`, `tokens_list_total`, `tokens_list_duration_seconds`), add `namespace` label to every metric and to the label conventions / cardinality table sections, fix PromQL cookbook (remove stale signing/validation key queries, replace `jwtauth_service_running` with `up{job="jwtauth"}`, add List Operations block), fix `TokenManagerStopped` alerting rule, remove 2 stale Grafana panel rows
- **`doc/ARCHITECTURE.md`**: Replace 34-row metric table with 18-row table, update pre-registered count (34 → 18), add ADR-010 and ADR-011 entries, update footer to v0.7.0 / May 21 2026
- **`README.md`**: Fix all metric counts (22 → 18, 34 → 18), rewrite 22-row metric reference table to 18-row with correct labels, fix 8 stale test counts, update API stability banner to reflect v0.7.0 shipped features, fix alerting guidance, remove removed `SpanOption` bullet from Tracing section

No code changes — pure documentation. No CHANGELOG entry needed.

## Test plan

- [x] `bash run-ci-locally.sh` — all 885 unit + 60 integration specs pass, lint clean
- [x] No stale metric counts remain (`grep '22 metrics|34 pre-registered' doc/ README.md` → empty)
- [x] No removed metric names in doc prose
- [x] New metrics documented in all three files
- [x] ADR-010 and ADR-011 in ARCHITECTURE.md

Closes #243