### PR TITLE
feat(tokens): add TokenManager interface for service-layer testability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`tokens.TokenManager` interface** — defines nine core service-layer operations
+  (`IssueTokenPairWithClaims`, `RefreshAccessTokenWithClaims`, `ValidateAccessToken`,
+  `ValidateAccessTokenWithClaims`, `IntrospectToken`, `RevokeRefreshToken`,
+  `RevokeAllUserTokens`, `RevokeAllForAudience`, `RevokeAllForUserAndAudience`).
+  Consumers may depend on this interface rather than the concrete `*Manager` type,
+  enabling service-layer unit testing without a running key store or storage backend.
+  Compile-time satisfaction is asserted on `*Manager`. See #248.
+
+---
+
 ## [v0.7.0] — 2026-05-21
 
 ### Breaking

--- a/pkg/tokens/interface.go
+++ b/pkg/tokens/interface.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Angel Tomala-Reyes
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tokens
+
+import (
+	"context"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// TokenManager defines the token lifecycle operations exposed by Manager.
+// Consumers may depend on this interface rather than the concrete type,
+// enabling service-layer unit testing without a running key store or
+// storage backend. All methods are safe for concurrent use.
+type TokenManager interface {
+	IssueTokenPairWithClaims(ctx context.Context, userID string, accessClaims CustomClaims, refreshClaims CustomClaims, opts ...IssueOption) (string, string, error)
+	RefreshAccessTokenWithClaims(ctx context.Context, refreshToken string, claims CustomClaims) (string, error)
+	ValidateAccessToken(ctx context.Context, tokenString string) (*jwt.RegisteredClaims, error)
+	ValidateAccessTokenWithClaims(ctx context.Context, tokenString string) (*jwt.RegisteredClaims, map[string]interface{}, error)
+	IntrospectToken(ctx context.Context, token string) (*TokenMetadata, error)
+	RevokeRefreshToken(ctx context.Context, tokenID string) error
+	RevokeAllUserTokens(ctx context.Context, userID string) error
+	RevokeAllForAudience(ctx context.Context, audience string) error
+	RevokeAllForUserAndAudience(ctx context.Context, userID, audience string) error
+}
+
+// Compile-time assertion: Manager must satisfy TokenManager.
+var _ TokenManager = (*Manager)(nil)


### PR DESCRIPTION
## Summary

- Adds `tokens.TokenManager` — a nine-method interface covering core service-handler operations: issuance, validation, refresh, revocation, and introspection
- Compile-time assertion `var _ TokenManager = (*Manager)(nil)` in `pkg/tokens/interface.go` guarantees `*Manager` satisfies the interface
- No mock generated in `internal/testutil` — `TokenManager` is an output interface with no internal consumer; external service layers run `mockgen -source=interface.go` themselves
- CHANGELOG updated under `[Unreleased] → ### Added`

## Interface

```go
type TokenManager interface {
    IssueTokenPairWithClaims(ctx context.Context, userID string, accessClaims CustomClaims, refreshClaims CustomClaims, opts ...IssueOption) (string, string, error)
    RefreshAccessTokenWithClaims(ctx context.Context, refreshToken string, claims CustomClaims) (string, error)
    ValidateAccessToken(ctx context.Context, tokenString string) (*jwt.RegisteredClaims, error)
    ValidateAccessTokenWithClaims(ctx context.Context, tokenString string) (*jwt.RegisteredClaims, map[string]interface{}, error)
    IntrospectToken(ctx context.Context, token string) (*TokenMetadata, error)
    RevokeRefreshToken(ctx context.Context, tokenID string) error
    RevokeAllUserTokens(ctx context.Context, userID string) error
    RevokeAllForAudience(ctx context.Context, audience string) error
    RevokeAllForUserAndAudience(ctx context.Context, userID, audience string) error
}
```

## Test plan

- [x] `go build ./pkg/tokens/` — compile-time assertion passes
- [x] `./run-ci-locally.sh` — 885 unit + 60 integration specs, no DATA RACE, lint clean

Closes #248