### PR TITLE
docs: fix badge links and add dynamic release badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # jwtauth
 
-![Tests](https://github.com/aetomala/jwtauth/actions/workflows/CI.yml/badge.svg?branch=main)
-![Go Version](https://img.shields.io/badge/go-1.25+-blue.svg)
+[![Tests](https://github.com/aetomala/jwtauth/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/aetomala/jwtauth/actions/workflows/CI.yml)
+[![Go Version](https://img.shields.io/badge/go-1.25+-blue.svg)](https://pkg.go.dev/github.com/aetomala/jwtauth)
+[![Release](https://img.shields.io/github/v/release/aetomala/jwtauth)](https://github.com/aetomala/jwtauth/releases/latest)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 **Stateful JWT authorization token engine for distributed Go applications**


### PR DESCRIPTION
## Summary

- `Tests` and `Go Version` badges were bare image tags (`![...]()`) — they rendered but clicking did nothing
- Wrapped both in proper linked badge form (`[![...]())](url)`)
- Added dynamic `Release` badge (`img.shields.io/github/v/release/...`) — auto-updates on every tag push, always shows the latest version without a manual README edit
- `License` badge unchanged (already correct)

## Badge destinations

| Badge | Links to |
|-------|----------|
| Tests | GitHub Actions CI page |
| Go Version | pkg.go.dev |
| Release | GitHub Releases latest |
| License | opensource.org/licenses/Apache-2.0 |

## Test plan

- [ ] Open rendered README on GitHub, confirm all four badges are clickable and resolve to correct destinations
- [ ] Confirm Release badge displays `v0.7.1`