### PR TITLE
feat: standardise span attribute keys to snake_case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Breaking
+
+- Span attribute keys standardised to `snake_case` across all components. Operators with span-based dashboards or alert rules must update the following keys: `storage.backend` → `storage_backend`; `token.namespace` / `key.namespace` / `storage.namespace` → `namespace`; `token.audience` / `storage.audience` → `audience`; `key.count` → `key_count`; `storage.cursor` → `cursor`; `storage.count` → `count`; `storage.result_count` → `result_count`; `storage.user_id` → `user_id`. See `doc/ARCHITECTURE.md` for the canonical per-component attribute list.
+
 ---
 
 ## [v0.7.1] — 2026-05-28

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -307,12 +307,13 @@ func (m *Manager) RotateKeys(ctx context.Context) error {
 **Interface**:
 ```go
 type Tracer interface {
-    Start(ctx context.Context, name string, opts ...SpanOption) (context.Context, Span)
+    Start(ctx context.Context, name string) (context.Context, Span)
 }
 
 type Span interface {
     End()
     SetAttribute(key string, value any)
+    SetAttributes(attrs map[string]any)
     SetStatus(code StatusCode, description string)
     RecordError(err error)
 }
@@ -324,14 +325,68 @@ type Span interface {
 
 **Span naming convention**: `<TypeName>.<MethodName>` — e.g., `TokenManager.IssueAccessToken`, `DiskKeyStore.Save`
 
-**Span attributes by layer**:
+**Attribute naming convention**: all attribute keys use `snake_case` — e.g., `user_id`, `token_id`, `storage_backend`. See the per-component tables below for the canonical names.
 
-| Component | Attributes |
-|-----------|-----------|
-| `DiskKeyStore` / `RedisKeyStore` | `storage.backend` (`"disk"` / `"redis"`), `key_id` |
-| `MemoryRefreshStore` / `RedisRefreshStore` | `storage.backend` (`"memory"` / `"redis"`), `token_id` |
-| `KeyManager` | `key_id` |
-| `TokenManager` | `user_id`, `token_id`, `active` (IntrospectToken), `deleted_count` (CleanupExpiredTokens) |
+**Span attributes — KeyManager**:
+
+| Span | Attributes |
+|------|-----------|
+| All spans (pre-set) | `namespace` |
+| `KeyManager.GetCurrentSigningKey` | `key_id` |
+| `KeyManager.GetPublicKey` | `key_id` |
+| `KeyManager.GetKeyInfo` | `key_id` |
+| `KeyManager.GetAllKeyInfo` | `key_count` |
+| `KeyManager.RotateKeys` | `key_id` |
+
+**Span attributes — DiskKeyStore / RedisKeyStore**:
+
+| Span | Attributes |
+|------|-----------|
+| All spans (pre-set) | `storage_backend` (`"disk"` / `"redis"`), `namespace` |
+| `DiskKeyStore.Save` / `RedisKeyStore.Save` | `key_id` |
+| `DiskKeyStore.UpdateMetadata` / `RedisKeyStore.UpdateMetadata` | `key_id` |
+| `DiskKeyStore.LoadKey` / `RedisKeyStore.LoadKey` | `key_id` |
+| `DiskKeyStore.Delete` / `RedisKeyStore.Delete` | `key_id` |
+
+**Span attributes — TokenManager**:
+
+| Span | Attributes |
+|------|-----------|
+| All spans (pre-set) | `namespace` |
+| `TokenManager.IssueAccessToken` | `user_id`, `token_id`, `audience` (if non-empty) |
+| `TokenManager.IssueAccessTokenWithClaims` | `user_id`, `token_id`, `audience` (if non-empty) |
+| `TokenManager.IssueRefreshToken` | `user_id`, `token_id`, `audience` (if non-empty) |
+| `TokenManager.IssueRefreshTokenWithClaims` | `user_id`, `token_id`, `audience` (if non-empty) |
+| `TokenManager.IssueTokenPair` | `user_id`, `token_id`, `audience` (if non-empty) |
+| `TokenManager.IssueTokenPairWithClaims` | `user_id`, `token_id`, `audience` (if non-empty) |
+| `TokenManager.ValidateAccessToken` | `user_id`, `token_id` |
+| `TokenManager.ValidateAccessTokenWithClaims` | `user_id`, `token_id` |
+| `TokenManager.RefreshAccessToken` | `token_id` |
+| `TokenManager.RefreshAccessTokenWithClaims` | `token_id` |
+| `TokenManager.RevokeRefreshToken` | `token_id` |
+| `TokenManager.RevokeAllUserTokens` | `user_id` |
+| `TokenManager.RevokeAllForAudience` | `audience` |
+| `TokenManager.RevokeAllForUserAndAudience` | `user_id`, `audience` |
+| `TokenManager.IntrospectToken` | `token_id` |
+| `TokenManager.ListTokens` | `namespace`, `cursor`, `count`, `result_count` |
+| `TokenManager.ListTokensForUser` | `namespace`, `user_id`, `cursor`, `count`, `result_count` |
+| `TokenManager.ListTokensForAudience` | `namespace`, `audience`, `cursor`, `count`, `result_count` |
+
+**Span attributes — MemoryRefreshStore / RedisRefreshStore**:
+
+| Span | Attributes |
+|------|-----------|
+| All spans (pre-set) | `storage_backend` (`"memory"` / `"redis"`), `namespace` (RedisRefreshStore only) |
+| `*.Store` | `token_id` |
+| `*.Retrieve` | `token_id` |
+| `*.Revoke` | `token_id` |
+| `*.RevokeAllForUser` | `user_id` |
+| `*.RevokeAllForAudience` | `audience` |
+| `*.RevokeAllForUserAndAudience` | `user_id`, `audience` |
+| `*.Cleanup` | `removed_count` |
+| `*.ListTokens` | `cursor`, `count`, `result_count` |
+| `*.ListTokensForUser` | `user_id`, `cursor`, `count`, `result_count` |
+| `*.ListTokensForAudience` | `audience`, `cursor`, `count`, `result_count` |
 
 **Status conventions**: `StatusOK` on all success paths; `RecordError(err)` + `StatusError` on all error paths. Wrapped errors (via `fmt.Errorf("...: %w", err)`) are passed to `RecordError` so the full message propagates to the trace backend.
 
@@ -341,8 +396,10 @@ type DiskKeyStore struct {
     tracer tracing.Tracer // never nil; defaults to NoOpTracer
 }
 
-func (d *DiskKeyStore) startSpan(ctx context.Context, op string, opts ...tracing.SpanOption) (context.Context, tracing.Span) {
-    return d.tracer.Start(ctx, "DiskKeyStore."+op, opts...)
+func (d *DiskKeyStore) startSpan(ctx context.Context, op string) (context.Context, tracing.Span) {
+    ctx, span := d.tracer.Start(ctx, "DiskKeyStore."+op)
+    span.SetAttributes(map[string]any{"storage_backend": d.backend, "namespace": d.namespace})
+    return ctx, span
 }
 
 func (d *DiskKeyStore) Save(ctx context.Context, key *KeyInfo) error {
@@ -979,7 +1036,7 @@ Catches:
 - ✅ Redis integration tests via miniredis (`pkg/tokens/integration`) covering distributed token operations end-to-end
 
 ### Phase 6: Distributed Tracing (v0.4.0)
-- ✅ `pkg/tracing` — `Tracer` and `Span` interfaces defined; `SpanOption` functional options; `StatusCode` and `SpanKind` enumerations
+- ✅ `pkg/tracing` — `Tracer` and `Span` interfaces defined; `StatusCode` enumeration
 - ✅ `NoOpTracer` / `NoOpSpan` — zero-allocation implementations; 36 tests, race-detection clean
 - ✅ `MockTracer` / `MockSpan` generated via gomock for dependency injection in component tests
 - ✅ Tracing wired into all six components — `DiskKeyStore`, `RedisKeyStore`, `MemoryRefreshStore`, `RedisRefreshStore`, `KeyManager`, `TokenManager`

--- a/pkg/keys/disk.go
+++ b/pkg/keys/disk.go
@@ -114,8 +114,8 @@ func (d *DiskKeyStore) Namespace() string { return d.namespace }
 func (d *DiskKeyStore) startSpan(ctx context.Context, operation string) (context.Context, tracing.Span) {
 	ctx, span := d.tracer.Start(ctx, "DiskKeyStore."+operation)
 	span.SetAttributes(map[string]any{
-		"storage.backend":   d.backend,
-		"storage.namespace": d.namespace,
+		"storage_backend": d.backend,
+		"namespace":       d.namespace,
 	})
 	return ctx, span
 }

--- a/pkg/keys/disk_test.go
+++ b/pkg/keys/disk_test.go
@@ -735,7 +735,7 @@ var _ = Describe("DiskKeyStore", func() {
 		Context("Save — success path", func() {
 			It("should start a span named DiskKeyStore.Save with key_id and StatusOK", func() {
 				mockTracer.EXPECT().Start(gomock.Any(), "DiskKeyStore.Save").Return(ctx, mockSpan)
-				mockSpan.EXPECT().SetAttributes(map[string]any{"storage.backend": "disk", "storage.namespace": ""})
+				mockSpan.EXPECT().SetAttributes(map[string]any{"storage_backend": "disk", "namespace": ""})
 				mockSpan.EXPECT().SetAttribute("key_id", testKeyA)
 				mockSpan.EXPECT().SetStatus(tracing.StatusOK, "")
 				mockSpan.EXPECT().End()
@@ -750,7 +750,7 @@ var _ = Describe("DiskKeyStore", func() {
 		Context("LoadKey — error path", func() {
 			It("should call RecordError and StatusError when key is not found", func() {
 				mockTracer.EXPECT().Start(gomock.Any(), "DiskKeyStore.LoadKey").Return(ctx, mockSpan)
-				mockSpan.EXPECT().SetAttributes(map[string]any{"storage.backend": "disk", "storage.namespace": ""})
+				mockSpan.EXPECT().SetAttributes(map[string]any{"storage_backend": "disk", "namespace": ""})
 				mockSpan.EXPECT().SetAttribute("key_id", testKeyMissing)
 				mockSpan.EXPECT().SetStatus(tracing.StatusError, gomock.Any())
 				mockSpan.EXPECT().End()

--- a/pkg/keys/manager.go
+++ b/pkg/keys/manager.go
@@ -806,7 +806,7 @@ func (m *Manager) GetAllKeyInfo(ctx context.Context) ([]KeyInfo, error) {
 		})
 	}
 
-	span.SetAttribute("key.count", len(result))
+	span.SetAttribute("key_count", len(result))
 	span.SetStatus(tracing.StatusOK, "")
 	m.config.Logger.Info("retrieved all key info", ctx, "count", len(result), "namespace", m.namespace)
 	m.metrics.RecordDuration(metricKeyOpDuration, time.Since(start),
@@ -1035,7 +1035,7 @@ func base64urlEncode(data []byte) string {
 // pre-seeded with the key.namespace attribute.
 func (m *Manager) startSpan(ctx context.Context, operation string) (context.Context, tracing.Span) {
 	ctx, span := m.tracer.Start(ctx, "KeyManager."+operation)
-	span.SetAttributes(map[string]any{"key.namespace": m.namespace})
+	span.SetAttributes(map[string]any{"namespace": m.namespace})
 	return ctx, span
 }
 

--- a/pkg/keys/manager_test.go
+++ b/pkg/keys/manager_test.go
@@ -934,7 +934,7 @@ var _ = Describe("Manager", func() {
 				defer shutdownManager()
 
 				mockTracer.EXPECT().Start(gomock.Any(), gomock.Eq("KeyManager.GetCurrentSigningKey")).Return(ctx, testSpan)
-				testSpan.EXPECT().SetAttributes(map[string]any{"key.namespace": ""})
+				testSpan.EXPECT().SetAttributes(map[string]any{"namespace": ""})
 				testSpan.EXPECT().SetAttribute("key_id", "tracing-test-key")
 				testSpan.EXPECT().SetStatus(tracing.StatusOK, "")
 				testSpan.EXPECT().End()
@@ -954,7 +954,7 @@ var _ = Describe("Manager", func() {
 				defer shutdownManager()
 
 				mockTracer.EXPECT().Start(gomock.Any(), gomock.Eq("KeyManager.GetPublicKey")).Return(ctx, testSpan)
-				testSpan.EXPECT().SetAttributes(map[string]any{"key.namespace": ""})
+				testSpan.EXPECT().SetAttributes(map[string]any{"namespace": ""})
 				testSpan.EXPECT().SetAttribute("key_id", "ghost-key")
 				testSpan.EXPECT().RecordError(keys.ErrKeyNotFound)
 				testSpan.EXPECT().SetStatus(tracing.StatusError, keys.ErrKeyNotFound.Error())
@@ -975,7 +975,7 @@ var _ = Describe("Manager", func() {
 				defer shutdownManager()
 
 				mockTracer.EXPECT().Start(gomock.Any(), gomock.Eq("KeyManager.RotateKeys")).Return(ctx, testSpan)
-				testSpan.EXPECT().SetAttributes(map[string]any{"key.namespace": ""})
+				testSpan.EXPECT().SetAttributes(map[string]any{"namespace": ""})
 				testSpan.EXPECT().SetAttribute("key_id", gomock.Any())
 				testSpan.EXPECT().SetStatus(tracing.StatusOK, "")
 				testSpan.EXPECT().End()

--- a/pkg/keys/redis.go
+++ b/pkg/keys/redis.go
@@ -108,8 +108,8 @@ func (r *RedisKeyStore) Namespace() string { return r.namespace }
 func (r *RedisKeyStore) startSpan(ctx context.Context, operation string) (context.Context, tracing.Span) {
 	ctx, span := r.tracer.Start(ctx, "RedisKeyStore."+operation)
 	span.SetAttributes(map[string]any{
-		"storage.backend":   r.backend,
-		"storage.namespace": r.namespace,
+		"storage_backend": r.backend,
+		"namespace":       r.namespace,
 	})
 	return ctx, span
 }

--- a/pkg/keys/redis_test.go
+++ b/pkg/keys/redis_test.go
@@ -753,7 +753,7 @@ var _ = Describe("RedisKeyStore", func() {
 		Context("Save — success path", func() {
 			It("should start a span named RedisKeyStore.Save with storage.backend, key_id and StatusOK", func() {
 				mockTracer.EXPECT().Start(gomock.Any(), "RedisKeyStore.Save").Return(ctx, mockSpan)
-				mockSpan.EXPECT().SetAttributes(map[string]any{"storage.backend": "redis", "storage.namespace": ""})
+				mockSpan.EXPECT().SetAttributes(map[string]any{"storage_backend": "redis", "namespace": ""})
 				mockSpan.EXPECT().SetAttribute("key_id", testKeyA)
 				mockSpan.EXPECT().SetStatus(tracing.StatusOK, "")
 				mockSpan.EXPECT().End()
@@ -768,7 +768,7 @@ var _ = Describe("RedisKeyStore", func() {
 		Context("LoadKey — error path", func() {
 			It("should call RecordError and StatusError when key is not found", func() {
 				mockTracer.EXPECT().Start(gomock.Any(), "RedisKeyStore.LoadKey").Return(ctx, mockSpan)
-				mockSpan.EXPECT().SetAttributes(map[string]any{"storage.backend": "redis", "storage.namespace": ""})
+				mockSpan.EXPECT().SetAttributes(map[string]any{"storage_backend": "redis", "namespace": ""})
 				mockSpan.EXPECT().SetAttribute("key_id", testKeyMissing)
 				mockSpan.EXPECT().RecordError(keys.ErrKeyStoreKeyNotFound)
 				mockSpan.EXPECT().SetStatus(tracing.StatusError, gomock.Any())

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -94,7 +94,7 @@ func (m *MemoryRefreshStore) Namespace() string { return "" }
 // the storage.backend attribute.
 func (m *MemoryRefreshStore) startSpan(ctx context.Context, operation string) (context.Context, tracing.Span) {
 	ctx, span := m.tracer.Start(ctx, "MemoryRefreshStore."+operation)
-	span.SetAttributes(map[string]any{"storage.backend": m.backend})
+	span.SetAttributes(map[string]any{"storage_backend": m.backend})
 	return ctx, span
 }
 
@@ -596,8 +596,8 @@ func (m *MemoryRefreshStore) Cleanup(ctx context.Context) (int, error) {
 func (m *MemoryRefreshStore) ListTokens(ctx context.Context, cursor string, count int) ([]*RefreshToken, string, error) {
 	ctx, span := m.startSpan(ctx, "ListTokens")
 	defer span.End()
-	span.SetAttribute("storage.cursor", cursor)
-	span.SetAttribute("storage.count", count)
+	span.SetAttribute("cursor", cursor)
+	span.SetAttribute("count", count)
 
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
@@ -669,7 +669,7 @@ func (m *MemoryRefreshStore) ListTokens(ctx context.Context, cursor string, coun
 
 	// ===== STEP 7: Log and Return =====
 	resultCount := len(tokens)
-	span.SetAttribute("storage.result_count", resultCount)
+	span.SetAttribute("result_count", resultCount)
 	span.SetStatus(tracing.StatusOK, "")
 	m.logger.Info("listTokens: page returned", ctx,
 		"result_count", resultCount,
@@ -691,9 +691,9 @@ func (m *MemoryRefreshStore) ListTokens(ctx context.Context, cursor string, coun
 func (m *MemoryRefreshStore) ListTokensForUser(ctx context.Context, userID string, cursor string, count int) ([]*RefreshToken, string, error) {
 	ctx, span := m.startSpan(ctx, "ListTokensForUser")
 	defer span.End()
-	span.SetAttribute("storage.user_id", userID)
-	span.SetAttribute("storage.cursor", cursor)
-	span.SetAttribute("storage.count", count)
+	span.SetAttribute("user_id", userID)
+	span.SetAttribute("cursor", cursor)
+	span.SetAttribute("count", count)
 
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
@@ -774,7 +774,7 @@ func (m *MemoryRefreshStore) ListTokensForUser(ctx context.Context, userID strin
 
 	// ===== STEP 7: Log and Return =====
 	resultCount := len(tokens)
-	span.SetAttribute("storage.result_count", resultCount)
+	span.SetAttribute("result_count", resultCount)
 	span.SetStatus(tracing.StatusOK, "")
 	m.logger.Info("listTokensForUser: page returned", ctx,
 		"user_id", userID,
@@ -799,9 +799,9 @@ func (m *MemoryRefreshStore) ListTokensForUser(ctx context.Context, userID strin
 func (m *MemoryRefreshStore) ListTokensForAudience(ctx context.Context, audience string, cursor string, count int) ([]*RefreshToken, string, error) {
 	ctx, span := m.startSpan(ctx, "ListTokensForAudience")
 	defer span.End()
-	span.SetAttribute("storage.audience", audience)
-	span.SetAttribute("storage.cursor", cursor)
-	span.SetAttribute("storage.count", count)
+	span.SetAttribute("audience", audience)
+	span.SetAttribute("cursor", cursor)
+	span.SetAttribute("count", count)
 
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
@@ -882,7 +882,7 @@ func (m *MemoryRefreshStore) ListTokensForAudience(ctx context.Context, audience
 
 	// ===== STEP 7: Log and Return =====
 	resultCount := len(tokens)
-	span.SetAttribute("storage.result_count", resultCount)
+	span.SetAttribute("result_count", resultCount)
 	span.SetStatus(tracing.StatusOK, "")
 	m.logger.Info("listTokensForAudience: page returned", ctx,
 		"audience", audience,

--- a/pkg/storage/memory_test.go
+++ b/pkg/storage/memory_test.go
@@ -81,7 +81,7 @@ var _ = Describe("MemoryRefreshStore — Phase 10: Tracing", func() {
 	Context("Store — success path", func() {
 		It("should start a span named MemoryRefreshStore.Store with storage.backend, token_id and StatusOK", func() {
 			mockTracer.EXPECT().Start(gomock.Any(), "MemoryRefreshStore.Store").Return(ctx, mockSpan)
-			mockSpan.EXPECT().SetAttributes(map[string]any{"storage.backend": "memory"})
+			mockSpan.EXPECT().SetAttributes(map[string]any{"storage_backend": "memory"})
 			mockSpan.EXPECT().SetAttribute("token_id", "trace-store-token")
 			mockSpan.EXPECT().SetStatus(tracing.StatusOK, "")
 			mockSpan.EXPECT().End()
@@ -93,7 +93,7 @@ var _ = Describe("MemoryRefreshStore — Phase 10: Tracing", func() {
 	Context("Retrieve — error path", func() {
 		It("should call RecordError and StatusError when token is not found", func() {
 			mockTracer.EXPECT().Start(gomock.Any(), "MemoryRefreshStore.Retrieve").Return(ctx, mockSpan)
-			mockSpan.EXPECT().SetAttributes(map[string]any{"storage.backend": "memory"})
+			mockSpan.EXPECT().SetAttributes(map[string]any{"storage_backend": "memory"})
 			mockSpan.EXPECT().SetAttribute("token_id", "missing-trace-token")
 			mockSpan.EXPECT().RecordError(storage.ErrTokenNotFound)
 			mockSpan.EXPECT().SetStatus(tracing.StatusError, gomock.Any())

--- a/pkg/storage/redis.go
+++ b/pkg/storage/redis.go
@@ -110,8 +110,8 @@ func (r *RedisRefreshStore) Namespace() string { return r.namespace }
 func (r *RedisRefreshStore) startSpan(ctx context.Context, operation string) (context.Context, tracing.Span) {
 	ctx, span := r.tracer.Start(ctx, "RedisRefreshStore."+operation)
 	span.SetAttributes(map[string]any{
-		"storage.backend":   r.backend,
-		"storage.namespace": r.namespace,
+		"storage_backend": r.backend,
+		"namespace":       r.namespace,
 	})
 	return ctx, span
 }
@@ -792,8 +792,8 @@ func (r *RedisRefreshStore) Cleanup(ctx context.Context) (int, error) {
 func (r *RedisRefreshStore) ListTokens(ctx context.Context, cursor string, count int) ([]*RefreshToken, string, error) {
 	ctx, span := r.startSpan(ctx, "ListTokens")
 	defer span.End()
-	span.SetAttribute("storage.cursor", cursor)
-	span.SetAttribute("storage.count", count)
+	span.SetAttribute("cursor", cursor)
+	span.SetAttribute("count", count)
 
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
@@ -850,7 +850,7 @@ func (r *RedisRefreshStore) ListTokens(ctx context.Context, cursor string, count
 
 	// ===== STEP 7: Log and Return =====
 	resultCount := len(tokens)
-	span.SetAttribute("storage.result_count", resultCount)
+	span.SetAttribute("result_count", resultCount)
 	span.SetStatus(tracing.StatusOK, "")
 	r.logger.Info("listTokens: page returned", ctx,
 		"result_count", resultCount,
@@ -872,9 +872,9 @@ func (r *RedisRefreshStore) ListTokens(ctx context.Context, cursor string, count
 func (r *RedisRefreshStore) ListTokensForUser(ctx context.Context, userID string, cursor string, count int) ([]*RefreshToken, string, error) {
 	ctx, span := r.startSpan(ctx, "ListTokensForUser")
 	defer span.End()
-	span.SetAttribute("storage.user_id", userID)
-	span.SetAttribute("storage.cursor", cursor)
-	span.SetAttribute("storage.count", count)
+	span.SetAttribute("user_id", userID)
+	span.SetAttribute("cursor", cursor)
+	span.SetAttribute("count", count)
 
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
@@ -935,7 +935,7 @@ func (r *RedisRefreshStore) ListTokensForUser(ctx context.Context, userID string
 
 	// ===== STEP 7: Log and Return =====
 	resultCount := len(tokens)
-	span.SetAttribute("storage.result_count", resultCount)
+	span.SetAttribute("result_count", resultCount)
 	span.SetStatus(tracing.StatusOK, "")
 	r.logger.Info("listTokensForUser: page returned", ctx,
 		"user_id", userID,
@@ -1246,9 +1246,9 @@ func (r *RedisRefreshStore) RevokeAllForUserAndAudience(ctx context.Context, use
 func (r *RedisRefreshStore) ListTokensForAudience(ctx context.Context, audience string, cursor string, count int) ([]*RefreshToken, string, error) {
 	ctx, span := r.startSpan(ctx, "ListTokensForAudience")
 	defer span.End()
-	span.SetAttribute("storage.audience", audience)
-	span.SetAttribute("storage.cursor", cursor)
-	span.SetAttribute("storage.count", count)
+	span.SetAttribute("audience", audience)
+	span.SetAttribute("cursor", cursor)
+	span.SetAttribute("count", count)
 
 	// ===== STEP 1: Check Context =====
 	if err := ctx.Err(); err != nil {
@@ -1309,7 +1309,7 @@ func (r *RedisRefreshStore) ListTokensForAudience(ctx context.Context, audience 
 
 	// ===== STEP 7: Log and Return =====
 	resultCount := len(tokens)
-	span.SetAttribute("storage.result_count", resultCount)
+	span.SetAttribute("result_count", resultCount)
 	span.SetStatus(tracing.StatusOK, "")
 	r.logger.Info("listTokensForAudience: page returned", ctx,
 		"audience", audience,

--- a/pkg/storage/redis_test.go
+++ b/pkg/storage/redis_test.go
@@ -255,7 +255,7 @@ var _ = Describe("RedisRefreshStore — Phase 10: Tracing", func() {
 	Context("Store — success path", func() {
 		It("should start a span named RedisRefreshStore.Store with storage.backend, token_id and StatusOK", func() {
 			mockTracer.EXPECT().Start(gomock.Any(), "RedisRefreshStore.Store").Return(ctx, mockSpan)
-			mockSpan.EXPECT().SetAttributes(map[string]any{"storage.backend": "redis", "storage.namespace": ""})
+			mockSpan.EXPECT().SetAttributes(map[string]any{"storage_backend": "redis", "namespace": ""})
 			mockSpan.EXPECT().SetAttribute("token_id", "trace-store-token")
 			mockSpan.EXPECT().SetStatus(tracing.StatusOK, "")
 			mockSpan.EXPECT().End()
@@ -267,7 +267,7 @@ var _ = Describe("RedisRefreshStore — Phase 10: Tracing", func() {
 	Context("Retrieve — error path", func() {
 		It("should call RecordError and StatusError when token is not found", func() {
 			mockTracer.EXPECT().Start(gomock.Any(), "RedisRefreshStore.Retrieve").Return(ctx, mockSpan)
-			mockSpan.EXPECT().SetAttributes(map[string]any{"storage.backend": "redis", "storage.namespace": ""})
+			mockSpan.EXPECT().SetAttributes(map[string]any{"storage_backend": "redis", "namespace": ""})
 			mockSpan.EXPECT().SetAttribute("token_id", "missing-trace-token")
 			mockSpan.EXPECT().RecordError(storage.ErrTokenNotFound)
 			mockSpan.EXPECT().SetStatus(tracing.StatusError, gomock.Any())

--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -280,7 +280,7 @@ func NewManager(config TokenManagerConfig) (*Manager, error) {
 // startSpan begins a new tracing span for the given Manager operation.
 func (m *Manager) startSpan(ctx context.Context, operation string) (context.Context, tracing.Span) {
 	ctx, span := m.tracer.Start(ctx, "TokenManager."+operation)
-	span.SetAttributes(map[string]any{"token.namespace": m.namespace})
+	span.SetAttributes(map[string]any{"namespace": m.namespace})
 	return ctx, span
 }
 
@@ -493,7 +493,7 @@ func (m *Manager) IssueAccessToken(ctx context.Context, userID string, opts ...I
 
 	audience := resolveAudience(m.audience, opts)
 	if !audienceEqual(audience, m.audience) {
-		span.SetAttribute("token.audience", strings.Join(audience, ","))
+		span.SetAttribute("audience", strings.Join(audience, ","))
 		m.logger.Info("issuing token with non-default audience", ctx, "audience", audience)
 	}
 
@@ -644,7 +644,7 @@ func (m *Manager) IssueAccessTokenWithClaims(ctx context.Context, userID string,
 
 	audience := resolveAudience(m.audience, opts)
 	if !audienceEqual(audience, m.audience) {
-		span.SetAttribute("token.audience", strings.Join(audience, ","))
+		span.SetAttribute("audience", strings.Join(audience, ","))
 		m.logger.Info("issuing token with non-default audience", ctx, "audience", audience)
 	}
 
@@ -805,7 +805,7 @@ func (m *Manager) IssueRefreshToken(ctx context.Context, userID string, opts ...
 
 	audience := resolveAudience(m.audience, opts)
 	if !audienceEqual(audience, m.audience) {
-		span.SetAttribute("token.audience", strings.Join(audience, ","))
+		span.SetAttribute("audience", strings.Join(audience, ","))
 		m.logger.Info("issuing token with non-default audience", ctx, "audience", audience)
 	}
 
@@ -934,7 +934,7 @@ func (m *Manager) IssueRefreshTokenWithClaims(ctx context.Context, userID string
 
 	audience := resolveAudience(m.audience, opts)
 	if !audienceEqual(audience, m.audience) {
-		span.SetAttribute("token.audience", strings.Join(audience, ","))
+		span.SetAttribute("audience", strings.Join(audience, ","))
 		m.logger.Info("issuing token with non-default audience", ctx, "audience", audience)
 	}
 
@@ -1066,7 +1066,7 @@ func (m *Manager) IssueTokenPair(ctx context.Context, userID string, opts ...Iss
 
 	audience := resolveAudience(m.audience, opts)
 	if !audienceEqual(audience, m.audience) {
-		span.SetAttribute("token.audience", strings.Join(audience, ","))
+		span.SetAttribute("audience", strings.Join(audience, ","))
 		m.logger.Info("issuing token with non-default audience", ctx, "audience", audience)
 	}
 
@@ -1251,7 +1251,7 @@ func (m *Manager) IssueTokenPairWithClaims(ctx context.Context, userID string, a
 
 	audience := resolveAudience(m.audience, opts)
 	if !audienceEqual(audience, m.audience) {
-		span.SetAttribute("token.audience", strings.Join(audience, ","))
+		span.SetAttribute("audience", strings.Join(audience, ","))
 		m.logger.Info("issuing token with non-default audience", ctx, "audience", audience)
 	}
 
@@ -2433,9 +2433,9 @@ func (m *Manager) CleanupExpiredTokens(ctx context.Context) (int, error) {
 func (m *Manager) ListTokens(ctx context.Context, cursor string, count int) ([]*storage.RefreshToken, string, error) {
 	ctx, span := m.startSpan(ctx, "ListTokens")
 	defer span.End()
-	span.SetAttribute("token.namespace", m.namespace)
-	span.SetAttribute("token.cursor", cursor)
-	span.SetAttribute("token.count", count)
+	span.SetAttribute("namespace", m.namespace)
+	span.SetAttribute("cursor", cursor)
+	span.SetAttribute("count", count)
 
 	start := time.Now()
 	errorType := "error"
@@ -2481,7 +2481,7 @@ func (m *Manager) ListTokens(ctx context.Context, cursor string, count int) ([]*
 
 	// ===== STEP 4: Record Success and Log =====
 	errorType = ""
-	span.SetAttribute("token.result_count", len(tokens))
+	span.SetAttribute("result_count", len(tokens))
 	span.SetStatus(tracing.StatusOK, "")
 	m.logger.Info("tokens listed", ctx,
 		"result_count", len(tokens),
@@ -2496,10 +2496,10 @@ func (m *Manager) ListTokens(ctx context.Context, cursor string, count int) ([]*
 func (m *Manager) ListTokensForUser(ctx context.Context, userID string, cursor string, count int) ([]*storage.RefreshToken, string, error) {
 	ctx, span := m.startSpan(ctx, "ListTokensForUser")
 	defer span.End()
-	span.SetAttribute("token.namespace", m.namespace)
-	span.SetAttribute("token.user_id", userID)
-	span.SetAttribute("token.cursor", cursor)
-	span.SetAttribute("token.count", count)
+	span.SetAttribute("namespace", m.namespace)
+	span.SetAttribute("user_id", userID)
+	span.SetAttribute("cursor", cursor)
+	span.SetAttribute("count", count)
 
 	start := time.Now()
 	errorType := "error"
@@ -2545,7 +2545,7 @@ func (m *Manager) ListTokensForUser(ctx context.Context, userID string, cursor s
 
 	// ===== STEP 4: Record Success and Log =====
 	errorType = ""
-	span.SetAttribute("token.result_count", len(tokens))
+	span.SetAttribute("result_count", len(tokens))
 	span.SetStatus(tracing.StatusOK, "")
 	m.logger.Info("tokens listed for user", ctx,
 		"user_id", userID,
@@ -2562,10 +2562,10 @@ func (m *Manager) ListTokensForUser(ctx context.Context, userID string, cursor s
 func (m *Manager) ListTokensForAudience(ctx context.Context, audience string, cursor string, count int) ([]*storage.RefreshToken, string, error) {
 	ctx, span := m.startSpan(ctx, "ListTokensForAudience")
 	defer span.End()
-	span.SetAttribute("token.namespace", m.namespace)
-	span.SetAttribute("token.audience", audience)
-	span.SetAttribute("token.cursor", cursor)
-	span.SetAttribute("token.count", count)
+	span.SetAttribute("namespace", m.namespace)
+	span.SetAttribute("audience", audience)
+	span.SetAttribute("cursor", cursor)
+	span.SetAttribute("count", count)
 
 	start := time.Now()
 	errorType := "error"
@@ -2611,7 +2611,7 @@ func (m *Manager) ListTokensForAudience(ctx context.Context, audience string, cu
 
 	// ===== STEP 4: Record Success and Log =====
 	errorType = ""
-	span.SetAttribute("token.result_count", len(tokens))
+	span.SetAttribute("result_count", len(tokens))
 	span.SetStatus(tracing.StatusOK, "")
 	m.logger.Info("tokens listed for audience", ctx,
 		"audience", audience,

--- a/pkg/tokens/manager_test.go
+++ b/pkg/tokens/manager_test.go
@@ -2758,7 +2758,7 @@ var _ = Describe("TokenManager — Phase N: Tracing", func() {
 			newTracingManager()
 
 			mockTracer.EXPECT().Start(gomock.Any(), gomock.Eq("TokenManager.IssueAccessToken")).Return(ctx, testSpan)
-			testSpan.EXPECT().SetAttributes(map[string]any{"token.namespace": ""})
+			testSpan.EXPECT().SetAttributes(map[string]any{"namespace": ""})
 			testSpan.EXPECT().SetAttribute("user_id", "tracing-user")
 			testSpan.EXPECT().SetAttribute("token_id", gomock.Any())
 			testSpan.EXPECT().SetStatus(tracing.StatusOK, "")
@@ -2781,7 +2781,7 @@ var _ = Describe("TokenManager — Phase N: Tracing", func() {
 			Expect(manager.Shutdown(shutdownCtx)).To(Succeed())
 
 			mockTracer.EXPECT().Start(gomock.Any(), gomock.Eq("TokenManager.IssueAccessToken")).Return(ctx, testSpan)
-			testSpan.EXPECT().SetAttributes(map[string]any{"token.namespace": ""})
+			testSpan.EXPECT().SetAttributes(map[string]any{"namespace": ""})
 			testSpan.EXPECT().SetAttribute("user_id", "stopped-user")
 			testSpan.EXPECT().RecordError(tokens.ErrManagerNotRunning)
 			testSpan.EXPECT().SetStatus(tracing.StatusError, gomock.Any())
@@ -2810,7 +2810,7 @@ var _ = Describe("TokenManager — Phase N: Tracing", func() {
 			mockTracer.EXPECT().Start(gomock.Any(), gomock.Eq("TokenManager.RefreshAccessToken")).Return(ctx, testSpan)
 			// IssueAccessToken is called internally — route to setupSpan to avoid expectation conflicts.
 			mockTracer.EXPECT().Start(gomock.Any(), gomock.Eq("TokenManager.IssueAccessToken")).Return(ctx, setupSpan)
-			testSpan.EXPECT().SetAttributes(map[string]any{"token.namespace": ""})
+			testSpan.EXPECT().SetAttributes(map[string]any{"namespace": ""})
 			testSpan.EXPECT().SetAttribute("token_id", refreshTok)
 			testSpan.EXPECT().SetStatus(tracing.StatusOK, "")
 			testSpan.EXPECT().End()
@@ -2825,7 +2825,7 @@ var _ = Describe("TokenManager — Phase N: Tracing", func() {
 			newTracingManager()
 
 			mockTracer.EXPECT().Start(gomock.Any(), gomock.Eq("TokenManager.ValidateAccessToken")).Return(ctx, testSpan)
-			testSpan.EXPECT().SetAttributes(map[string]any{"token.namespace": ""})
+			testSpan.EXPECT().SetAttributes(map[string]any{"namespace": ""})
 			testSpan.EXPECT().RecordError(tokens.ErrInvalidToken)
 			testSpan.EXPECT().SetStatus(tracing.StatusError, gomock.Any())
 			testSpan.EXPECT().End()
@@ -2840,7 +2840,7 @@ var _ = Describe("TokenManager — Phase N: Tracing", func() {
 			newTracingManager()
 
 			mockTracer.EXPECT().Start(gomock.Any(), gomock.Eq("TokenManager.IssueTokenPairWithClaims")).Return(ctx, testSpan)
-			testSpan.EXPECT().SetAttributes(map[string]any{"token.namespace": ""})
+			testSpan.EXPECT().SetAttributes(map[string]any{"namespace": ""})
 			testSpan.EXPECT().SetAttribute("user_id", "tracing-user")
 			testSpan.EXPECT().SetAttribute("token_id", gomock.Any())
 			testSpan.EXPECT().SetStatus(tracing.StatusOK, "")
@@ -2864,7 +2864,7 @@ var _ = Describe("TokenManager — Phase N: Tracing", func() {
 			Expect(manager.Shutdown(shutdownCtx)).To(Succeed())
 
 			mockTracer.EXPECT().Start(gomock.Any(), gomock.Eq("TokenManager.IssueTokenPairWithClaims")).Return(ctx, testSpan)
-			testSpan.EXPECT().SetAttributes(map[string]any{"token.namespace": ""})
+			testSpan.EXPECT().SetAttributes(map[string]any{"namespace": ""})
 			testSpan.EXPECT().SetAttribute("user_id", "stopped-user")
 			testSpan.EXPECT().RecordError(tokens.ErrManagerNotRunning)
 			testSpan.EXPECT().SetStatus(tracing.StatusError, gomock.Any())
@@ -2893,7 +2893,7 @@ var _ = Describe("TokenManager — Phase N: Tracing", func() {
 			mockTracer.EXPECT().Start(gomock.Any(), gomock.Eq("TokenManager.RefreshAccessTokenWithClaims")).Return(ctx, testSpan)
 			// IssueAccessTokenWithClaims is called internally — route to setupSpan to avoid expectation conflicts.
 			mockTracer.EXPECT().Start(gomock.Any(), gomock.Eq("TokenManager.IssueAccessTokenWithClaims")).Return(ctx, setupSpan)
-			testSpan.EXPECT().SetAttributes(map[string]any{"token.namespace": ""})
+			testSpan.EXPECT().SetAttributes(map[string]any{"namespace": ""})
 			testSpan.EXPECT().SetAttribute("token_id", refreshTok)
 			testSpan.EXPECT().SetStatus(tracing.StatusOK, "")
 			testSpan.EXPECT().End()
@@ -2913,7 +2913,7 @@ var _ = Describe("TokenManager — Phase N: Tracing", func() {
 			Expect(manager.Shutdown(shutdownCtx)).To(Succeed())
 
 			mockTracer.EXPECT().Start(gomock.Any(), gomock.Eq("TokenManager.RefreshAccessTokenWithClaims")).Return(ctx, testSpan)
-			testSpan.EXPECT().SetAttributes(map[string]any{"token.namespace": ""})
+			testSpan.EXPECT().SetAttributes(map[string]any{"namespace": ""})
 			testSpan.EXPECT().RecordError(tokens.ErrManagerNotRunning)
 			testSpan.EXPECT().SetStatus(tracing.StatusError, gomock.Any())
 			testSpan.EXPECT().End()

--- a/pkg/tracing/interface.go
+++ b/pkg/tracing/interface.go
@@ -73,8 +73,9 @@ type Span interface {
 
 	// SetAttribute adds a key-value attribute to the span.
 	//
-	// Attributes provide additional context about the operation.
-	// Common examples: user_id, token_id, operation type, etc.
+	// Attribute keys must use snake_case — e.g., user_id, token_id,
+	// storage_backend. See doc/ARCHITECTURE.md for the canonical
+	// per-component attribute list.
 	//
 	// The value can be string, int, int64, float64, or bool.
 	// Other types are converted to string via fmt.Sprintf.


### PR DESCRIPTION
## Summary

- Renames all dot-notation span attribute keys to `snake_case` across six components, locking the attribute API before v1.0.0
- Adds comprehensive per-component span attribute tables to `doc/ARCHITECTURE.md`
- Adds naming convention note to `SetAttribute` godoc in `pkg/tracing/interface.go`
- Removes stale `SpanOption` / `SpanKind` references from `ARCHITECTURE.md`

## Attribute renames

| Old key | New key |
|---|---|
| `token.namespace` / `key.namespace` / `storage.namespace` | `namespace` |
| `storage.backend` | `storage_backend` |
| `token.audience` / `storage.audience` | `audience` |
| `key.count` | `key_count` |
| `storage.cursor` / `token.cursor` | `cursor` |
| `storage.count` / `token.count` | `count` |
| `storage.result_count` / `token.result_count` | `result_count` |
| `storage.user_id` / `token.user_id` | `user_id` |

## Test plan

- [x] All dot-notation attribute strings removed (`grep -rn '"token\.\|"key\.\|"storage\.' pkg/` returns zero matches)
- [x] 885 unit specs pass under `-race`
- [x] 60 integration specs pass under `-race`
- [x] `golangci-lint` clean
- [x] `govulncheck` clean

Closes #193