### PR TITLE
feat: add PrometheusMetrics.MetricNames()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `PrometheusMetrics.MetricNames()` returns a map of all registered metric names to their help strings — enables programmatic dashboard generation and test assertions without hand-maintaining a metric name list.
+
 ### Breaking
 
 - Span attribute keys standardised to `snake_case` across all components. Operators with span-based dashboards or alert rules must update the following keys: `storage.backend` → `storage_backend`; `token.namespace` / `key.namespace` / `storage.namespace` → `namespace`; `token.audience` / `storage.audience` → `audience`; `key.count` → `key_count`; `storage.cursor` → `cursor`; `storage.count` → `count`; `storage.result_count` → `result_count`; `storage.user_id` → `user_id`. See `doc/ARCHITECTURE.md` for the canonical per-component attribute list.

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -34,6 +34,9 @@ type PrometheusMetrics struct {
 	// ===== Histograms =====
 	histograms   map[string]*prometheus.HistogramVec
 	histogramsMu sync.RWMutex
+
+	// ===== Metric Names =====
+	names map[string]string // name → help string; written once at construction, read-only after
 }
 
 // PrometheusConfig holds configuration for a PrometheusMetrics instance.
@@ -67,6 +70,7 @@ func NewPrometheusMetrics(config PrometheusConfig) *PrometheusMetrics {
 		counters:   make(map[string]*prometheus.CounterVec),
 		gauges:     make(map[string]*prometheus.GaugeVec),
 		histograms: make(map[string]*prometheus.HistogramVec),
+		names:      make(map[string]string),
 	}
 
 	// ===== STEP 3: Pre-register All Metrics =====
@@ -177,6 +181,7 @@ func (pm *PrometheusMetrics) registerCounter(namespace, name, help string, label
 	)
 	pm.registry.MustRegister(counter)
 	pm.counters[namespace+"_"+name] = counter
+	pm.names[namespace+"_"+name] = help
 }
 
 // registerGauge creates a GaugeVec with the given namespace, name, help
@@ -193,6 +198,7 @@ func (pm *PrometheusMetrics) registerGauge(namespace, name, help string, labels 
 	)
 	pm.registry.MustRegister(gauge)
 	pm.gauges[namespace+"_"+name] = gauge
+	pm.names[namespace+"_"+name] = help
 }
 
 // registerHistogram creates a HistogramVec with the given namespace, name,
@@ -210,6 +216,7 @@ func (pm *PrometheusMetrics) registerHistogram(namespace, name, help string, lab
 	)
 	pm.registry.MustRegister(histogram)
 	pm.histograms[namespace+"_"+name] = histogram
+	pm.names[namespace+"_"+name] = help
 }
 
 // IncrementCounter increments the named counter by 1. It is a convenience
@@ -320,4 +327,14 @@ func (pm *PrometheusMetrics) Handler() http.Handler {
 // families in tests.
 func (pm *PrometheusMetrics) Registry() *prometheus.Registry {
 	return pm.registry
+}
+
+// MetricNames returns a map of every registered metric name to its help string.
+// Returns a defensive copy — mutations do not affect the registry.
+func (pm *PrometheusMetrics) MetricNames() map[string]string {
+	result := make(map[string]string, len(pm.names))
+	for k, v := range pm.names {
+		result[k] = v
+	}
+	return result
 }

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -907,4 +907,33 @@ var _ = Describe("Prometheus", func() {
 			})
 		})
 	})
+
+	// ===== PHASE 10: MetricNames =====
+	Describe("Phase 10: MetricNames", func() {
+		It("should return a non-empty map after construction", func() {
+			names := pm.MetricNames()
+			Expect(names).NotTo(BeEmpty())
+		})
+
+		It("should contain all 18 registered metrics with correct help strings", func() {
+			names := pm.MetricNames()
+			Expect(names).To(HaveLen(18))
+
+			Expect(names).To(HaveKeyWithValue("jwtauth_tokens_issued_total", "Total number of tokens issued"))
+			Expect(names).To(HaveKeyWithValue("jwtauth_tokens_validated_total", "Total number of tokens validated"))
+			Expect(names).To(HaveKeyWithValue("jwtauth_operation_duration_seconds", "Duration of operations in seconds"))
+			Expect(names).To(HaveKeyWithValue("jwtauth_storage_operations_total", "Total number of storage operations"))
+			Expect(names).To(HaveKeyWithValue("jwtauth_storage_tokens_count", "Number of tokens in storage"))
+			Expect(names).To(HaveKeyWithValue("jwtauth_keystore_operations_total", "Total number of key store operations"))
+			Expect(names).To(HaveKeyWithValue("jwtauth_key_active_versions_count", "Number of active key versions"))
+		})
+
+		It("should return a defensive copy — mutations do not affect the registry", func() {
+			first := pm.MetricNames()
+			first["injected_key"] = "injected_help"
+
+			second := pm.MetricNames()
+			Expect(second).NotTo(HaveKey("injected_key"))
+		})
+	})
 })


### PR DESCRIPTION
## Summary

- Adds `MetricNames() map[string]string` to `*PrometheusMetrics` — returns every registered metric name mapped to its help string
- Built at construction time by capturing the `help` argument in each `registerCounter` / `registerGauge` / `registerHistogram` helper; zero overhead at call time
- Returns a defensive copy — mutations do not affect the registry
- No interface change, no mock regeneration — this is operator tooling, not a contract every `Metrics` backend needs

## Test plan

- [x] Phase 10 specs in `pkg/metrics/prometheus_test.go`: non-empty map, `HaveLen(18)` with representative sample assertions across tokens/storage/keys, defensive copy
- [x] 888 unit specs pass under `-race`
- [x] 60 integration specs pass under `-race`
- [x] `golangci-lint` clean

Closes #194