### PR TITLE
feat: add explicit Namespace field to RedisKeyStoreConfig and RedisRefreshStoreConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `RedisKeyStoreConfig.Namespace` and `RedisRefreshStoreConfig.Namespace` — explicit observability namespace field that decouples log fields, span attributes, and metric labels from the `KeyPrefix` storage routing field. Empty value falls back to `KeyPrefix` for backward compatibility.
 - `PrometheusMetrics.MetricNames()` returns a map of all registered metric names to their help strings — enables programmatic dashboard generation and test assertions without hand-maintaining a metric name list.
 
 ### Breaking

--- a/doc/adr/007-namespace-consistency-contract.md
+++ b/doc/adr/007-namespace-consistency-contract.md
@@ -71,3 +71,21 @@ When non-empty:
 An empty string preserves prior behavior exactly. With this change, all six components tracked
 in ADR-007 are fully wired: KeyManager, TokenManager, DiskKeyStore, RedisKeyStore,
 RedisRefreshStore, and MemoryRefreshStore (single-tenant; namespace="" by design).
+
+## Addendum — RedisKeyStore and RedisRefreshStore explicit Namespace field (issue #241, 2026-06-01)
+
+Both `RedisKeyStoreConfig` and `RedisRefreshStoreConfig` previously used `KeyPrefix` for dual
+roles: storage routing (Redis key prefix) and observability labeling (log fields, span
+attributes, metric labels). An operator who wanted a distinct observability namespace was forced
+to change the Redis key prefix too, conflating two independent concerns.
+
+An explicit `Namespace string` field has been added to both configs, following the pattern
+established for `DiskKeyStoreConfig` in issue #184. When `Namespace` is set it is used
+exclusively for observability output; `KeyPrefix` continues to drive storage routing. When
+`Namespace` is empty, the store falls back to `KeyPrefix` for observability — preserving
+backward compatibility for existing deployments.
+
+With this addendum, all four store types have clean separation between storage and observability
+namespace axes: `DiskKeyStore` (Namespace only), `RedisKeyStore` (KeyPrefix + Namespace),
+`RedisRefreshStore` (KeyPrefix + Namespace), and `MemoryRefreshStore` (single-tenant;
+namespace="" by design).

--- a/pkg/keys/redis.go
+++ b/pkg/keys/redis.go
@@ -26,6 +26,7 @@ import (
 type RedisKeyStoreConfig struct {
 	Client    *redis.Client   // Required; must not be nil.
 	KeyPrefix string          // Optional; prepended to all Redis keys; empty preserves current behavior.
+	Namespace string          // Optional; scopes log fields, span attributes, and metric labels. Defaults to KeyPrefix when empty.
 	Logger    logging.Logger  // Optional; nil defaults to NoOpLogger.
 	Metrics   metrics.Metrics // Optional; nil defaults to NoOpMetrics.
 	Tracer    tracing.Tracer  // Optional; nil defaults to NoOpTracer.
@@ -52,7 +53,7 @@ type RedisKeyStore struct {
 	client *redis.Client // Thread-safe Redis client
 
 	// ===== Key Prefixes =====
-	namespace  string // = cfg.KeyPrefix; returned by Namespace()
+	namespace  string // observability label; cfg.Namespace when set, else cfg.KeyPrefix
 	pemPrefix  string // = cfg.KeyPrefix + keyPEMPrefix;  applied to all PEM keys
 	metaPrefix string // = cfg.KeyPrefix + keyMetaPrefix; applied to all metadata keys
 
@@ -82,14 +83,19 @@ func NewRedisKeyStore(cfg RedisKeyStoreConfig) (*RedisKeyStore, error) {
 	if cfg.Tracer == nil {
 		cfg.Tracer = defaults.Tracer
 	}
-	if cfg.KeyPrefix != "" {
-		cfg.Logger = cfg.Logger.With("namespace", cfg.KeyPrefix)
+	// ===== STEP 3: Resolve Observability Namespace =====
+	namespace := cfg.Namespace
+	if namespace == "" {
+		namespace = cfg.KeyPrefix
+	}
+	if namespace != "" {
+		cfg.Logger = cfg.Logger.With("namespace", namespace)
 	}
 
-	// ===== STEP 3: Return Initialized Store =====
+	// ===== STEP 4: Return Initialized Store =====
 	return &RedisKeyStore{
 		client:     cfg.Client,
-		namespace:  cfg.KeyPrefix,
+		namespace:  namespace,
 		pemPrefix:  cfg.KeyPrefix + keyPEMPrefix,
 		metaPrefix: cfg.KeyPrefix + keyMetaPrefix,
 		logger:     cfg.Logger,
@@ -99,8 +105,8 @@ func NewRedisKeyStore(cfg RedisKeyStoreConfig) (*RedisKeyStore, error) {
 	}, nil
 }
 
-// Namespace returns the KeyPrefix this store was configured with. An empty
-// string indicates an unscoped (single-tenant) deployment.
+// Namespace returns the observability namespace this store was configured with.
+// An empty string indicates an unscoped (single-tenant) deployment.
 func (r *RedisKeyStore) Namespace() string { return r.namespace }
 
 // startSpan starts a new span for the given operation name, pre-seeded with

--- a/pkg/keys/redis_test.go
+++ b/pkg/keys/redis_test.go
@@ -98,6 +98,18 @@ var _ = Describe("RedisKeyStore", func() {
 			})
 		})
 
+		Context("with an explicit Namespace field", func() {
+			It("should return Namespace() equal to the Namespace field, not KeyPrefix", func() {
+				store, err := keys.NewRedisKeyStore(keys.RedisKeyStoreConfig{
+					Client:    client,
+					KeyPrefix: "storage:",
+					Namespace: "obs-ns",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(store.Namespace()).To(Equal("obs-ns"))
+			})
+		})
+
 		Context("with a nil client", func() {
 			It("should return ErrNilRedisClient", func() {
 				_, err := keys.NewRedisKeyStore(keys.RedisKeyStoreConfig{})
@@ -625,10 +637,39 @@ var _ = Describe("RedisKeyStore", func() {
 				Expect(func() { _ = rs.Delete(ctx, testKeyA) }).NotTo(Panic())
 			})
 		})
+
+		Context("Namespace field takes precedence over KeyPrefix in metric labels", func() {
+			It("should emit namespace label from Namespace field, not KeyPrefix", func() {
+				mockM.EXPECT().IncrementCounter("jwtauth_keystore_operations_total", map[string]string{
+					"operation":       "save",
+					"status":          "success",
+					"error_type":      "",
+					"storage_backend": "redis",
+					"namespace":       "obs-ns",
+				})
+				mockM.EXPECT().RecordDuration("jwtauth_keystore_operation_duration_seconds", gomock.Any(), map[string]string{
+					"operation":       "save",
+					"storage_backend": "redis",
+					"namespace":       "obs-ns",
+				})
+
+				store, err := keys.NewRedisKeyStore(keys.RedisKeyStoreConfig{
+					Client:    client,
+					KeyPrefix: "storage:",
+					Namespace: "obs-ns",
+					Metrics:   mockM,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				key := newTestKey()
+				metadata := keys.KeyMetadata{ID: testKeyA, CreatedAt: time.Now()}
+				Expect(store.Save(ctx, testKeyA, key, metadata)).To(Succeed())
+			})
+		})
 	})
 
-	// ===== PHASE 11: KeyPrefix Namespace Isolation =====
-	Describe("Phase 11: KeyPrefix Namespace Isolation", func() {
+	// ===== PHASE 11: KeyPrefix and Namespace Isolation =====
+	Describe("Phase 11: KeyPrefix and Namespace Isolation", func() {
 		Context("with a non-empty KeyPrefix", func() {
 			It("should store all keys under the configured prefix", func() {
 				store, err := keys.NewRedisKeyStore(keys.RedisKeyStoreConfig{
@@ -728,6 +769,28 @@ var _ = Describe("RedisKeyStore", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
+
+		Context("with both KeyPrefix and Namespace set", func() {
+			It("should use KeyPrefix for Redis key routing and Namespace for observability", func() {
+				store, err := keys.NewRedisKeyStore(keys.RedisKeyStoreConfig{
+					Client:    client,
+					KeyPrefix: "ks:tenant-a:",
+					Namespace: "tenant-a-obs",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(store.Namespace()).To(Equal("tenant-a-obs"))
+
+				key := newTestKey()
+				metadata := keys.KeyMetadata{ID: testKeyA, CreatedAt: time.Now()}
+				Expect(store.Save(ctx, testKeyA, key, metadata)).To(Succeed())
+
+				storedKeys, err := client.Keys(ctx, "*").Result()
+				Expect(err).NotTo(HaveOccurred())
+				for _, k := range storedKeys {
+					Expect(k).To(HavePrefix("ks:tenant-a:"))
+				}
+			})
+		})
 	})
 
 	// ===== PHASE 10: Tracing =====
@@ -776,6 +839,28 @@ var _ = Describe("RedisKeyStore", func() {
 
 				_, _, err := tracingStore.LoadKey(ctx, testKeyMissing)
 				Expect(err).To(MatchError(keys.ErrKeyStoreKeyNotFound))
+			})
+		})
+
+		Context("Namespace field takes precedence over KeyPrefix in span attributes", func() {
+			It("should set namespace span attribute from Namespace field, not KeyPrefix", func() {
+				store, err := keys.NewRedisKeyStore(keys.RedisKeyStoreConfig{
+					Client:    client,
+					KeyPrefix: "storage:",
+					Namespace: "obs-ns",
+					Tracer:    mockTracer,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				mockTracer.EXPECT().Start(gomock.Any(), "RedisKeyStore.Save").Return(ctx, mockSpan)
+				mockSpan.EXPECT().SetAttributes(map[string]any{"storage_backend": "redis", "namespace": "obs-ns"})
+				mockSpan.EXPECT().SetAttribute("key_id", testKeyA)
+				mockSpan.EXPECT().SetStatus(tracing.StatusOK, "")
+				mockSpan.EXPECT().End()
+
+				key := newTestKey()
+				metadata := keys.KeyMetadata{ID: testKeyA, CreatedAt: time.Now()}
+				Expect(store.Save(ctx, testKeyA, key, metadata)).To(Succeed())
 			})
 		})
 	})

--- a/pkg/storage/redis.go
+++ b/pkg/storage/redis.go
@@ -24,6 +24,7 @@ import (
 type RedisRefreshStoreConfig struct {
 	Client    *redis.Client   // Required. Redis client used for all operations.
 	KeyPrefix string          // Optional; prepended to all Redis keys; empty preserves current behavior.
+	Namespace string          // Optional; scopes log fields, span attributes, and metric labels. Defaults to KeyPrefix when empty.
 	Logger    logging.Logger  // Optional; nil defaults to NoOpLogger.
 	Metrics   metrics.Metrics // Optional; nil defaults to NoOpMetrics.
 	Tracer    tracing.Tracer  // Optional; nil defaults to NoOpTracer.
@@ -51,7 +52,7 @@ type RedisRefreshStore struct {
 	client *redis.Client // Redis client; internally thread-safe
 
 	// ===== Key Prefixes =====
-	namespace            string // = cfg.KeyPrefix; returned by Namespace()
+	namespace            string // observability label; cfg.Namespace when set, else cfg.KeyPrefix
 	tokenPrefix          string // = cfg.KeyPrefix + tokenKeyPrefix;         applied to all token hash keys
 	userSetPrefix        string // = cfg.KeyPrefix + userSetKeyPrefix;        applied to all user-set keys
 	audienceSetPrefix    string // = cfg.KeyPrefix + audienceSetKeyPrefix;    applied to audience-scoped index sets
@@ -83,13 +84,18 @@ func NewRedisRefreshStore(cfg RedisRefreshStoreConfig) (*RedisRefreshStore, erro
 	if cfg.Tracer == nil {
 		cfg.Tracer = defaults.Tracer
 	}
-	if cfg.KeyPrefix != "" {
-		cfg.Logger = cfg.Logger.With("namespace", cfg.KeyPrefix)
+	// ===== Resolve Observability Namespace =====
+	namespace := cfg.Namespace
+	if namespace == "" {
+		namespace = cfg.KeyPrefix
+	}
+	if namespace != "" {
+		cfg.Logger = cfg.Logger.With("namespace", namespace)
 	}
 
 	return &RedisRefreshStore{
 		client:               cfg.Client,
-		namespace:            cfg.KeyPrefix,
+		namespace:            namespace,
 		tokenPrefix:          cfg.KeyPrefix + tokenKeyPrefix,
 		userSetPrefix:        cfg.KeyPrefix + userSetKeyPrefix,
 		audienceSetPrefix:    cfg.KeyPrefix + audienceSetKeyPrefix,
@@ -101,8 +107,8 @@ func NewRedisRefreshStore(cfg RedisRefreshStoreConfig) (*RedisRefreshStore, erro
 	}, nil
 }
 
-// Namespace returns the KeyPrefix this store was configured with. An empty
-// string indicates an unscoped (single-tenant) deployment.
+// Namespace returns the observability namespace this store was configured with.
+// An empty string indicates an unscoped (single-tenant) deployment.
 func (r *RedisRefreshStore) Namespace() string { return r.namespace }
 
 // startSpan starts a new span for the given operation name, pre-seeded with

--- a/pkg/storage/redis_test.go
+++ b/pkg/storage/redis_test.go
@@ -110,10 +110,20 @@ var _ = Describe("RedisRefreshStore — Constructor", func() {
 		ctx := context.Background()
 		Expect(store.Store(ctx, "tracer-token", "tracer-user", nil, time.Now().Add(time.Hour), nil)).To(Succeed())
 	})
+
+	It("should return Namespace() equal to the Namespace field, not KeyPrefix", func() {
+		store, err := storage.NewRedisRefreshStore(storage.RedisRefreshStoreConfig{
+			Client:    client,
+			KeyPrefix: "storage:",
+			Namespace: "obs-ns",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(store.Namespace()).To(Equal("obs-ns"))
+	})
 })
 
-// ===== PHASE 11: KeyPrefix Namespace Isolation =====
-var _ = Describe("RedisRefreshStore — Phase 11: KeyPrefix Namespace Isolation", func() {
+// ===== PHASE 11: KeyPrefix and Namespace Isolation =====
+var _ = Describe("RedisRefreshStore — Phase 11: KeyPrefix and Namespace Isolation", func() {
 	var (
 		mr  *miniredis.Miniredis
 		ctx context.Context
@@ -216,6 +226,28 @@ var _ = Describe("RedisRefreshStore — Phase 11: KeyPrefix Namespace Isolation"
 			Expect(removed).To(Equal(0))
 		})
 	})
+
+	Context("with both KeyPrefix and Namespace set", func() {
+		It("should use KeyPrefix for Redis key routing and Namespace for observability", func() {
+			client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+			store, err := storage.NewRedisRefreshStore(storage.RedisRefreshStoreConfig{
+				Client:    client,
+				KeyPrefix: "tokens:tenant-a:",
+				Namespace: "tenant-a-obs",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(store.Namespace()).To(Equal("tenant-a-obs"))
+
+			Expect(store.Store(ctx, "tok1", "user1", nil, time.Now().Add(time.Hour), nil)).To(Succeed())
+
+			rawClient := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+			storedKeys, err := rawClient.Keys(ctx, "*").Result()
+			Expect(err).NotTo(HaveOccurred())
+			for _, k := range storedKeys {
+				Expect(k).To(HavePrefix("tokens:tenant-a:"))
+			}
+		})
+	})
 })
 
 // ===== PHASE 10: Tracing =====
@@ -275,6 +307,32 @@ var _ = Describe("RedisRefreshStore — Phase 10: Tracing", func() {
 
 			_, err := tracingStore.Retrieve(ctx, "missing-trace-token")
 			Expect(err).To(MatchError(storage.ErrTokenNotFound))
+		})
+	})
+
+	Context("Namespace field takes precedence over KeyPrefix in span attributes", func() {
+		It("should set namespace span attribute from Namespace field, not KeyPrefix", func() {
+			var err error
+			localMr, err := miniredis.Run()
+			Expect(err).NotTo(HaveOccurred())
+			defer localMr.Close()
+
+			client := redis.NewClient(&redis.Options{Addr: localMr.Addr()})
+			store, err := storage.NewRedisRefreshStore(storage.RedisRefreshStoreConfig{
+				Client:    client,
+				KeyPrefix: "storage:",
+				Namespace: "obs-ns",
+				Tracer:    mockTracer,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			mockTracer.EXPECT().Start(gomock.Any(), "RedisRefreshStore.Store").Return(ctx, mockSpan)
+			mockSpan.EXPECT().SetAttributes(map[string]any{"storage_backend": "redis", "namespace": "obs-ns"})
+			mockSpan.EXPECT().SetAttribute("token_id", "trace-ns-token")
+			mockSpan.EXPECT().SetStatus(tracing.StatusOK, "")
+			mockSpan.EXPECT().End()
+
+			Expect(store.Store(ctx, "trace-ns-token", "user1", nil, time.Now().Add(time.Hour), nil)).To(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
## Summary

Closes #241

Both `RedisKeyStoreConfig` and `RedisRefreshStoreConfig` previously used `KeyPrefix` for dual purposes — Redis key routing and observability labeling. An operator who wanted a distinct observability namespace was forced to change the Redis key prefix too, conflating two independent concerns.

This PR adds an explicit `Namespace string` field to both configs, following the pattern established for `DiskKeyStoreConfig` in #184.

## Changes

- `RedisKeyStoreConfig.Namespace` — scopes log fields, span attributes, and metric labels; falls back to `KeyPrefix` when empty
- `RedisRefreshStoreConfig.Namespace` — same semantics
- `KeyPrefix` continues to control Redis key routing exclusively — no storage behavior changes
- `Namespace()` method doc comments updated on both store types
- ADR-007 addendum documenting the separation between `KeyPrefix` (storage) and `Namespace` (observability) across all four store types
- `CHANGELOG.md` `### Added` entry

## Test plan

- [x] Phase 1 spec: `store.Namespace()` returns `Namespace` field value, not `KeyPrefix`, when both are set (both stores)
- [x] Phase 9 spec: metric labels carry `Namespace` value, not `KeyPrefix` (RedisKeyStore)
- [x] Phase 10 spec: span attributes carry `Namespace` value, not `KeyPrefix` (both stores)
- [x] Phase 11 spec: Redis keys still use `KeyPrefix` prefix when `Namespace` is set to a different value (both stores)
- [x] Backward compat: empty `Namespace` falls back to `KeyPrefix` — existing deployments require no change
- [x] `./run-ci-locally.sh` — 895 unit + 60 integration specs, all passing under `-race`