### PR TITLE
feat: expand TokenManager interface to full token lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Breaking
+
+- `tokens.TokenManager` interface expanded with 10 additional methods covering
+  issuance variants (`IssueAccessToken`, `IssueAccessTokenWithClaims`,
+  `IssueRefreshToken`, `IssueRefreshTokenWithClaims`, `IssueTokenPair`,
+  `RefreshAccessToken`) and the operational path (`CleanupExpiredTokens`,
+  `ListTokens`, `ListTokensForUser`, `ListTokensForAudience`). Consumers that
+  use `TokenManager` as a dependency type are unaffected. Direct implementors
+  (hand-written test doubles) must add the new method stubs. See #258.
+
 ---
 
 ## [v0.7.1] — 2026-05-28

--- a/pkg/tokens/interface.go
+++ b/pkg/tokens/interface.go
@@ -8,22 +8,43 @@ import (
 	"context"
 
 	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/aetomala/jwtauth/pkg/storage"
 )
 
-// TokenManager defines the token lifecycle operations exposed by Manager.
+// TokenManager defines the full token lifecycle operations exposed by Manager.
 // Consumers may depend on this interface rather than the concrete type,
 // enabling service-layer unit testing without a running key store or
 // storage backend. All methods are safe for concurrent use.
 type TokenManager interface {
+	// ===== Issuance =====
+	IssueAccessToken(ctx context.Context, userID string, opts ...IssueOption) (string, error)
+	IssueAccessTokenWithClaims(ctx context.Context, userID string, claims CustomClaims, opts ...IssueOption) (string, error)
+	IssueRefreshToken(ctx context.Context, userID string, opts ...IssueOption) (string, error)
+	IssueRefreshTokenWithClaims(ctx context.Context, userID string, claims CustomClaims, opts ...IssueOption) (string, error)
+	IssueTokenPair(ctx context.Context, userID string, opts ...IssueOption) (string, string, error)
 	IssueTokenPairWithClaims(ctx context.Context, userID string, accessClaims CustomClaims, refreshClaims CustomClaims, opts ...IssueOption) (string, string, error)
-	RefreshAccessTokenWithClaims(ctx context.Context, refreshToken string, claims CustomClaims) (string, error)
+
+	// ===== Validation and Refresh =====
 	ValidateAccessToken(ctx context.Context, tokenString string) (*jwt.RegisteredClaims, error)
 	ValidateAccessTokenWithClaims(ctx context.Context, tokenString string) (*jwt.RegisteredClaims, map[string]interface{}, error)
+	RefreshAccessToken(ctx context.Context, refreshToken string) (string, error)
+	RefreshAccessTokenWithClaims(ctx context.Context, refreshToken string, claims CustomClaims) (string, error)
+
+	// ===== Introspection =====
 	IntrospectToken(ctx context.Context, token string) (*TokenMetadata, error)
+
+	// ===== Revocation =====
 	RevokeRefreshToken(ctx context.Context, tokenID string) error
 	RevokeAllUserTokens(ctx context.Context, userID string) error
 	RevokeAllForAudience(ctx context.Context, audience string) error
 	RevokeAllForUserAndAudience(ctx context.Context, userID, audience string) error
+
+	// ===== Operational =====
+	CleanupExpiredTokens(ctx context.Context) (int, error)
+	ListTokens(ctx context.Context, cursor string, count int) ([]*storage.RefreshToken, string, error)
+	ListTokensForUser(ctx context.Context, userID string, cursor string, count int) ([]*storage.RefreshToken, string, error)
+	ListTokensForAudience(ctx context.Context, audience string, cursor string, count int) ([]*storage.RefreshToken, string, error)
 }
 
 // Compile-time assertion: Manager must satisfy TokenManager.


### PR DESCRIPTION
## Summary

- Expands `tokens.TokenManager` to cover all operations already implemented on the concrete `*Manager` type
- Adds 6 issuance variants (`IssueAccessToken`, `IssueAccessTokenWithClaims`, `IssueRefreshToken`, `IssueRefreshTokenWithClaims`, `IssueTokenPair`, `RefreshAccessToken`) and 4 operational methods (`CleanupExpiredTokens`, `ListTokens`, `ListTokensForUser`, `ListTokensForAudience`)
- Only `interface.go` changes — compile-time assertion and all implementations on `*Manager` are unchanged

## Breaking change

Direct implementors of `TokenManager` (hand-written test doubles) must add stubs for the 10 new methods. Consumers that depend on the interface type are unaffected.

## Test plan

- [x] `go build ./...` — compile-time assertion passes
- [x] `./run-ci-locally.sh` — 885 unit + 60 integration specs pass under `-race`

Closes #258