### PR TITLE
chore: enforce example module isolation and go directive floor in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,6 +31,9 @@ jobs:
       - name: go vet
         run: go vet ./...
 
+      - name: Check Go constraints
+        run: bash scripts/check-go-constraints.sh
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Chore
+
+- Add `scripts/check-go-constraints.sh` and wire it into CI lint job and `run-ci-locally.sh`;
+  enforces example module isolation (every example directory must have its own `go.mod`) and
+  asserts the root `go` directive does not exceed the `./pkg/...` floor (`1.25.0`) — closes #265
+
 ---
 
 ## [v1.0.0] — 2026-06-03

--- a/run-ci-locally.sh
+++ b/run-ci-locally.sh
@@ -36,6 +36,7 @@ run_test() {
 # Lint Job
 echo -e "\n${YELLOW}====== LINT JOB ======${NC}"
 run_test "go vet" "go vet ./..."
+run_test "go constraints" "bash scripts/check-go-constraints.sh"
 run_test "golangci-lint" "golangci-lint run ./..."
 run_test "govulncheck (library)" "govulncheck ./pkg/..."
 

--- a/scripts/check-go-constraints.sh
+++ b/scripts/check-go-constraints.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Validates two Go module constraints for jwtauth:
+#   1. Every example module directory contains a go.mod (prevents root module contamination).
+#   2. The root go directive does not exceed the minimum version required by ./pkg/... dependencies.
+#
+# GO_FLOOR is the single source of truth. Bumping it requires an intentional, documented
+# change tied to a dependency in ./pkg/... that genuinely requires a higher Go version.
+set -euo pipefail
+
+GO_FLOOR="1.25.0"  # Set by go.opentelemetry.io/otel v1.43.0; do not raise without updating this comment.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+ERRORS=0
+
+# ===== CHECK 1: Every example module directory must have its own go.mod =====
+echo "Checking example module isolation..."
+while IFS= read -r mainfile; do
+    dir="$(dirname "$mainfile")"
+    if [[ ! -f "$dir/go.mod" ]]; then
+        echo "  FAIL: $dir has Go files but no go.mod — add one to isolate it from the root module"
+        ERRORS=$((ERRORS + 1))
+    fi
+done < <(find examples/ -name "main.go" | sort)
+
+if [[ $ERRORS -eq 0 ]]; then
+    echo "  OK: all example directories are isolated modules"
+fi
+
+# ===== CHECK 2: Root go directive must not exceed the floor =====
+echo "Checking root go directive floor..."
+current=$(grep '^go ' go.mod | awk '{print $2}')
+if [[ "$(printf '%s\n' "$GO_FLOOR" "$current" | sort -V | tail -1)" != "$GO_FLOOR" ]]; then
+    echo "  FAIL: root go directive is $current, exceeds floor $GO_FLOOR"
+    echo "        Raising the floor requires an intentional, documented change — update GO_FLOOR"
+    echo "        in scripts/check-go-constraints.sh and note which ./pkg/... dependency requires it."
+    ERRORS=$((ERRORS + 1))
+else
+    echo "  OK: root go directive ($current) is within floor ($GO_FLOOR)"
+fi
+
+if [[ $ERRORS -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Closes #265

Adds `scripts/check-go-constraints.sh` and wires it into both the CI lint job and `run-ci-locally.sh` to close two structural gaps that allow the root `go` directive to be silently raised.

**Check 1 — example module isolation**: walks `examples/` for any directory containing a `main.go` and fails if that directory lacks a `go.mod`. Using `main.go` as the anchor covers both flat examples (`examples/chi-example/`) and nested ones (`examples/telemetry/otlp/`) without a fixed-depth glob. This prevents a repeat of the PR #209 / `examples/correlation-example/` incident.

**Check 2 — root go directive floor**: extracts the `go` directive from root `go.mod` and compares it against `GO_FLOOR="1.25.0"` (set by `go.opentelemetry.io/otel v1.43.0`) using `sort -V`. The floor is defined once in the script with an inline comment identifying the dependency; raising it requires editing one file.

Both checks pass against the current state (14 examples all have `go.mod`, root is `go 1.25.0`).

## Test plan

- [x] `bash scripts/check-go-constraints.sh` exits 0 on current state
- [x] Temporarily removing an example's `go.mod` causes exit 1 with a clear message
- [x] Temporarily changing root `go.mod` to `go 1.26.0` causes exit 1 with a clear message
- [x] CI green on this PR