### PR TITLE
docs: add Ecosystem section linking token-engine to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ All notable changes to this project will be documented in this file.
   enforces example module isolation (every example directory must have its own `go.mod`) and
   asserts the root `go` directive does not exceed the `./pkg/...` floor (`1.25.0`) — closes #265
 
+### Documentation
+
+- Add `## Ecosystem` section to README linking token-engine, the official gRPC service
+  wrapper built on jwtauth — closes #266
+
 ---
 
 ## [v1.0.0] — 2026-06-03

--- a/README.md
+++ b/README.md
@@ -1218,6 +1218,26 @@ The full token lifecycle is implemented and the API is stable. Highlights:
 ### v1.1.0 (Planned)
 - PostgreSQL `RefreshStore` implementation — durable, transactional token storage for deployments that already operate a PostgreSQL cluster and want to avoid a Redis dependency
 
+## Ecosystem
+
+### token-engine — Official gRPC Service Wrapper
+
+[**token-engine**](https://github.com/aetomala/token-engine) is a production-grade gRPC service built on top of jwtauth. It adds a network transport layer and operational infrastructure for teams that want token lifecycle management exposed as a standalone service rather than embedded in their Go application:
+
+- Six RPCs covering issuance, refresh, and revocation (including audience- and user-scoped bulk revocation)
+- mTLS (TLS 1.3 minimum) or API key authentication
+- Multi-tenant support with Redis-backed token and key stores
+- OpenTelemetry tracing, Prometheus metrics, and structured logging with correlation IDs
+- Health probes, JWKS endpoint, and Docker Hub images (`linux/amd64` + `linux/arm64`)
+
+**When to use token-engine vs. jwtauth directly:**
+
+| Scenario | Use |
+|---|---|
+| Embedding token management inside a Go application | `jwtauth` (this library) |
+| Exposing token management as a standalone service over gRPC | [token-engine](https://github.com/aetomala/token-engine) |
+| Polyglot environment — clients are not written in Go | [token-engine](https://github.com/aetomala/token-engine) |
+
 ## Architecture
 
 This library follows SOLID principles and clean architecture patterns. For detailed design decisions, dependency inversion patterns, and component architecture, see:


### PR DESCRIPTION
## Summary

Closes #266

Adds a `## Ecosystem` section to README.md, inserted between `## Roadmap` and `## Architecture`. The section formally acknowledges token-engine as the official gRPC service wrapper built on top of jwtauth, with a summary of what it adds and a decision table to guide readers toward the right tool for their use case.

**Changes:**
- `README.md` — new `## Ecosystem` section with `### token-engine — Official gRPC Service Wrapper` subsection and a two-column decision table
- `CHANGELOG.md` — `### Documentation` entry under `[Unreleased]`

## Test plan

- [x] `grep -n "Ecosystem" README.md` confirms section at line 1221 (between Roadmap and Architecture)
- [x] `grep -n "token-engine" README.md` confirms link appears in body and decision table
- [x] `grep -n "Documentation" CHANGELOG.md` confirms entry under `[Unreleased]`
- [ ] Visual review: section renders cleanly, table has two columns, link resolves to correct repo